### PR TITLE
Add View.sensoryFeedback and Android OS version check

### DIFF
--- a/Sources/SkipUI/SkipUI/System/SensoryFeedback.swift
+++ b/Sources/SkipUI/SkipUI/System/SensoryFeedback.swift
@@ -4,6 +4,10 @@
 // under the terms of the GNU Lesser General Public License 3.0
 // as published by the Free Software Foundation https://fsf.org
 
+#if SKIP
+import android.os.VibrationEffect
+#endif
+
 public struct SensoryFeedback : RawRepresentable, Equatable, Sendable {
     public let rawValue: Int
 
@@ -43,5 +47,180 @@ public struct SensoryFeedback : RawRepresentable, Equatable, Sendable {
         case rigid
         case solid
         case soft
+    }
+
+    public func activate() {
+        #if SKIP
+        guard let systemVibratorService else { return }
+
+        // see: https://developer.android.com/develop/ui/views/haptics/custom-haptic-effects
+        let composition = VibrationEffect.startComposition()
+
+        // we create custom haptic feedback; we don't use https://developer.android.com/reference/android/view/HapticFeedbackConstants because many of those constants are only available in API 34+
+
+        // various experimental implementations; we may eventually expose this to the user to be able to configure their "haptics style"
+        let impl = 3
+
+        if impl == 0 {
+            switch self {
+            case .success:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_RISE, Float(0.7))
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_FALL, Float(0.5))
+            case .warning:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_FALL, Float(0.9))
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_FALL, Float(0.6))
+            case .error:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_FALL, Float(1.0))
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_FALL, Float(0.7))
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_FALL, Float(0.5))
+            case .selection:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(0.4))
+            case .increase:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_RISE, Float(0.6))
+            case .decrease:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_FALL, Float(0.6))
+            case .start:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_RISE, Float(0.7))
+            case .stop:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_FALL, Float(0.7))
+            case .alignment:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(0.4))
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(0.3))
+            case .levelChange:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(0.5))
+            case .impact:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_FALL, Float(0.8))
+            }
+        } else if impl == 1 {
+            switch self {
+            case .success:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(1.0))
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, Float(0.5))
+            case .warning:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(1.0))
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_LOW_TICK, Float(0.7))
+            case .error:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(1.0))
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_LOW_TICK, Float(1.0))
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_LOW_TICK, Float(1.0))
+            case .selection:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, Float(1.0))
+            case .increase:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(1.0))
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_RISE, Float(0.7))
+            case .decrease:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(1.0))
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_FALL, Float(0.7))
+            case .start:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_RISE, Float(1.0))
+            case .stop:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_FALL, Float(1.0))
+            case .alignment:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, Float(0.5))
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(0.5))
+            case .levelChange:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(1.0))
+            case .impact:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, Float(1.0))
+            }
+        } else if impl == 3 {
+            switch self {
+            case .success:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, Float(1.0), 100)
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(1.0), 200)
+            case .warning:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_LOW_TICK, Float(1.0), 100)
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_LOW_TICK, Float(1.0), 200)
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_LOW_TICK, Float(1.0), 300)
+            case .error:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_SLOW_RISE, Float(1.0), 100)
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_FALL, Float(1.0), 200)
+            case .selection:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(1.0), 50)
+            case .increase:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, Float(1.0), 100)
+            case .decrease:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, Float(1.0), 100)
+            case .start:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_RISE, Float(1.0), 100)
+            case .stop:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_FALL, Float(1.0), 100)
+            case .alignment:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(1.0), 50)
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(1.0), 100)
+            case .levelChange:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, Float(1.0), 100)
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, Float(1.0), 200)
+            case .impact:
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_THUD, Float(1.0), 100)
+            }
+        } else if impl == 4 {
+            switch self {
+            case .success:
+                // iOS success: A strong tap followed by a lighter tap after 100ms
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, Float(1.0), 0) // Strong tap
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(0.5), 100) // Light tap after 100ms
+            case .warning:
+                // iOS warning: A strong, sharp tap followed by a quick fade after 100ms
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_SLOW_RISE, Float(1.0), 0) // Strong rise
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_FALL, Float(1.0), 100) // Quick fall after 100ms
+            case .error:
+                // iOS error: Three sequential taps with decreasing intensity and 100ms delays
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_LOW_TICK, Float(1.0), 0) // Strong tap
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_LOW_TICK, Float(0.75), 100) // Medium tap after 100ms
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_LOW_TICK, Float(0.5), 200) // Light tap after 200ms
+            case .selection:
+                // iOS selection: A light, subtle tap
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(0.3), 0) // Light tap
+            case .increase:
+                // iOS increase: A single, sharp tap
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, Float(1.0), 0) // Strong tap
+            case .decrease:
+                // iOS decrease: A single, sharp tap (same as increase)
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, Float(1.0), 0) // Strong tap
+            case .start:
+                // iOS start: A quick rise in intensity
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_RISE, Float(1.0), 0) // Quick rise
+            case .stop:
+                // iOS stop: A quick fall in intensity
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_QUICK_FALL, Float(1.0), 0) // Quick fall
+            case .alignment:
+                // iOS alignment: Two light taps in quick succession (50ms delay)
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(0.5), 0) // First tap
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_TICK, Float(0.5), 50) // Second tap after 50ms
+            case .levelChange:
+                // iOS levelChange: Two sharp taps in quick succession (100ms delay)
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, Float(1.0), 0) // First tap
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_CLICK, Float(1.0), 100) // Second tap after 100ms
+            case .impact:
+                // iOS impact: A strong, heavy tap
+                composition.addPrimitive(VibrationEffect.Composition.PRIMITIVE_THUD, Float(1.0), 0) // Heavy tap
+            }
+        }
+
+        systemVibratorService.vibrate(composition.compose())
+        #endif
+    }
+}
+
+extension View {
+    public func sensoryFeedback<T>(_ feedback: SensoryFeedback, trigger: T) -> some View {
+        return onChange(of: trigger) {
+            feedback.activate()
+        }
+    }
+
+    public func sensoryFeedback<T>(_ feedback: SensoryFeedback, trigger: T, condition: @escaping (_ oldValue: T, _ newValue: T) -> Bool) -> some View {
+        return onChange(of: trigger) { oldValue, newValue in
+            if condition(oldValue, newValue) {
+                feedback.activate()
+            }
+        }
+    }
+
+    public func sensoryFeedback<T>(trigger: T, _ feedback: @escaping (_ oldValue: T, _ newValue: T) -> SensoryFeedback?) -> some View {
+        return onChange(of: trigger) { oldValue, newValue in
+            feedback(oldValue, newValue)?.activate()
+        }
     }
 }

