### PR TITLE
Use ic_launcher resource for the Android notification icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1933,9 +1933,17 @@ Support levels:
 
 Skip integrates its support for the UserNotifications framework into SkipUI.
 
+**Important:** on Android devices to properly display notification icons in the status bar they must have specific properites. The icon must have a transparent background and a solid shape (usually white). It's recommended to use a specific icon for that and it must be specified in the AndroidManifest.xml with the following code inside the application tag:
+
+```xml
+<meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_notification" />
+```
+
+SKIP assume that the icon is called `ic_notification` and it's available inside the drawable resources. Otherwise it will fall back to use the app icon (eg. @mipmap/ic_launcher). Note that in this case it will most likely be displayed as solid white dot instead of the usual app icon.
+
 The following table summarizes SkipUI's UserNotifications support on Android. Anything not listed here is likely not supported. Note that in your iOS-only code - i.e. code within `#if !SKIP` blocks - you can use any UserNotifications API you want.
-
-
 
 Support levels:
 

--- a/README.md
+++ b/README.md
@@ -1935,6 +1935,8 @@ Skip integrates its support for the UserNotifications framework into SkipUI.
 
 The following table summarizes SkipUI's UserNotifications support on Android. Anything not listed here is likely not supported. Note that in your iOS-only code - i.e. code within `#if !SKIP` blocks - you can use any UserNotifications API you want.
 
+
+
 Support levels:
 
   - ✅ – Full

--- a/Sources/SkipUI/SkipUI/UIKit/UserNotifications.swift
+++ b/Sources/SkipUI/SkipUI/UIKit/UserNotifications.swift
@@ -114,8 +114,14 @@ public final class UNUserNotificationCenter {
             let iconNotificationIdentifier = "ic_notification"
             let resourceFolder = "drawable"
             
-            let resId = application.resources.getIdentifier(iconNotificationIdentifier, resourceFolder, packageName)
-//            notificationBuilder.setSmallIcon(IconCompat.createWithResource(application, resId))
+            var resId = application.resources.getIdentifier(iconNotificationIdentifier, resourceFolder, packageName)
+            
+            // Check if the resource is found, otherwise fallback to use the default app icon (eg. ic_launcher)
+            if resId == 0 {
+                resId = application.resources.getIdentifier("ic_launcher", "mipmap", packageName)
+            }
+            
+            notificationBuilder.setSmallIcon(IconCompat.createWithResource(application, resId))
         }
 
         let manager = activity.getSystemService(Context.NOTIFICATION_SERVICE) as! NotificationManager

--- a/Sources/SkipUI/SkipUI/UIKit/UserNotifications.swift
+++ b/Sources/SkipUI/SkipUI/UIKit/UserNotifications.swift
@@ -115,7 +115,7 @@ public final class UNUserNotificationCenter {
             let resourceFolder = "drawable"
             
             let resId = application.resources.getIdentifier(iconNotificationIdentifier, resourceFolder, packageName)
-            notificationBuilder.setSmallIcon(IconCompat.createWithResource(application, resId))
+//            notificationBuilder.setSmallIcon(IconCompat.createWithResource(application, resId))
         }
 
         let manager = activity.getSystemService(Context.NOTIFICATION_SERVICE) as! NotificationManager

--- a/Sources/SkipUI/SkipUI/UIKit/UserNotifications.swift
+++ b/Sources/SkipUI/SkipUI/UIKit/UserNotifications.swift
@@ -104,7 +104,17 @@ public final class UNUserNotificationCenter {
             notificationBuilder.setSmallIcon(IconCompat.createWithContentUri(imageAttachment.url.absoluteString))
         } else {
             let packageName = application.getPackageName()
-            let resId = application.resources.getIdentifier("ic_launcher", "mipmap", packageName)
+            
+            // Notification icon: must be a resource with transparent background and white logo
+            // eg: to be used as a default icon must be added in the AndroidManifest.xml with the following code:
+            // <meta-data
+            // android:name="com.google.firebase.messaging.default_notification_icon"
+            // android:resource="@drawable/ic_notification" />
+            
+            let iconNotificationIdentifier = "ic_notification"
+            let resourceFolder = "drawable"
+            
+            let resId = application.resources.getIdentifier(iconNotificationIdentifier, resourceFolder, packageName)
             notificationBuilder.setSmallIcon(IconCompat.createWithResource(application, resId))
         }
 


### PR DESCRIPTION
Changed the setSmallIcon call to use a specific notifcation icon insted of the ic_laucnher one to avoid a wrong icon in the tray

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

