### PR TITLE
Add page TabView style

### DIFF
--- a/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
+++ b/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
@@ -549,6 +549,11 @@ extension EnvironmentValues {
         set { setBuiltinValue(key: "_progressViewStyle", value: newValue, defaultValue: { nil }) }
     }
 
+    var _tabViewStyle: TabViewStyle? {
+        get { builtinValue(key: "_tabViewStyle", defaultValue: { nil }) as! TabViewStyle? }
+        set { setBuiltinValue(key: "_tabViewStyle", value: newValue, defaultValue: { nil }) }
+    }
+
     var _safeArea: SafeArea? {
         get { builtinValue(key: "_safeArea", defaultValue: { nil }) as! SafeArea? }
         set { setBuiltinValue(key: "_safeArea", value: newValue, defaultValue: { nil }) }


### PR DESCRIPTION
First attempt at supporting the page scrolling TabView style. There's still details I don't totally understand. Putting this up now to get confirmation if this approach is acceptable or not.

I added examples to `TabViewPlayground` on this branch: https://github.com/ky-is/skipapp-showcase/tree/tabview-page-style

Additional things for review:
- Recomposes: I tried to audit this and I think I've minimized them but it should be confirmed I'm using `remember` correctly (especially after any additional changes).
- I'm not sure on exactly how to handle the layout for the outer container. This version might crash in certain configurations if it can't figure out how to size itself (I don't currently have any repros).
- Page indicator UI: I just tried to make it look like SwiftUI since there isn't a standard Android indicator overlay I saw.
- I'm applying `aspectRatio` because I want it for my own use case. But currently Skip considers `aspectRatio` to be an `Image`-only modifier. It should probably be abstracted to apply to other views (and respect `contentMode` here...). I'm just not sure the best way to go about this.
- There is also `IndexViewStyle`, it should probably be implemented or stubbed along side this.

---

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

