### PR TITLE
Render Section header/footer outside of List

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/Section.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Section.swift
@@ -70,7 +70,13 @@ public struct Section : View, LazyItemFactory {
 
     #if SKIP
     @Composable override func ComposeContent(context: ComposeContext) {
+        if let header {
+            header.Compose(context: context)
+        }
         content.Compose(context: context)
+        if let footer {
+            footer.Compose(context: context)
+        }
     }
 
     @Composable func appendLazyItemViews(to composer: LazyItemCollectingComposer, appendingContext: ComposeContext) -> ComposeResult {


### PR DESCRIPTION
Section has special behavior inside SwiftUI List. But otherwise, it simply renders the optional header/footer before/after the content you pass to it. This attempts to match that behavior.

---

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device