### PR TITLE
Fix deprecated ProgressView for Android

### DIFF
--- a/Sources/SkipUI/SkipUI/Components/ProgressView.swift
+++ b/Sources/SkipUI/SkipUI/Components/ProgressView.swift
@@ -95,7 +95,13 @@ public struct ProgressView : View {
         if value == nil || total == nil {
             LinearProgressIndicator(modifier: modifier, color: color)
         } else {
-            LinearProgressIndicator(progress: Float(value! / total!), modifier: modifier, color: color)
+            LinearProgressIndicator(
+                progress: { Float(value! / total!) },
+                modifier: modifier,
+                color: color,
+                gapSize = -8.dp, // Makes sure the progress overlaps the background
+                drawStopIndicator = {}
+            )
         }
     }
 


### PR DESCRIPTION
There seems to be a deprecated use of Android's `LinearProgressIndicator`. I did a fix to look same as it did before for when there is a value. Let me know if I should update to include same change for when the progress is indeterminate.

Before:
<img width="534" alt="Screenshot 2025-03-02 at 11 32 44" src="https://github.com/user-attachments/assets/36bd96f0-d21e-4766-931f-f07984af880d" />

After:
<img width="534" alt="Screenshot 2025-03-02 at 11 40 28" src="https://github.com/user-attachments/assets/ca6f6ca5-71fe-4c0e-a530-bf4da0f7d264" />

------

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config) https://github.com/skiptools/clabot-config/pull/31 
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
