### PR TITLE
Fix overlay alignment issue with .bottomLeading

### DIFF
--- a/Sources/SkipUI/SkipUI/Layout/Alignment.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Alignment.swift
@@ -11,7 +11,7 @@ public struct Alignment : Equatable, Sendable {
     public static let leading = Alignment(horizontal: .leading, vertical: .center)
     public static let trailing = Alignment(horizontal: .trailing, vertical: .center)
     public static let top = Alignment(horizontal: .center, vertical: .top)
-    public static let bottom = Alignment(horizontal: .leading, vertical: .bottom)
+    public static let bottom = Alignment(horizontal: .center, vertical: .bottom)
     public static let topLeading = Alignment(horizontal: .leading, vertical: .top)
     public static let topTrailing = Alignment(horizontal: .trailing, vertical: .top)
     public static let bottomLeading = Alignment(horizontal: .leading, vertical: .bottom)


### PR DESCRIPTION
Fixed a bug where specifying .bottomLeading alignment for an overlay caused it to display at the bottom.

```Swift
            Rectangle()
                .fill(.blue)
                .frame(width: 100, height: 100)
                .overlay(alignment: .bottomLeading) { // ← .bottomLeading bug
                    Image(systemName: "heart.fill")
                        .resizable()
                        .aspectRatio(contentMode: .fit)
                        .frame(width: 20, height: 20)
                        .foregroundColor(.white)
                }
```
|before|after|
|--|--|
|![Screenshot_1741276558](https://github.com/user-attachments/assets/f1409986-5a2a-4e7f-b548-69632c557b82)|![Screenshot_1741277278](https://github.com/user-attachments/assets/9cfd7b74-056a-49c2-9622-ef8c8bfeb0be)|

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