--- a/Sources/SkipUI/SkipUI/UIKit/UIFeedbackGenerator.swift
+++ b/Sources/SkipUI/SkipUI/UIKit/UIFeedbackGenerator.swift
@@ -6,36 +6,36 @@
 
 import Foundation
 
+// note that this needs AndroidManifest.xml permission:
+// <uses-permission android:name="android.permission.VIBRATE"/>
+#if SKIP
+let systemVibratorService = createSystemVibratorService()
+
+private func createSystemVibratorService() -> android.os.Vibrator? {
+    let context = ProcessInfo.processInfo.androidContext // Android-specific extension to get the global Context
+
+    if android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.S {
+        logger.log("vibratorManager: return null due to Android version too old (\(android.os.Build.VERSION.SDK_INT))")
+        return nil
+    }
+
+    guard let vibratorManager = context.getSystemService(android.content.Context.VIBRATOR_MANAGER_SERVICE) as? android.os.VibratorManager else {
+        logger.log("vibratorManager: returned null")
+        return nil
+    }
+
+    logger.log("vibratorManager: \(vibratorManager)")
+
+    // https://developer.android.com/reference/android/os/Vibrator
+    return vibratorManager.getDefaultVibrator()
+}
+#endif
+
 public protocol UIFeedbackGenerator {
 }
 
-extension UIFeedbackGenerator {
-    #if SKIP
-    // note that this needs AndroidManifest.xml permission:
-    // <uses-permission android:name="android.permission.VIBRATE"/>
-    private var vibrator: android.os.Vibrator? {
-        let context = ProcessInfo.processInfo.androidContext // Android-specific extension to get the global Context
-
-        if android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.S {
-            logger.log("vibratorManager: return null due to Android version too old (\(android.os.Build.VERSION.SDK_INT))")
-            return nil
-        }
-
-        guard let vibratorManager = context.getSystemService(android.content.Context.VIBRATOR_MANAGER_SERVICE) as? android.os.VibratorManager else {
-            logger.log("vibratorManager: returned null")
-            return nil
-        }
-
-        logger.log("vibratorManager: \(vibratorManager)")
-
-        // https://developer.android.com/reference/android/os/Vibrator
-        return vibratorManager.getDefaultVibrator()
-    }
-    #endif
-}
-
 /// UIImpactFeedbackGenerator is used to give user feedback when an impact between UI elements occurs
