### PR TITLE
Allow tagging with optional types

### DIFF
--- a/Sources/SkipUI/SkipUI/View/View.swift
+++ b/Sources/SkipUI/SkipUI/View/View.swift
@@ -714,10 +714,10 @@ extension View {
         return ComposeModifierView(targetView: self) { context in
             let rememberedValue = rememberSaveable(stateSaver: context.stateSaver as! Saver<V, Any>) { mutableStateOf(value) }
             let rememberedInitial = rememberSaveable(stateSaver: context.stateSaver as! Saver<Bool, Any>) { mutableStateOf(true) }
-            
+
             let isInitial = rememberedInitial.value
             rememberedInitial.value = false
-            
+
             let oldValue = rememberedValue.value
             let isUpdate = oldValue != value
             if isUpdate {
@@ -1069,7 +1069,7 @@ extension View {
     }
 
     // SKIP @bridge
-    public func tag(_ tag: Any) -> any View {
+    public func tag(_ tag: Any?) -> any View {
         #if SKIP
         return TagModifierView(view: self, value: tag, role: ComposeModifierRole.tag)
         #else
@@ -1145,9 +1145,9 @@ extension View {
 #if SKIP
 /// Used to mark views with a tag or ID.
 struct TagModifierView: ComposeModifierView {
-    let value: Any
+    let value: Any?
 
-    init(view: View, value: Any, role: ComposeModifierRole) {
+    init(view: View, value: Any?, role: ComposeModifierRole) {
         self.value = value
         super.init(view: view, role: role)
     }


### PR DESCRIPTION
SwiftUI lets you `.tag(nil as String?)`. This is useful for providing a default value for a Picker where the selection value is a `String?` in this case.

I'm not sure if more should be done in ForEach, where `value` is guarded non-nil before being passed to TagModifierView: https://github.com/skiptools/skip-ui/blob/63bc24afa860656c34dba4b90146680c8d3aa74b/Sources/SkipUI/SkipUI/Containers/ForEach.swift#L227

---

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device