### PR TITLE
Add sheet presentation detent & item parameter

### DIFF
--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -566,6 +566,9 @@ extension View {
     public func presentationDetents(_ detents: Set<PresentationDetent>) -> some View {
         #if SKIP
         // TODO: Add support for multiple detents
+        if detents.count == 0 {
+            return self
+        }
         let selectedDetent = detents.first
         return preference(key: PresentationDetentPreferences.self, value: PresentationDetentPreferences(detent: selectedDetent))
         #else

--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -529,7 +529,6 @@ extension View {
         #endif
     }
 
-    @available(*, unavailable)
     public func fullScreenCover<Item>(item: Binding<Item?>, onDismiss: (() -> Void)? = nil, @ViewBuilder content: @escaping (Item) -> any View) -> some View /* where Item : Identifiable, */ {
         #if SKIP
         let isPresented = Binding<Bool>(

--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -105,10 +105,17 @@ let overlayPresentationCornerRadius = 16.0
                     systemBarEdges.remove(.bottom)
                 }
                 
-                // TODO: add other cases
-                switch reducedDetentPreferences.detent {
-                case PresentationDetent.medium:
-                    inset += 400.dp    // TODO: replace by half of the container or screen ?
+                // TODO: add custom cases
+                // Add inset depending on the presentation detent
+                let screenHeight = LocalConfiguration.current.screenHeightDp.dp
+                let detent: PresentationDetent = reducedDetentPreferences.detent
+                switch detent {
+                case .medium:
+                    inset += screenHeight / 2
+                case let .height(h):
+                    inset += screenHeight - h.dp
+                case let .fraction(f):
+                    inset += screenHeight * Float(1 - f)
                 default:
                     break
                 }


### PR DESCRIPTION
I added small support for `.presentationDetents([])` with sheets.
Currently only support zero or one detent in the detents list.
This commit also add support for item binding in sheet and fullScreenCover.

It is one of my first pull requests, I'm new to SwiftUI and I don't know anything about Kotlin and Compose, so tell me if anything I made is bad or wrongly implemented.