### PR TITLE
Upgrade to coil3 and add SVG image support

### DIFF
--- a/Sources/SkipUI/Skip/skip.yml
+++ b/Sources/SkipUI/Skip/skip.yml
@@ -12,12 +12,12 @@ settings:
           contents:
             - block: 'create("libs")'
               contents:
-                - 'version("coil-compose", "2.6.0")'
-                - 'version("androidx-navigation", "2.7.7")'
+                - 'version("coil", "3.0.0")'
+                - 'version("androidx-navigation", "2.8.3")'
                 - 'version("androidx-appcompat", "1.7.0")'
-                - 'version("androidx-activity", "1.9.0")'
-                - 'version("androidx-lifecycle-process", "2.8.2")'
-                - 'version("androidx-material3-adaptive", "1.0.0-beta04")'
+                - 'version("androidx-activity", "1.9.3")'
+                - 'version("androidx-lifecycle-process", "2.8.7")'
+                - 'version("androidx-material3-adaptive", "1.0.0")'
 
                 # the version for these libraries is derived from the kotlin-bom declared is skip-model/Sources/SkipModel/Skip/skip.yml
                 - 'library("androidx-core-ktx", "androidx.core", "core-ktx").withoutVersion()'
@@ -36,7 +36,10 @@ settings:
                 - 'library("androidx-lifecycle-process", "androidx.lifecycle", "lifecycle-process").versionRef("androidx-lifecycle-process")'
                 - 'library("androidx-compose-material3-adaptive", "androidx.compose.material3.adaptive", "adaptive").versionRef("androidx-material3-adaptive")'
 
-                - 'library("coil-compose", "io.coil-kt", "coil-compose").versionRef("coil-compose")'
+                - 'library("coil-compose", "io.coil-kt.coil3", "coil-compose").versionRef("coil")'
+                - 'library("coil-network-okhttp", "io.coil-kt.coil3", "coil-network-okhttp").versionRef("coil")'
+                - 'library("coil-svg", "io.coil-kt.coil3", "coil-svg").versionRef("coil")'
+                #- 'library("coil-gif", "io.coil-kt.coil3", "coil-gif").versionRef("coil")'
 
                 - 'library("androidx-compose-ui-test", "androidx.compose.ui", "ui-test").withoutVersion()'
                 - 'library("androidx-compose-ui-test-junit4", "androidx.compose.ui", "ui-test-junit4").withoutVersion()'
@@ -73,6 +76,9 @@ build:
         - 'api(libs.androidx.activity.compose)'
         - 'api(libs.androidx.lifecycle.process)'
         - 'implementation(libs.coil.compose)'
+        - 'implementation(libs.coil.network.okhttp)'
+        - 'implementation(libs.coil.svg)'
+        #- 'implementation(libs.coil.gif)'
 
         - 'testImplementation(libs.androidx.compose.ui.test)'
         - 'androidTestImplementation(libs.androidx.compose.ui.test)'

--- a/Sources/SkipUI/SkipUI/Animation/Transition.swift
+++ b/Sources/SkipUI/SkipUI/Animation/Transition.swift
@@ -20,7 +20,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 import struct CoreGraphics.CGSize
 #endif

--- a/Sources/SkipUI/SkipUI/Components/Image.swift
+++ b/Sources/SkipUI/SkipUI/Components/Image.swift
@@ -47,9 +47,9 @@ import androidx.compose.ui.layout.ScaleFactor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
-import coil.compose.SubcomposeAsyncImage
-import coil.request.ImageRequest
-#else
+import coil3.compose.SubcomposeAsyncImage
+import coil3.request.ImageRequest
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 import struct CoreGraphics.CGRect
 import struct CoreGraphics.CGSize
