### PR TITLE
Fix Menu Link Label formatting

### DIFF
--- a/Sources/SkipUI/SkipUI/Commands/Menu.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Menu.swift
@@ -130,7 +130,14 @@ public final class Menu : View {
 
     @Composable static func ComposeDropdownMenuItems(for itemViews: [View], selection: Hashable? = nil, context: ComposeContext, replaceMenu: (Menu?) -> Void) {
         for itemView in itemViews {
-            if let strippedItemView = itemView.strippingModifiers(perform: { $0 }) {
+            if var strippedItemView = itemView.strippingModifiers(perform: { $0 }) {
+                if let shareLink = strippedItemView as? ShareLink {
+                    shareLink.ComposeAction()
+                    strippedItemView = shareLink.content
+                } else if let link = strippedItemView as? Link {
+                    link.ComposeAction()
+                    strippedItemView = link.content
+                }
                 if let button = strippedItemView as? Button {
                     let isSelected: Bool?
                     if let tagView = itemView as? TagModifierView, tagView.role == ComposeModifierRole.tag {

--- a/Sources/SkipUI/SkipUI/Commands/Menu.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Menu.swift
@@ -112,8 +112,14 @@ public final class Menu : View {
                             nestedMenu.value = nil
                         }
                     }) {
-                        let itemViews = (nestedMenu.value?.content ?? content).collectViews(context: context)
-                        Self.ComposeDropdownMenuItems(for: itemViews, context: contentContext, replaceMenu: replaceMenu)
+                        var placement = EnvironmentValues.shared._placement
+                        EnvironmentValues.shared.setValues {
+                            placement.remove(ViewPlacement.toolbar) // Menus popovers are displayed outside the toolbar context
+                            $0.set_placement(placement)
+                        } in: {
+                            let itemViews = (nestedMenu.value?.content ?? content).collectViews(context: context)
+                            Self.ComposeDropdownMenuItems(for: itemViews, context: contentContext, replaceMenu: replaceMenu)
+                        }
                     }
                 } else {
                     toggleMenu = {}

--- a/Sources/SkipUI/SkipUI/Components/Link.swift
+++ b/Sources/SkipUI/SkipUI/Components/Link.swift
@@ -33,8 +33,12 @@ public final class Link : View {
 
     #if SKIP
     @Composable override func ComposeContent(context: ComposeContext) {
-        openURL = EnvironmentValues.shared.openURL
+        ComposeAction()
         content.Compose(context: context)
+    }
+
+    @Composable func ComposeAction() {
+        openURL = EnvironmentValues.shared.openURL
     }
     #else
     public var body: some View {

--- a/Sources/SkipUI/SkipUI/Components/ShareLink.swift
+++ b/Sources/SkipUI/SkipUI/Components/ShareLink.swift
@@ -93,6 +93,11 @@ public final class ShareLink : View {
 
     #if SKIP
     @Composable override func ComposeContent(context: ComposeContext) {
+        ComposeAction()
+        content.Compose(context: context)
+    }
+
+    @Composable func ComposeAction() {
         let localContext = LocalContext.current
 
         let intent = Intent().apply {
@@ -108,7 +113,6 @@ public final class ShareLink : View {
             let shareIntent = Intent.createChooser(intent, nil)
             localContext.startActivity(shareIntent)
         }
-        content.Compose(context: context)
     }
     #else
     public var body: some View {

--- a/Sources/SkipUI/SkipUI/Controls/Button.swift
+++ b/Sources/SkipUI/SkipUI/Controls/Button.swift
@@ -47,6 +47,14 @@ public struct Button : View, ListItemAdapting {
         self.init(action: action, label: { Text(titleKey) })
     }
 
+    public init(_ title: String, systemImage: String, role: ButtonRole? = nil, action: @escaping () -> Void) {
+        self.init(role: role, action: action, label: { Label(title, systemImage: systemImage) })
+    }
+
+    public init(_ titleKey: LocalizedStringKey, systemImage: String, role: ButtonRole? = nil, action: @escaping () -> Void) {
+        self.init(role: role, action: action, label: { Label(titleKey, systemImage: systemImage) })
+    }
+
     public init(role: ButtonRole?, action: @escaping () -> Void, @ViewBuilder label: () -> any View) {
         self.role = role
         self.action = action


### PR DESCRIPTION
Because Links wrap a Button, they are not currently recognized by Menu and the custom Button layout is not applied. Also, Menus inside a toolbar apply the icon only style which is incorrect inside a Menu. This fixes #121.

This implementation is kind of ugly as it relies on calling ComposeAction to prepare the Intent/openURL handler. Ideas on a better approach?

Slightly unrelated but I also added missing Button initializers with systemImage that create a Label.

---

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

