### PR TITLE
onPreferenceChange

### DIFF
--- a/Sources/SkipUI/SkipUI/Environment/PreferenceKey.swift
+++ b/Sources/SkipUI/SkipUI/Environment/PreferenceKey.swift
@@ -168,16 +168,23 @@ struct PreferenceNode<Value>: Equatable {
 
 extension View {
     public func preference(key: Any.Type, value: Any) -> any View {
-        #if SKIP
+#if SKIP
         return ComposeModifierView(targetView: self) {
             PreferenceValues.shared.contribute(context: $0, key: key, value: value)
             return ComposeResult.ok
         }
-        #else
+#else
         return self
-        #endif
+#endif
+    }
+    
+    // TODO: Add Equatable constraint to K.Value
+    // SKIP DECLARE: public fun <K: PreferenceKey<V>, V: Any> View.onPreferenceChange(key: KClass<K>, perform: (V) -> Unit): View
+    public func onPreferenceChange<K>(_ key: K.Type = K.self, perform action: @escaping (K.Value) -> Void) -> some View where K : PreferenceKey/*, K.Value : Equatable*/ {
+        return self
     }
 }
+
 
 #if false
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
@@ -316,23 +323,6 @@ extension View {
     ///
     /// - Returns: a new version of the view that writes the preference.
     public func anchorPreference<A, K>(key _: K.Type = K.self, value: Anchor<A>.Source, transform: @escaping (Anchor<A>) -> K.Value) -> some View where K : PreferenceKey { return stubView() }
-
-}
-
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-extension View {
-
-    /// Adds an action to perform when the specified preference key's value
-    /// changes.
-    ///
-    /// - Parameters:
-    ///   - key: The key to monitor for value changes.
-    ///   - action: The action to perform when the value for `key` changes. The
-    ///     `action` closure passes the new value as its parameter.
-    ///
-    /// - Returns: A view that triggers `action` when the value for `key`
-    ///   changes.
-    public func onPreferenceChange<K>(_ key: K.Type = K.self, perform action: @escaping (K.Value) -> Void) -> some View where K : PreferenceKey, K.Value : Equatable { return stubView() }
 
 }
 


### PR DESCRIPTION
Fixes #133

This PR is weird in several ways.

First, it appears that `SKIP DECLARE` won't let me disregard the complex `where` clause of the declaration of this function. If I uncomment the `K.Value : Equatable` part, Skip will complain, "Skip does not support the referenced type as a generic constraint." I would have expected `SKIP DECLARE` to tell Skip to disregard that problem, but it doesn't. (Relaxing that constraint should be harmless in practice, because the Xcode build will reject it if someone tries to make a PreferenceKey of a non-Equatable value.) I've filed this as a bug on the transpiler. https://github.com/skiptools/skip/issues/432

Second, I'm using `snapshotFlow`; I have no idea how I'd port that to Swift, so I just didn't; I'm heavily using `SKIP INSERT` for this.

Third, you can't just build out an ordinary `PreferenceKey` and use it with `preference`. I had to declare my PreferenceKey like this:

```swift
struct TestPreferenceKey: PreferenceKey {
    typealias Value = String
    
    #if SKIP
    // SKIP DECLARE: companion object: PreferenceKeyCompanion<String>
    final class Companion: PreferenceKeyCompanion {
        let defaultValue = ""
        func reduce(value: inout String, nextValue: () -> String) {
            value = nextValue()
        }
    }
    #else
    static var defaultValue: String = ""

    static func reduce(value: inout String, nextValue: () -> String) {
        value = nextValue()
    }
    #endif
}
```

That is, in SwiftUI, I could just declare a couple of static methods, but in SkipUI, I had to explicitly declare a companion object so I could declare it a `PreferenceKeyCompanion`.

This is all quite strange, but it _does_ work. (And isn't that really what Skip is all about? 😉)

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

