### PR TITLE
Fixes for ForEach not causing recompose and misc regressions

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/ForEach.swift
+++ b/Sources/SkipUI/SkipUI/Containers/ForEach.swift
@@ -49,12 +49,18 @@ public final class ForEach : View, LazyItemFactory {
         if context.composer is ForEachComposer {
             return super.Compose(context: context)
         } else {
-            ComposeContent(context: context)
-            return ComposeResult.ok
+            return ComposeUnrolled(context: context)
         }
     }
-    
+
     @Composable public override func ComposeContent(context: ComposeContext) {
+        ComposeUnrolled(context: context)
+    }
+
+    @Composable private func ComposeUnrolled(context: ComposeContext) -> ComposeResult {
+        // This function returns a value, so we can ensure that when the ForEach body reads state and
+        // is recomposed, it escapes and is reflected in the broader composition. Otherwise state reads
+        // with an unrolled ForEach do not cause the composition to update
         let isTagging = EnvironmentValues.shared._placement.contains(ViewPlacement.tagged)
         if let indexRange {
             for index in indexRange {
@@ -82,6 +88,7 @@ public final class ForEach : View, LazyItemFactory {
                 views.forEach { $0.Compose(context: context) }
             }
         }
+        return ComposeResult.ok
     }
 
     @Composable func appendLazyItemViews(to composer: LazyItemCollectingComposer, appendingContext: ComposeContext) -> ComposeResult {

--- a/Sources/SkipUI/SkipUI/Containers/VStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/VStack.swift
@@ -9,7 +9,10 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.togetherWith
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
@@ -84,7 +87,18 @@ public struct VStack : View {
     // SKIP INSERT: @OptIn(ExperimentalAnimationApi::class)
     @Composable private func ComposeAnimatedContent(context: ComposeContext, modifier: Modifier, arguments: AnimatedContentArguments, columnAlignment: androidx.compose.ui.Alignment.Horizontal, columnArrangement: Arrangement.Vertical) {
         AnimatedContent(modifier: modifier, targetState: arguments.views, transitionSpec: {
-            // SKIP INSERT: EnterTransition.None togetherWith ExitTransition.None
+            EnterTransition.None.togetherWith(ExitTransition.None).using(SizeTransform(clip: false) { initialSize, targetSize in
+                 if initialSize.width <= 0 || initialSize.height <= 0 {
+                     // When starting at zero size, immediately go to target size so views animate into proper place
+                     snap()
+                 } else if targetSize.width > initialSize.width || targetSize.height > initialSize.height {
+                     // Animate expansion so views slide into place
+                     tween()
+                 } else {
+                     // Delay contraction to give old view time to leave
+                     snap(delayMillis: Int(defaultAnimationDuration * 1000))
+                 }
+             })
         }, contentKey: {
             $0.map(arguments.idMap)
         }, content: { state in

--- a/Sources/SkipUI/SkipUI/Containers/ZStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/ZStack.swift
@@ -9,7 +9,10 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.togetherWith
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -60,7 +63,18 @@ public struct ZStack : View {
     // SKIP INSERT: @OptIn(ExperimentalAnimationApi::class)
     @Composable private func ComposeAnimatedContent(context: ComposeContext, modifier: Modifier, arguments: AnimatedContentArguments) {
         AnimatedContent(modifier: modifier, targetState: arguments.views, transitionSpec: {
-            // SKIP INSERT: EnterTransition.None togetherWith ExitTransition.None
+            EnterTransition.None.togetherWith(ExitTransition.None).using(SizeTransform(clip: false) { initialSize, targetSize in
+                 if initialSize.width <= 0 || initialSize.height <= 0 {
+                     // When starting at zero size, immediately go to target size so views animate into proper place
+                     snap()
+                 } else if targetSize.width > initialSize.width || targetSize.height > initialSize.height {
+                     // Animate expansion so views slide into place
+                     tween()
+                 } else {
+                     // Delay contraction to give old view time to leave
+                     snap(delayMillis: Int(defaultAnimationDuration * 1000))
+                 }
+             })
         }, contentKey: {
             $0.map(arguments.idMap)
         }, content: { state in

--- a/Sources/SkipUI/SkipUI/Controls/Picker.swift
+++ b/Sources/SkipUI/SkipUI/Controls/Picker.swift
@@ -336,10 +336,10 @@ struct PickerSelectionView<SelectionValue> : View {
             HStack {
                 // The embedded ZStack allows us to fill the width without a Spacer, which in Compose will share equal space with
                 // the label if it also wants to expand to fill space
-                ZStack(alignment: .leading) {
+                ZStack {
                     label
                 }
-                .frame(maxWidth: .infinity)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 Image(systemName: "checkmark")
                     .foregroundStyle(EnvironmentValues.shared._tint ?? Color.accentColor)
                     .opacity(labelValue == selectionValue ? 1.0 : 0.0)


### PR DESCRIPTION
- Fix ForEach state reads not causing recompose
- Fix regression in .navigationStyle Picker layout
- Fix regression in .transition support