-@MainActor open class UIImpactFeedbackGenerator : UIFeedbackGenerator {
+open class UIImpactFeedbackGenerator : UIFeedbackGenerator {
     private let style: UIImpactFeedbackGenerator.FeedbackStyle
 
     public init() {
@@ -49,7 +49,7 @@ extension UIFeedbackGenerator {
     /// call when your UI element impacts something else
     open func impactOccurred() {
         #if SKIP
-        self.vibrator?.vibrate(style.vibrationEffect)
+        systemVibratorService?.vibrate(style.vibrationEffect)
         #endif
     }
 
@@ -61,7 +61,7 @@ extension UIFeedbackGenerator {
         let effect = android.os.VibrationEffect.startComposition()
             .addPrimitive(android.os.VibrationEffect.Composition.PRIMITIVE_CLICK, Float(intensity), 0)
             .compose()
-        self.vibrator?.vibrate(effect)
+        systemVibratorService?.vibrate(effect)
         #endif
     }
 
@@ -98,7 +98,7 @@ extension UIFeedbackGenerator {
 }
 
 /// UINotificationFeedbackGenerator is used to give user feedback when an notification is displayed
-@MainActor open class UINotificationFeedbackGenerator : UIFeedbackGenerator {
+open class UINotificationFeedbackGenerator : UIFeedbackGenerator {
 
     public init() {
     }
@@ -107,7 +107,7 @@ extension UIFeedbackGenerator {
     open func notificationOccurred(_ notificationType: FeedbackType) {
         #if SKIP
         // amplitude parameter: “The strength of the vibration. This must be a value between 1 and 255”
-        self.vibrator?.vibrate(notificationType.vibrationEffect)
+        systemVibratorService?.vibrate(notificationType.vibrationEffect)
         #endif
     }
 
@@ -148,7 +148,7 @@ extension UIFeedbackGenerator {
 
 
 /// UINotificationFeedbackGenerator is used to give user feedback when an notification is displayed
-@MainActor open class UISelectionFeedbackGenerator : UIFeedbackGenerator {
+open class UISelectionFeedbackGenerator : UIFeedbackGenerator {
 
     public init() {
     }
@@ -156,7 +156,7 @@ extension UIFeedbackGenerator {
     /// call when a notification is displayed, passing the corresponding type
     open func selectionChanged() {
         #if SKIP
-        self.vibrator?.vibrate(android.os.VibrationEffect.createPredefined(android.os.VibrationEffect.EFFECT_TICK))
+        systemVibratorService?.vibrate(android.os.VibrationEffect.createPredefined(android.os.VibrationEffect.EFFECT_TICK))
         #endif
     }
 

--- a/Sources/SkipUI/SkipUI/UIKit/UIFeedbackGenerator.swift
+++ b/Sources/SkipUI/SkipUI/UIKit/UIFeedbackGenerator.swift
@@ -16,6 +16,11 @@ extension UIFeedbackGenerator {
     private var vibrator: android.os.Vibrator? {
         let context = ProcessInfo.processInfo.androidContext // Android-specific extension to get the global Context
 
+        if android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.S {
+            logger.log("vibratorManager: return null due to Android version too old (\(android.os.Build.VERSION.SDK_INT))")
+            return nil
+        }
+
         guard let vibratorManager = context.getSystemService(android.content.Context.VIBRATOR_MANAGER_SERVICE) as? android.os.VibratorManager else {
             logger.log("vibratorManager: returned null")
             return nil

--- a/Sources/SkipUI/SkipUI/View/View.swift
+++ b/Sources/SkipUI/SkipUI/View/View.swift
@@ -1029,21 +1029,6 @@ extension View {
         return self
     }
 
-    @available(*, unavailable)
-    public func sensoryFeedback(_ feedback: SensoryFeedback, trigger: any Equatable) -> some View {
-        return self
-    }
-
-    @available(*, unavailable)
-    public func sensoryFeedback<T>(_ feedback: SensoryFeedback, trigger: T, condition: @escaping (_ oldValue: T, _ newValue: T) -> Bool) -> some View where T: Equatable {
-        return self
-    }
-
-    @available(*, unavailable)
-    public func sensoryFeedback<T>(trigger: T, _ feedback: @escaping (_ oldValue: T, _ newValue: T) -> SensoryFeedback?) -> some View where T : Equatable {
-        return self
-    }
-
     public func shadow(color: Color = Color(/* .sRGBLinear, */ white: 0.0, opacity: 0.33), radius: CGFloat, x: CGFloat = 0.0, y: CGFloat = 0.0) -> some View {
         #if SKIP
         return ComposeModifierView(contentView: self) { view, context in


### PR DESCRIPTION
This PR add `View.sensoryFeedback` functions that delegate to the `UIFeedbackGenerator` and `UIImpactFeedbackGenerator` when their values change.

It also adds an Android OS version check for android.os.Build.VERSION_CODES.S before attempting to access the VibratorManager