@@ -129,9 +129,11 @@ public struct Image : View, Equatable {
         let url = asset.url
         let model = ImageRequest.Builder(LocalContext.current)
             .fetcherFactory(JarURLFetcher.Factory())
+            .decoderFactory(coil3.svg.SvgDecoder.Factory())
+            //.decoderFactory(coil3.gif.GifDecoder.Factory())
             .decoderFactory(PdfDecoder.Factory())
             .data(url)
-            .size(coil.size.Size.ORIGINAL)
+            .size(coil3.size.Size.ORIGINAL)
             .memoryCacheKey(url.description)
             .diskCacheKey(url.description)
             .build()

--- a/Sources/SkipUI/SkipUI/Components/Spacer.swift
+++ b/Sources/SkipUI/SkipUI/Components/Spacer.swift
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 #endif
 

--- a/Sources/SkipUI/SkipUI/Containers/Grid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Grid.swift
@@ -7,7 +7,7 @@
 #if SKIP
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.ui.unit.dp
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 #endif
 

--- a/Sources/SkipUI/SkipUI/Containers/HStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/HStack.swift
@@ -19,7 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 import struct CoreGraphics.CGRect
 import struct CoreGraphics.CGSize

--- a/Sources/SkipUI/SkipUI/Containers/LazyHGrid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyHGrid.swift
@@ -16,7 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 #endif
 

--- a/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
@@ -14,7 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 #endif
 

--- a/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
@@ -20,7 +20,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 #endif
 

--- a/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
@@ -19,7 +19,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 #endif
 

--- a/Sources/SkipUI/SkipUI/Containers/List.swift
+++ b/Sources/SkipUI/SkipUI/Containers/List.swift
@@ -59,7 +59,7 @@ import org.burnoutcrew.reorderable.ReorderableLazyListState
 import org.burnoutcrew.reorderable.detectReorderAfterLongPress
 import org.burnoutcrew.reorderable.rememberReorderableLazyListState
 import org.burnoutcrew.reorderable.reorderable
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 #endif
 

--- a/Sources/SkipUI/SkipUI/Containers/ScrollView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/ScrollView.swift
@@ -28,7 +28,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 import struct CoreGraphics.CGRect
 #endif

--- a/Sources/SkipUI/SkipUI/Containers/VStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/VStack.swift
@@ -20,7 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 import struct CoreGraphics.CGRect
 import struct CoreGraphics.CGSize

--- a/Sources/SkipUI/SkipUI/Containers/ZStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/ZStack.swift
@@ -17,7 +17,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGRect
 import struct CoreGraphics.CGSize
 #endif

--- a/Sources/SkipUI/SkipUI/Controls/Button.swift
+++ b/Sources/SkipUI/SkipUI/Controls/Button.swift
@@ -23,7 +23,7 @@ import androidx.compose.material3.RippleConfiguration
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 import struct CoreGraphics.CGRect
 #endif

--- a/Sources/SkipUI/SkipUI/Graphics/Gradient.swift
+++ b/Sources/SkipUI/SkipUI/Graphics/Gradient.swift
@@ -24,7 +24,7 @@ import androidx.compose.ui.graphics.ShaderBrush
 import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 #endif
 

--- a/Sources/SkipUI/SkipUI/Graphics/Path.swift
+++ b/Sources/SkipUI/SkipUI/Graphics/Path.swift
@@ -13,7 +13,7 @@ import androidx.compose.ui.graphics.Matrix
 import androidx.compose.ui.graphics.PathOperation
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGAffineTransform
 import struct CoreGraphics.CGFloat
 import struct CoreGraphics.CGRect

--- a/Sources/SkipUI/SkipUI/Graphics/Shape.swift
+++ b/Sources/SkipUI/SkipUI/Graphics/Shape.swift
@@ -21,7 +21,7 @@ import androidx.compose.ui.graphics.drawscope.inset
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 import struct CoreGraphics.CGRect
 import struct CoreGraphics.CGSize

--- a/Sources/SkipUI/SkipUI/Graphics/StrokeStyle.swift
+++ b/Sources/SkipUI/SkipUI/Graphics/StrokeStyle.swift
@@ -21,7 +21,7 @@ public enum CGLineCap : Int, Sendable {
 public enum CGLineJoin : Int, Sendable {
     case miter, round, bevel
 }
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 import enum CoreGraphics.CGLineCap
 import enum CoreGraphics.CGLineJoin

--- a/Sources/SkipUI/SkipUI/Layout/EdgeInsets.swift
+++ b/Sources/SkipUI/SkipUI/Layout/EdgeInsets.swift
@@ -8,7 +8,7 @@
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 #endif
 

--- a/Sources/SkipUI/SkipUI/Layout/GeometryProxy.swift
+++ b/Sources/SkipUI/SkipUI/Layout/GeometryProxy.swift
@@ -7,7 +7,7 @@
 #if SKIP
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.unit.Density
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGRect
 import struct CoreGraphics.CGSize
 #endif

--- a/Sources/SkipUI/SkipUI/Layout/HorizontalAlignment.swift
+++ b/Sources/SkipUI/SkipUI/Layout/HorizontalAlignment.swift
@@ -5,7 +5,9 @@
 // as published by the Free Software Foundation https://fsf.org
 
 #if !SKIP
+#if canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
+#endif
 #endif
 
 public struct HorizontalAlignment : Equatable, Sendable {

--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -66,7 +66,7 @@ import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 #endif
 

--- a/Sources/SkipUI/SkipUI/Layout/VerticalAlignment.swift
+++ b/Sources/SkipUI/SkipUI/Layout/VerticalAlignment.swift
@@ -5,7 +5,9 @@
 // as published by the Free Software Foundation https://fsf.org
 
 #if !SKIP
+#if canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
+#endif
 #endif
 
 public struct VerticalAlignment : Equatable, Sendable {

--- a/Sources/SkipUI/SkipUI/System/Accessibility.swift
+++ b/Sources/SkipUI/SkipUI/System/Accessibility.swift
@@ -14,7 +14,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
-#else
+#elseif canImport(CoreGraphics)
 import class Accessibility.AXCustomContent
 import class Accessibility.AXChartDescriptor
 import struct CoreGraphics.CGPoint

--- a/Sources/SkipUI/SkipUI/System/HoverPhase.swift
+++ b/Sources/SkipUI/SkipUI/System/HoverPhase.swift
@@ -5,7 +5,9 @@
 // as published by the Free Software Foundation https://fsf.org
 
 #if !SKIP
+#if canImport(CoreGraphics)
 import struct CoreGraphics.CGPoint
+#endif
 #endif
 
 public enum HoverPhase : Equatable, Sendable {

--- a/Sources/SkipUI/SkipUI/System/ProposedViewSize.swift
+++ b/Sources/SkipUI/SkipUI/System/ProposedViewSize.swift
@@ -5,8 +5,10 @@
 // as published by the Free Software Foundation https://fsf.org
 
 #if !SKIP
+#if canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 import struct CoreGraphics.CGSize
+#endif
 #endif
 
 public struct ProposedViewSize : Equatable, Sendable {

--- a/Sources/SkipUI/SkipUI/Text/Font.swift
+++ b/Sources/SkipUI/SkipUI/Text/Font.swift
@@ -14,7 +14,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 #endif
 

--- a/Sources/SkipUI/SkipUI/Text/Text.swift
+++ b/Sources/SkipUI/SkipUI/Text/Text.swift
@@ -39,7 +39,7 @@ import androidx.compose.ui.unit.TextUnit
 import skip.foundation.LocalizedStringResource
 import skip.foundation.Bundle
 import skip.foundation.Locale
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 #endif
 

--- a/Sources/SkipUI/SkipUI/View/View.swift
+++ b/Sources/SkipUI/SkipUI/View/View.swift
@@ -28,7 +28,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-#else
+#elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGAffineTransform
 import struct CoreGraphics.CGFloat
 import struct CoreGraphics.CGPoint


### PR DESCRIPTION
This PR upgrades the coil dependency to 3.0.0 and adds a `io.coil-kt.coil3.coil-svg` dependency which enables SVG images in asset bundles.

It also scales up PDF images to the display scale, which improves rasterization (although PDF images are still rasterized at their own canvas size, rather than at the target size).