### PR TITLE
Improve sheet presentations:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1095,6 +1095,7 @@ Support levels:
               <summary><code>.fullScreenCover</code></summary>
               <ul>
                   <li><code>func fullScreenCover(isPresented: Binding&lt;Bool>, onDismiss: (() -> Void)? = nil, @ViewBuilder content: @escaping () -> any View) -> some View</code></li>
+                  <li>Note that covers are dismissible via swipe and the back button on Android.</li>
               </ul>
           </details>      
        </td>


### PR DESCRIPTION
- Do not allow scrolling content to dismiss sheets, as false positives were too common
- Add additional top space and a drag handle above sheets so they can be interactively dismissed even if they contain only scrolling content
- Do not re-present fullscreen covers if they are dismissed via swipe or back button, as it is not desirable in many situations; rather, the user should track any required actions and re-present as needed