### PR TITLE
Bridge Toolbar and Link

### DIFF
--- a/Sources/SkipUI/SkipUI/Commands/Actions.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Actions.swift
@@ -3,8 +3,10 @@
 #if !SKIP_BRIDGE
 import Foundation
 
+// SKIP @bridge
 public struct DismissAction {
-    let action: () -> Void
+    // SKIP @bridge
+    public let action: () -> Void
 
     static let `default` = DismissAction(action: { })
 

--- a/Sources/SkipUI/SkipUI/Components/Link.swift
+++ b/Sources/SkipUI/SkipUI/Components/Link.swift
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 #endif
 
 // Use a class to be able to update our openURL action on compose by reference.
+// SKIP @bridge
 public final class Link : View {
     let content: Button
     var openURL = OpenURLAction.default
@@ -14,6 +15,15 @@ public final class Link : View {
     public init(destination: URL, @ViewBuilder label: () -> any View) {
         #if SKIP
         content = Button(action: { self.openURL(destination) }, label: label)
+        #else
+        content = Button("", action: {})
+        #endif
+    }
+
+    // SKIP @bridge
+    public init(destination: URL, bridgedLabel: any View) {
+        #if SKIP
+        content = Button(bridgedRole: nil, action: { self.openURL(destination) }, bridgedLabel: bridgedLabel)
         #else
         content = Button("", action: {})
         #endif

--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -211,6 +211,7 @@ public struct NavigationStack : View {
 
     // SKIP INSERT: @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
     @Composable private func ComposeEntry(navigator: MutableState<Navigator>, arguments: NavigationEntryArguments, context: ComposeContext, content: @Composable (ComposeContext) -> Void) {
+        android.util.Log.e("", "RECOMPOSING ENTRY HERE !!!!!!!!!!") //~~~
         let context = context.content(stateSaver: arguments.state.stateSaver)
 
         let topBarPreferences = arguments.toolbarPreferences.navigationBar

--- a/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
+++ b/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
@@ -221,6 +221,8 @@ extension EnvironmentValues {
         switch key {
         case "colorScheme":
             return EnvironmentSupport(builtinValue: colorScheme.rawValue)
+        case "dismiss":
+            return EnvironmentSupport(builtinValue: dismiss)
         default:
             return nil
         }

--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -213,7 +213,7 @@ final class DisableScrollToDismissConnection : NestedScrollConnection {
         } else {
             actionViews = [actions]
         }
-        let composableActions = actionViews.compactMap {
+        let composableActions: [View] = actionViews.compactMap {
             $0.strippingModifiers { $0 as? Button ?? $0 as? Link ?? $0 as? NavigationLink }
         }
         let messageViews: [View]
@@ -343,10 +343,10 @@ final class DisableScrollToDismissConnection : NestedScrollConnection {
     } else {
         actionViews = [actions]
     }
-    let textFields = actionViews.compactMap {
+    let textFields: [TextField] = actionViews.compactMap {
         $0.strippingModifiers { ($0 as? TextField) ?? ($0 as? SecureField)?.textField }
     }
-    let optionViews = actionViews.compactMap {
+    let optionViews: [View] = actionViews.compactMap {
         $0.strippingModifiers { $0 as? Button ?? $0 as? NavigationLink ?? $0 as? Link }
     }
     let messageViews: [View]

--- a/Sources/SkipUI/SkipUI/View/View.swift
+++ b/Sources/SkipUI/SkipUI/View/View.swift
@@ -560,7 +560,8 @@ extension View {
         return self
     }
 
-    public func hidden() -> some View {
+    // SKIP @bridge
+    public func hidden() -> any View {
         #if SKIP
         return opacity(0.0)
         #else
@@ -592,7 +593,7 @@ extension View {
         #endif
     }
 
-    public func ignoresSafeArea(_ regions: SafeAreaRegions = .all, edges: Edge.Set = .all) -> some View {
+    public func ignoresSafeArea(_ regions: SafeAreaRegions = .all, edges: Edge.Set = .all) -> any View {
         #if SKIP
         guard regions.contains(.container) else {
             return self
@@ -603,6 +604,11 @@ extension View {
         #else
         return self
         #endif
+    }
+
+    // SKIP @bridge
+    public func ignoresSafeArea(bridgedRegions: Int, bridgedEdges: Int) -> any View {
+        return ignoresSafeArea(SafeAreaRegions(rawValue: bridgedRegions), edges: Edge.Set(rawValue: bridgedEdges))
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
Toolbar bridging required separating out the toolbar content Preference for efficiency, as the native side couldn't take advantage of the automatic state tracking within the @Composable toolbar { } block. We now have a separate content Preference that we only read from within the top band bottom bar @Composables