### PR TITLE
Add ProgressView labels

### DIFF
--- a/Sources/SkipUI/SkipUI/Components/ProgressView.swift
+++ b/Sources/SkipUI/SkipUI/Components/ProgressView.swift
@@ -69,19 +69,21 @@ public struct ProgressView : View {
         }
         if style == .linear {
             if let label, !EnvironmentValues.shared._labelsHidden {
+                let contentContext = context.content()
                 Column(modifier: context.modifier, verticalArrangement: Arrangement.spacedBy(3.dp), horizontalAlignment: androidx.compose.ui.Alignment.Start) {
-                    label.Compose(context: context.content())
-                    ComposeLinearProgress(context: context)
+                    label.Compose(context: contentContext)
+                    ComposeLinearProgress(context: contentContext)
                 }
             } else {
                 ComposeLinearProgress(context: context)
             }
         } else {
             if let label, !EnvironmentValues.shared._labelsHidden {
+                let contentContext = context.content()
                 Column(modifier: context.modifier, verticalArrangement: Arrangement.spacedBy(4.dp), horizontalAlignment: androidx.compose.ui.Alignment.CenterHorizontally) {
-                    ComposeCircularProgress(context: context)
-                    Row(modifier: context.modifier, horizontalArrangement: Arrangement.spacedBy(4.dp), verticalAlignment: androidx.compose.ui.Alignment.CenterVertically) {
-                        label.Compose(context: context.content())
+                    ComposeCircularProgress(context: contentContext)
+                    Row(horizontalArrangement: Arrangement.spacedBy(4.dp), verticalAlignment: androidx.compose.ui.Alignment.CenterVertically) {
+                        label.Compose(context: contentContext)
                     }
                 }
             } else {

--- a/Sources/SkipUI/SkipUI/Components/ProgressView.swift
+++ b/Sources/SkipUI/SkipUI/Components/ProgressView.swift
@@ -8,6 +8,7 @@
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
@@ -72,7 +73,7 @@ public struct ProgressView : View {
         }
         if style == .linear {
             if let label, !EnvironmentValues.shared._labelsHidden {
-                Column(modifier: context.modifier, verticalArrangement: Arrangement.spacedBy(4.dp), horizontalAlignment: androidx.compose.ui.Alignment.Start) {
+                Column(modifier: context.modifier, verticalArrangement: Arrangement.spacedBy(3.dp), horizontalAlignment: androidx.compose.ui.Alignment.Start) {
                     label.Compose(context: context.content())
                     ComposeLinearProgress(context: context)
                 }
@@ -81,9 +82,11 @@ public struct ProgressView : View {
             }
         } else {
             if let label, !EnvironmentValues.shared._labelsHidden {
-                Column(modifier: context.modifier, verticalArrangement: Arrangement.spacedBy(8.dp), horizontalAlignment: androidx.compose.ui.Alignment.CenterHorizontally) {
+                Column(modifier: context.modifier, verticalArrangement: Arrangement.spacedBy(4.dp), horizontalAlignment: androidx.compose.ui.Alignment.CenterHorizontally) {
                     ComposeCircularProgress(context: context)
-                    label.Compose(context: context.content())
+                    Row(modifier: context.modifier, horizontalArrangement: Arrangement.spacedBy(4.dp), verticalAlignment: androidx.compose.ui.Alignment.CenterVertically) {
+                        label.Compose(context: context.content())
+                    }
                 }
             } else {
                 ComposeCircularProgress(context: context)

--- a/Sources/SkipUI/SkipUI/Components/ProgressView.swift
+++ b/Sources/SkipUI/SkipUI/Components/ProgressView.swift
@@ -5,7 +5,9 @@
 // as published by the Free Software Foundation https://fsf.org
 
 #if SKIP
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
@@ -18,51 +20,48 @@ import androidx.compose.ui.unit.dp
 public struct ProgressView : View {
     let value: Double?
     let total: Double?
+    let label: (any View)?
 
     public init() {
         self.value = nil
         self.total = nil
+        self.label = nil
     }
 
-    @available(*, unavailable)
     public init(@ViewBuilder label: () -> any View) {
-        self.value = nil
-        self.total = nil
+        self.init(value: nil, label: label)
     }
 
-    @available(*, unavailable)
     public init(_ titleKey: LocalizedStringKey) {
-        self.value = nil
-        self.total = nil
+        self.init(titleKey, value: nil)
     }
 
-    @available(*, unavailable)
     public init(_ title: String) {
-        self.value = nil
-        self.total = nil
+        self.init(title, value: nil)
     }
 
     public init(value: Double?, total: Double = 1.0) {
         self.value = value
         self.total = total
+        self.label = nil
     }
 
-    @available(*, unavailable)
     public init(value: Double?, total: Double = 1.0, @ViewBuilder label: () -> any View) {
         self.value = value
         self.total = total
+        self.label = label()
     }
 
-    @available(*, unavailable)
     public init(_ titleKey: LocalizedStringKey, value: Double?, total: Double = 1.0) {
         self.value = value
         self.total = total
+        self.label = Text(titleKey)
     }
 
-    @available(*, unavailable)
     public init(_ title: String, value: Double?, total: Double = 1.0) {
         self.value = value
         self.total = total
+        self.label = Text(verbatim: title)
     }
 
     #if SKIP
@@ -72,23 +71,45 @@ public struct ProgressView : View {
             style = value == nil ? .circular : .linear
         }
         if style == .linear {
-            let modifier = Modifier.fillWidth().then(context.modifier)
-            let color = EnvironmentValues.shared._tint?.colorImpl() ?? ProgressIndicatorDefaults.linearColor
-            if value == nil || total == nil {
-                LinearProgressIndicator(modifier: modifier, color: color)
+            if let label, !EnvironmentValues.shared._labelsHidden {
+                Column(modifier: context.modifier, verticalArrangement: Arrangement.spacedBy(4.dp), horizontalAlignment: androidx.compose.ui.Alignment.Start) {
+                    label.Compose(context: context.content())
+                    ComposeLinearProgress(context: context)
+                }
             } else {
-                LinearProgressIndicator(progress: Float(value! / total!), modifier: modifier, color: color)
+                ComposeLinearProgress(context: context)
             }
         } else {
-            let color = EnvironmentValues.shared._tint?.colorImpl() ?? ProgressIndicatorDefaults.circularColor
-            // Reduce size to better match SwiftUI
-            let indicatorModifier = Modifier.size(20.dp)
-            Box(modifier: context.modifier, contentAlignment: androidx.compose.ui.Alignment.Center) {
-                if value == nil || total == nil {
-                    CircularProgressIndicator(modifier: indicatorModifier, color: color)
-                } else {
-                    CircularProgressIndicator(progress: Float(value! / total!), modifier: indicatorModifier, color: color)
+            if let label, !EnvironmentValues.shared._labelsHidden {
+                Column(modifier: context.modifier, verticalArrangement: Arrangement.spacedBy(8.dp), horizontalAlignment: androidx.compose.ui.Alignment.CenterHorizontally) {
+                    ComposeCircularProgress(context: context)
+                    label.Compose(context: context.content())
                 }
+            } else {
+                ComposeCircularProgress(context: context)
+            }
+        }
+    }
+
+    @Composable private func ComposeLinearProgress(context: ComposeContext) {
+        let modifier = Modifier.fillWidth().then(context.modifier)
+        let color = EnvironmentValues.shared._tint?.colorImpl() ?? ProgressIndicatorDefaults.linearColor
+        if value == nil || total == nil {
+            LinearProgressIndicator(modifier: modifier, color: color)
+        } else {
+            LinearProgressIndicator(progress: Float(value! / total!), modifier: modifier, color: color)
+        }
+    }
+
+    @Composable private func ComposeCircularProgress(context: ComposeContext) {
+        let color = EnvironmentValues.shared._tint?.colorImpl() ?? ProgressIndicatorDefaults.circularColor
+        // Reduce size to better match SwiftUI
+        let indicatorModifier = Modifier.size(20.dp)
+        Box(modifier: context.modifier, contentAlignment: androidx.compose.ui.Alignment.Center) {
+            if value == nil || total == nil {
+                CircularProgressIndicator(modifier: indicatorModifier, color: color)
+            } else {
+                CircularProgressIndicator(progress: Float(value! / total!), modifier: indicatorModifier, color: color)
             }
         }
     }

--- a/Sources/SkipUI/SkipUI/Components/ProgressView.swift
+++ b/Sources/SkipUI/SkipUI/Components/ProgressView.swift
@@ -21,7 +21,7 @@ import androidx.compose.ui.unit.dp
 public struct ProgressView : View {
     let value: Double?
     let total: Double?
-    let label: (any View)?
+    let label: ComposeBuilder?
 
     public init() {
         self.value = nil
@@ -50,19 +50,15 @@ public struct ProgressView : View {
     public init(value: Double?, total: Double = 1.0, @ViewBuilder label: () -> any View) {
         self.value = value
         self.total = total
-        self.label = label()
+        self.label = ComposeBuilder.from(label)
     }
 
     public init(_ titleKey: LocalizedStringKey, value: Double?, total: Double = 1.0) {
-        self.value = value
-        self.total = total
-        self.label = Text(titleKey)
+        self.init(value: value, total: total, label: { Text(titleKey) })
     }
 
     public init(_ title: String, value: Double?, total: Double = 1.0) {
-        self.value = value
-        self.total = total
-        self.label = Text(verbatim: title)
+        self.init(value: value, total: total, label: { Text(verbatim: title) })
     }
 
     #if SKIP


### PR DESCRIPTION
Displays ProgressView labels according to their style matching SwiftUI.

Additional things to review:
- I used `let label: (any View)?` instead of the reference impl `let label: ComposeBuilder` because it made this cleaner. I don't know if there's a meaningful difference, but happy to switch if preferred.
- In theory there should be another set of initializers for setting `total` to nil with a label, but when `value` is nil, `total` is always ignored in current codepaths anyway.
- There weren't existing ProgressView tests to add to, but I made a quick UI validation screen separately. Not sure if this is worth saving somewhere here.
---
- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device