### PR TITLE
Add support for accessibilityHint(_:)

### DIFF
--- a/Sources/SkipUI/SkipUI/System/Accessibility.swift
+++ b/Sources/SkipUI/SkipUI/System/Accessibility.swift
@@ -6,6 +6,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.invisibleToUser
+import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.popup
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
@@ -107,19 +108,31 @@ extension View {
         return self
     }
 
-    @available(*, unavailable)
     public func accessibilityHint(_ hint: Text) -> some View {
+        #if SKIP
+        return ComposeModifierView(targetView: self, role: .accessibility) {
+            let label = hint.localizedTextString()
+            $0.modifier = $0.modifier.semantics { onClick(label: label, action: nil ) }
+            return ComposeResult.ok
+        }
+        #else
         return self
+        #endif
     }
 
-    @available(*, unavailable)
     public func accessibilityHint(_ hintKey: LocalizedStringKey) -> some View {
-        return self
+        return accessibilityHint(Text(hintKey))
     }
 
-    @available(*, unavailable)
     public func accessibilityHint(_ hint: String) -> some View {
+        #if SKIP
+        return ComposeModifierView(targetView: self, role: .accessibility) {
+            $0.modifier = $0.modifier.semantics { onClick(label: hint, action: nil ) }
+            return ComposeResult.ok
+        }
+        #else
         return self
+        #endif
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
I guess this isn't a perfect match for <https://developer.apple.com/documentation/swiftui/view/accessibilityhint(_:)>, because I think the iOS version applies whenever the user "performs the view's action," whereas my implementation only applies when the user clicks on a clickable (a button).

But I've never seen anyone use accessibility hints on anything except buttons. (I'm struggling to imagine how/why an accessibility hint would be necessary on anything _but_ a button.)

If you think this implementation isn't close enough to iOS's behavior, we could document that users should do this instead, at least for buttons:

```swift
#if SKIP
import androidx.compose.ui.semantics.onClick
import androidx.compose.ui.semantics.semantics
#endif

Button("Click me") { print("clicked") }
#if SKIP
.composeModifier { $0.semantics { onClick(label: "Insert hint here", action: nil) } }
#else
.accessibilityHint("Insert hint here")
#endif
```

But IMO that's even jankier.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

