### PR TITLE
Made ComposeModifierView public.

### DIFF
--- a/Sources/SkipUI/SkipUI/Compose/ComposeModifierView.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeModifierView.swift
@@ -23,14 +23,14 @@ public enum ComposeModifierRole {
 }
 
 /// Used internally by modifiers to apply changes to the context supplied to modified views.
-class ComposeModifierView: View {
+public class ComposeModifierView: View {
     let view: View
     let role: ComposeModifierRole
     var action: (@Composable (inout ComposeContext) -> ComposeResult)?
     var composeContent: (@Composable (any View, ComposeContext) -> Void)?
 
     /// Constructor for subclasses.
-    init(view: any View, role: ComposeModifierRole = .unspecified) {
+    public init(view: any View, role: ComposeModifierRole = .unspecified) {
         // Don't copy view
         // SKIP REPLACE: this.view = view
         self.view = view
@@ -38,13 +38,13 @@ class ComposeModifierView: View {
     }
 
     /// A modfiier that performs an action, optionally modifying the `ComposeContext` passed to the modified view.
-    init(targetView: any View, role: ComposeModifierRole = .unspecified, action: @Composable (inout ComposeContext) -> ComposeResult) {
+    public init(targetView: any View, role: ComposeModifierRole = .unspecified, action: @Composable (inout ComposeContext) -> ComposeResult) {
         self.init(view: targetView, role: role)
         self.action = action
     }
 
     /// A modifier that takes over the composition of the modified view.
-    init(contentView: any View, role: ComposeModifierRole = .unspecified, composeContent: @Composable (any View, ComposeContext) -> Void) {
+    public init(contentView: any View, role: ComposeModifierRole = .unspecified, composeContent: @Composable (any View, ComposeContext) -> Void) {
         self.init(view: contentView, role: role)
         self.composeContent = composeContent
     }


### PR DESCRIPTION
Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Would be useful to make `ComposeModifierView` public to allow a 3rd party codebase to define their own view extensions. I was exploring creating my own extension as mentioned on the documentation but couldn't because of type visibility. The other types, like ComposeContext and ComposeResult are already public. I ran tests though I see existing failing cases; an @testable import makes internal types visible to the unit test meaning increasing the visibility more wouldn't contribute to test failers.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

