### PR TITLE
Remove invalid star fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -2368,7 +2368,6 @@ If a matching system symbol with the same name is not found in any of the asset 
 | plus.circle.fill | Icons.Outlined.AddCircle |
 | square.and.arrow.up | Icons.Outlined.Share |
 | square.and.arrow.up.fill | Icons.Filled.Share |
-| star | Icons.Outlined.Star |
 | star.fill | Icons.Filled.Star |
 | trash | Icons.Outlined.Delete |
 | trash.fill | Icons.Filled.Delete |

--- a/Sources/SkipUI/SkipUI/Components/Image.swift
+++ b/Sources/SkipUI/SkipUI/Components/Image.swift
@@ -450,7 +450,8 @@ public struct Image : View, Equatable {
         case "gearshape": return "Icons.Outlined.Settings" //􀣋
         case "square.and.arrow.up": return "Icons.Outlined.Share" //􀈂
         case "cart": return "Icons.Outlined.ShoppingCart" //􀍩
-        case "star": return "Icons.Outlined.Star" //􀋃
+        // #148 Icons.Outlined.Star is not actually outlined!
+        // case "star": return "Icons.Outlined.Star" //􀋃
         case "hand.thumbsup": return "Icons.Outlined.ThumbUp" //􀉿
         case "exclamationmark.triangle": return "Icons.Outlined.Warning" //􀇿
 


### PR DESCRIPTION
Icons.Outlined.Star is, shockingly, _not_ outlined! https://stackoverflow.com/questions/74050270/compose-icons-outlined-star-isnt-outlined

Fixes #148

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

