### PR TITLE
Updates to work with Strong Skipping in Kotlin/Compose 2.0.20+

### DIFF
--- a/Sources/SkipUI/SkipUI/Animation/Animation.swift
+++ b/Sources/SkipUI/SkipUI/Animation/Animation.swift
@@ -64,6 +64,7 @@ extension View {
                 if isValueChange || (animation?.isInfinite == true && hasChangedValue.value) {
                     $0.set_animation(animation)
                 }
+                return ComposeResult.ok
             } in: {
                 view.Compose(context: context)
             }

--- a/Sources/SkipUI/SkipUI/Color/ColorScheme.swift
+++ b/Sources/SkipUI/SkipUI/Color/ColorScheme.swift
@@ -96,6 +96,7 @@ extension View {
 @Composable public func Material3ColorScheme(_ scheme: (@Composable (androidx.compose.material3.ColorScheme, Bool) -> androidx.compose.material3.ColorScheme)?, content: @Composable () -> Void) {
     EnvironmentValues.shared.setValues {
         $0.set_material3ColorScheme(scheme)
+        return ComposeResult.ok
     } in: {
         content()
     }

--- a/Sources/SkipUI/SkipUI/Commands/Menu.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Menu.swift
@@ -128,6 +128,7 @@ public final class Menu : View {
                         EnvironmentValues.shared.setValues {
                             placement.remove(ViewPlacement.toolbar) // Menus popovers are displayed outside the toolbar context
                             $0.set_placement(placement)
+                            return ComposeResult.ok
                         } in: {
                             let itemViews = (nestedMenu.value?.content ?? content).collectViews(context: context)
                             Self.ComposeDropdownMenuItems(for: itemViews, context: contentContext, replaceMenu: replaceMenu)

--- a/Sources/SkipUI/SkipUI/Commands/Search.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Search.swift
@@ -47,6 +47,7 @@ extension View {
             if view.strippingModifiers(perform: { $0 is NavigationStack}) || LocalNavigator.current?.isRoot != true {
                 EnvironmentValues.shared.setValues {
                     $0.set_searchableState(state)
+                    return ComposeResult.ok
                 } in: {
                     view.Compose(context: context)
                 }

--- a/Sources/SkipUI/SkipUI/Commands/Toolbar.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Toolbar.swift
@@ -73,6 +73,7 @@ public struct ToolbarItem : View, CustomizableToolbarContent {
                 textEnvironment.fontWeight = Font.Weight.bold
                 $0.set_textEnvironment(textEnvironment)
             }
+            return ComposeResult.ok
         } in: {
             content.Compose(context: context)
         }

--- a/Sources/SkipUI/SkipUI/Compose/ComposeBuilder.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeBuilder.swift
@@ -64,13 +64,7 @@ public struct ComposeBuilder: View {
     }
 
     @Composable public override func ComposeContent(context: ComposeContext) {
-        if let composer = context.composer as? RenderingComposer {
-            composer.willCompose()
-            let result = content(context)
-            composer.didCompose(result: result)
-        } else {
-            content(context)
-        }
+        content(context)
     }
 
     /// Use a custom composer to collect the views composed within this view.

--- a/Sources/SkipUI/SkipUI/Compose/ComposeContainer.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeContainer.swift
@@ -108,6 +108,7 @@ import androidx.compose.ui.Modifier
             }
             return EnvironmentValues.shared._fillHeightModifier ?? Modifier.fillMaxHeight()
         }
+        return ComposeResult.ok
     } in: {
         // Render the container content with the above environment setup
         content(modifier)

--- a/Sources/SkipUI/SkipUI/Compose/ComposeContext.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeContext.swift
@@ -59,14 +59,6 @@ public class RenderingComposer : Composer {
         self.compose = nil
     }
 
-    /// Called before a `ComposeBuilder` composes its content.
-    public func willCompose() {
-    }
-
-    /// Called after a `ComposeBuilder` composes its content.
-    public func didCompose(result: ComposeResult) {
-    }
-
     /// Compose the given view's content.
     ///
     /// - Parameter context: The context to use to render the view, optionally retaining this composer.

--- a/Sources/SkipUI/SkipUI/Compose/ComposeLayouts.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeLayouts.swift
@@ -180,6 +180,7 @@ import androidx.compose.ui.unit.dp
     let contentSafeArea = SafeArea(presentation: safeArea.presentationBoundsPx, safe: contentSafeBounds, absoluteSystemBars: safeArea.absoluteSystemBarEdges)
     EnvironmentValues.shared.setValues {
         $0.set_safeArea(contentSafeArea)
+        return ComposeResult.ok
     } in: {
         Layout(modifier: modifier.onGloballyPositionedInWindow {
             let edges = adjacentSafeAreaEdges(bounds: $0, safeArea: safeArea, isRTL: isRTL, checkEdges: expandInto.union(checkEdges))

--- a/Sources/SkipUI/SkipUI/Containers/AnimatedContentArguments.swift
+++ b/Sources/SkipUI/SkipUI/Containers/AnimatedContentArguments.swift
@@ -13,7 +13,6 @@ struct AnimatedContentArguments: Equatable {
     let rememberedIds: MutableSet<Any>
     let newIds: Array<Any>
     let rememberedNewIds: MutableSet<Any>
-    let composer: RenderingComposer?
     let isBridged: Bool
 
     static func ==(lhs: AnimatedContentArguments, rhs: AnimatedContentArguments) -> Bool {

--- a/Sources/SkipUI/SkipUI/Containers/DisclosureGroup.swift
+++ b/Sources/SkipUI/SkipUI/Containers/DisclosureGroup.swift
@@ -139,6 +139,7 @@ public struct DisclosureGroup : View, ListItemAdapting, LazyItemFactory {
                     if let foregroundStyle {
                         $0.set_foregroundStyle(foregroundStyle)
                     }
+                    return ComposeResult.ok
                 } in: {
                     label.Compose(context: contentContext)
                 }

--- a/Sources/SkipUI/SkipUI/Containers/Group.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Group.swift
@@ -61,7 +61,7 @@ public struct Group : View {
         if ids.count < views.count {
             views.forEach { $0.Compose(context: context) }
         } else {
-            let arguments = AnimatedContentArguments(views: views, idMap: idMap, ids: ids, rememberedIds: rememberedIds, newIds: newIds, rememberedNewIds: rememberedNewIds, composer: nil, isBridged: isBridged)
+            let arguments = AnimatedContentArguments(views: views, idMap: idMap, ids: ids, rememberedIds: rememberedIds, newIds: newIds, rememberedNewIds: rememberedNewIds, isBridged: isBridged)
             ComposeAnimatedContent(context: context, arguments: arguments)
         }
     }

--- a/Sources/SkipUI/SkipUI/Containers/HStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/HStack.swift
@@ -68,6 +68,7 @@ public struct HStack : View {
                     let fillWidthModifier = Modifier.weight(Float(1.0)) // Only available in Row context
                     EnvironmentValues.shared.setValues {
                         $0.set_fillWidthModifier(fillWidthModifier)
+                        return ComposeResult.ok
                     } in: {
                         views.forEach { $0.Compose(context: contentContext) }
                     }
@@ -107,6 +108,7 @@ public struct HStack : View {
                 let fillWidthModifier = Modifier.weight(Float(1.0)) // Only available in Row context
                 EnvironmentValues.shared.setValues {
                     $0.set_fillWidthModifier(fillWidthModifier)
+                    return ComposeResult.ok
                 } in: {
                     for view in state {
                         let id = arguments.idMap(view)

--- a/Sources/SkipUI/SkipUI/Containers/HStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/HStack.swift
@@ -76,7 +76,7 @@ public struct HStack : View {
             }
         } else {
             ComposeContainer(axis: .horizontal, modifier: context.modifier) { modifier in
-                let arguments = AnimatedContentArguments(views: views, idMap: idMap, ids: ids, rememberedIds: rememberedIds, newIds: newIds, rememberedNewIds: rememberedNewIds, composer: nil, isBridged: isBridged)
+                let arguments = AnimatedContentArguments(views: views, idMap: idMap, ids: ids, rememberedIds: rememberedIds, newIds: newIds, rememberedNewIds: rememberedNewIds, isBridged: isBridged)
                 ComposeAnimatedContent(context: context, modifier: modifier, arguments: arguments, rowAlignment: rowAlignment, rowArrangement: rowArrangement)
             }
         }

--- a/Sources/SkipUI/SkipUI/Containers/LazyHGrid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyHGrid.swift
@@ -90,6 +90,7 @@ public struct LazyHGrid: View {
 
             EnvironmentValues.shared.setValues {
                 $0.set_scrollTargetBehavior(nil)
+                return ComposeResult.ok
             } in: {
                 LazyHorizontalGrid(state: gridState, modifier: modifier, rows: gridCells, horizontalArrangement: horizontalArrangement, verticalArrangement: verticalArrangement, contentPadding: EnvironmentValues.shared._contentPadding.asPaddingValues(), userScrollEnabled: isScrollEnabled, flingBehavior: flingBehavior) {
                     factoryContext.value.initialize(

--- a/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
@@ -82,6 +82,7 @@ public struct LazyHStack : View {
 
             EnvironmentValues.shared.setValues {
                 $0.set_scrollTargetBehavior(nil)
+                return ComposeResult.ok
             } in: {
                 LazyRow(state: listState, modifier: modifier, horizontalArrangement: rowArrangement, verticalAlignment: rowAlignment, contentPadding: EnvironmentValues.shared._contentPadding.asPaddingValues(), userScrollEnabled: isScrollEnabled, flingBehavior: flingBehavior) {
                     factoryContext.value.initialize(

--- a/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
@@ -107,6 +107,7 @@ public struct LazyVGrid: View {
 
                 EnvironmentValues.shared.setValues {
                     $0.set_scrollTargetBehavior(nil)
+                    return ComposeResult.ok
                 } in: {
                     LazyVerticalGrid(state: gridState, modifier: Modifier.fillMaxWidth(), columns: gridCells, horizontalArrangement: horizontalArrangement, verticalArrangement: verticalArrangement, contentPadding: EnvironmentValues.shared._contentPadding.asPaddingValues(), userScrollEnabled: isScrollEnabled, flingBehavior: flingBehavior) {
                         factoryContext.value.initialize(

--- a/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
@@ -100,6 +100,7 @@ public struct LazyVStack : View {
 
                 EnvironmentValues.shared.setValues {
                     $0.set_scrollTargetBehavior(nil)
+                    return ComposeResult.ok
                 } in: {
                     LazyColumn(state: listState, modifier: Modifier.fillMaxWidth(), verticalArrangement: columnArrangement, horizontalAlignment: columnAlignment, contentPadding: EnvironmentValues.shared._contentPadding.asPaddingValues(), userScrollEnabled: isScrollEnabled, flingBehavior: flingBehavior) {
                         factoryContext.value.initialize(

--- a/Sources/SkipUI/SkipUI/Containers/List.swift
+++ b/Sources/SkipUI/SkipUI/Containers/List.swift
@@ -394,6 +394,7 @@ public final class List : View {
                 let placement = EnvironmentValues.shared._placement
                 EnvironmentValues.shared.setValues {
                     $0.set_placement(placement.union(ViewPlacement.listItem))
+                    return ComposeResult.ok
                 } in: {
                     // Note that we're calling the same view's Compose function again with a new context
                     view.Compose(context: context.content(composer: ListItemComposer(contentModifier: Self.contentModifier(level: level), itemTransformer: itemTransformer)))
@@ -502,6 +503,7 @@ public final class List : View {
             Column(modifier: Modifier.fillMaxWidth()) {
                 EnvironmentValues.shared.setValues {
                     $0.set_listSectionHeaderStyle(styling.style)
+                    return ComposeResult.ok
                 } in: {
                     view.Compose(context: context.content(modifier: contentModifier))
                 }
@@ -526,6 +528,7 @@ public final class List : View {
                 Column(modifier: Modifier.fillMaxWidth().heightIn(min: 1.dp)) {
                     EnvironmentValues.shared.setValues {
                         $0.set_listSectionFooterStyle(styling.style)
+                        return ComposeResult.ok
                     } in: {
                         view.Compose(context: context.content(modifier: contentModifier))
                     }

--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -194,6 +194,7 @@ public struct NavigationStack : View {
                                 let toolbarContentPreferencesCollector = PreferenceCollector<ToolbarContentPreferences>(key: ToolbarContentPreferenceKey.self, state: toolbarContentPreferences)
                                 EnvironmentValues.shared.setValues {
                                     $0.setdismiss(DismissAction(action: { navigator.value.navigateBack() }))
+                                    return ComposeResult.ok
                                 } in: {
                                     let arguments = NavigationEntryArguments(isRoot: false, state: state, safeArea: safeArea, ignoresSafeAreaEdges: ignoresSafeAreaEdges, title: title.value.reduced, toolbarPreferences: toolbarPreferences.value.reduced)
                                     PreferenceValues.shared.collectPreferences([titleCollector, toolbarPreferencesCollector, toolbarContentPreferencesCollector, destinationsCollector]) {
@@ -321,6 +322,7 @@ public struct NavigationStack : View {
                 EnvironmentValues.shared.setValues {
                     $0.set_placement(placement.union(ViewPlacement.toolbar))
                     $0.set_tint(tint)
+                    return ComposeResult.ok
                 } in: {
                     let interactionSource = remember { MutableInteractionSource() }
                     var topBarModifier = Modifier.zIndex(Float(1.1))
@@ -448,6 +450,7 @@ public struct NavigationStack : View {
                 EnvironmentValues.shared.setValues {
                     $0.set_tint(tint)
                     $0.set_placement(placement.union(ViewPlacement.toolbar))
+                    return ComposeResult.ok
                 } in: {
                     var bottomBarModifier = Modifier.zIndex(Float(1.1))
                         .onGloballyPositionedInWindow { bounds in
@@ -523,6 +526,7 @@ public struct NavigationStack : View {
                     if arguments.isRoot {
                         $0.set_searchableState(searchableState)
                     }
+                    return ComposeResult.ok
                 } in: {
                     // Elevate the top padding modifier so that content always has the same context, allowing it to avoid recomposition
                     Box(modifier: Modifier.padding(top: topPadding)) {

--- a/Sources/SkipUI/SkipUI/Containers/PresentationRoot.swift
+++ b/Sources/SkipUI/SkipUI/Containers/PresentationRoot.swift
@@ -81,6 +81,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
                         $0.set_isEdgeToEdge(safeBounds != presentationBounds.value)
                     }
                     $0.set_safeArea(safeArea)
+                    return ComposeResult.ok
                 } in: {
                     Box(modifier: Modifier.fillMaxSize().padding(safeArea), contentAlignment = androidx.compose.ui.Alignment.Center) {
                         content(context)

--- a/Sources/SkipUI/SkipUI/Containers/ScrollView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/ScrollView.swift
@@ -120,6 +120,7 @@ public struct ScrollView : View {
                         }
                         EnvironmentValues.shared.setValues {
                             $0.set_scrollViewAxes(axes)
+                            return ComposeResult.ok
                         } in: {
                             PreferenceValues.shared.collectPreferences([builtinScrollAxisSetCollector]) {
                                 content.Compose(context: contentContext)

--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -387,6 +387,7 @@ public struct TabView : View {
                             enterTransition: { fadeIn() },
                             exitTransition: { fadeOut() }) {
                         // Use a constant number of routes. Changing routes causes a NavHost to reset its state
+                        let entryContext = context.content()
                         for tabIndex in 0..<100 {
                             composable(String(describing: tabIndex)) { _ in
                                 // Inset manually where our container ignored the safe area, but we aren't showing a bar
@@ -409,7 +410,7 @@ public struct TabView : View {
                                     // recomposing when called with the same values
                                     let arguments = TabEntryArguments(tabIndex: tabIndex, modifier: contentModifier, safeArea: contentSafeArea)
                                     PreferenceValues.shared.collectPreferences([tabBarPreferencesCollector]) {
-                                        ComposeEntry(with: arguments, context: context)
+                                        ComposeEntry(with: arguments, context: entryContext)
                                     }
                                 }
                             }
@@ -431,8 +432,10 @@ public struct TabView : View {
                 }
                 return ComposeResult.ok
             } in: {
-                // Use a custom composer to only render the tabIndex'th view
-                content.Compose(context: context.content(composer: TabIndexComposer(index: arguments.tabIndex)))
+                let views = content.collectViews(context: context).filter { !$0.isSwiftUIEmptyView }
+                if views.count > arguments.tabIndex {
+                    views[arguments.tabIndex].Compose(context: context)
+                }
             }
         }
     }
@@ -526,31 +529,6 @@ struct TabItemModifierView: ComposeModifierView {
 
     @Composable public override func ComposeContent(context: ComposeContext) {
         view.Compose(context: context)
-    }
-}
-
-final class TabIndexComposer: RenderingComposer {
-    let index: Int
-    var currentIndex = 0
-
-    init(index: Int) {
-        self.index = index
-        super.init()
-    }
-
-    override func willCompose() {
-        currentIndex = 0
-    }
-
-    @Composable override func Compose(view: View, context: (Bool) -> ComposeContext) {
-        // Be sure to keep the filtering of empty views consistent with our rendering of corresponding TabItems in the navigation bar
-        guard !view.isSwiftUIEmptyView else {
-            return
-        }
-        if currentIndex == index {
-            view.ComposeContent(context: context(false))
-        }
-        currentIndex += 1
     }
 }
 #endif

--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -210,6 +210,7 @@ public struct TabView : View {
         var tabViews: [View] = []
         EnvironmentValues.shared.setValues {
             $0.set_placement(ViewPlacement.tagged)
+            return ComposeResult.ok
         } in: {
             tabViews = content.collectViews(context: tabContext).filter { !$0.isSwiftUIEmptyView }
         }
@@ -428,6 +429,7 @@ public struct TabView : View {
                 if let safeArea = arguments.safeArea {
                     $0.set_safeArea(safeArea)
                 }
+                return ComposeResult.ok
             } in: {
                 // Use a custom composer to only render the tabIndex'th view
                 content.Compose(context: context.content(composer: TabIndexComposer(index: arguments.tabIndex)))

--- a/Sources/SkipUI/SkipUI/Containers/Table.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Table.swift
@@ -135,6 +135,7 @@ public final class Table<ObjectType, ID> : View where ObjectType: Identifiable<I
         let foregroundStyle: ShapeStyle = EnvironmentValues.shared._foregroundStyle ?? Color.accentColor
         EnvironmentValues.shared.setValues {
             $0.set_foregroundStyle(foregroundStyle)
+            return ComposeResult.ok
         } in: {
             Column(modifier: modifier) {
                 Row(modifier: List.contentModifier(level: 0), verticalAlignment: androidx.compose.ui.Alignment.CenterVertically) {
@@ -191,6 +192,7 @@ public final class Table<ObjectType, ID> : View where ObjectType: Identifiable<I
                     EnvironmentValues.shared.setValues {
                         $0.set_foregroundStyle(itemForegroundStyle)
                         $0.set_placement(placement.union(ViewPlacement.listItem))
+                        return ComposeResult.ok
                     } in: {
                         tableColumn.cellContent(data[index]).Compose(context: itemContext)
                     }

--- a/Sources/SkipUI/SkipUI/Containers/VStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/VStack.swift
@@ -77,6 +77,7 @@ public struct VStack : View {
                     let fillHeightModifier = Modifier.weight(Float(1.0)) // Only available in Column context
                     EnvironmentValues.shared.setValues {
                         $0.set_fillHeightModifier(fillHeightModifier)
+                        return ComposeResult.ok
                     } in: {
                         composer?.willCompose()
                         views.forEach { $0.Compose(context: contentContext) }
@@ -118,6 +119,7 @@ public struct VStack : View {
                 let fillHeightModifier = Modifier.weight(Float(1.0)) // Only available in Column context
                 EnvironmentValues.shared.setValues {
                     $0.set_fillHeightModifier(fillHeightModifier)
+                    return ComposeResult.ok
                 } in: {
                     arguments.composer?.willCompose()
                     for view in state {

--- a/Sources/SkipUI/SkipUI/Containers/VStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/VStack.swift
@@ -48,18 +48,15 @@ public struct VStack : View {
     #if SKIP
     @Composable public override func ComposeContent(context: ComposeContext) {
         let columnAlignment = alignment.asComposeAlignment()
-        let composer: VStackComposer?
         let columnArrangement: Arrangement.Vertical
         if let spacing {
-            composer = nil
             columnArrangement = Arrangement.spacedBy(spacing.dp, alignment: androidx.compose.ui.Alignment.CenterVertically)
         } else {
-            composer = VStackComposer()
             columnArrangement = Arrangement.spacedBy(0.dp, alignment: androidx.compose.ui.Alignment.CenterVertically)
         }
 
         let views = content.collectViews(context: context).filter { !($0 is EmptyView) }
-        let idMap: (View) -> Any? = { TagModifierView.strip(from = it, role = ComposeModifierRole.id)?.value }
+        let idMap: (View) -> Any? = { TagModifierView.strip(from: $0, role: ComposeModifierRole.id)?.value }
         let ids = views.compactMap(idMap)
         let rememberedIds = remember { mutableSetOf<Any>() }
         let newIds = ids.filter { !rememberedIds.contains(it) }
@@ -71,7 +68,7 @@ public struct VStack : View {
 
         if ids.count < views.count {
             rememberedNewIds.clear()
-            let contentContext = context.content(composer: composer)
+            let contentContext = context.content()
             ComposeContainer(axis: .vertical, modifier: context.modifier) { modifier in
                 Column(modifier: modifier, verticalArrangement: columnArrangement, horizontalAlignment: columnAlignment) {
                     let fillHeightModifier = Modifier.weight(Float(1.0)) // Only available in Column context
@@ -79,15 +76,16 @@ public struct VStack : View {
                         $0.set_fillHeightModifier(fillHeightModifier)
                         return ComposeResult.ok
                     } in: {
-                        composer?.willCompose()
-                        views.forEach { $0.Compose(context: contentContext) }
-                        composer?.didCompose(result: ComposeResult.ok)
+                        var lastViewWasText: Bool? = nil
+                        for view in views {
+                            lastViewWasText = ComposeSpaced(view: view, lastViewWasText: lastViewWasText, context: contentContext)
+                        }
                     }
                 }
             }
         } else {
             ComposeContainer(axis: .vertical, modifier: context.modifier) { modifier in
-                let arguments = AnimatedContentArguments(views: views, idMap: idMap, ids: ids, rememberedIds: rememberedIds, newIds: newIds, rememberedNewIds: rememberedNewIds, composer: composer, isBridged: isBridged)
+                let arguments = AnimatedContentArguments(views: views, idMap: idMap, ids: ids, rememberedIds: rememberedIds, newIds: newIds, rememberedNewIds: rememberedNewIds, isBridged: isBridged)
                 ComposeAnimatedContent(context: context, modifier: modifier, arguments: arguments, columnAlignment: columnAlignment, columnArrangement: columnArrangement)
             }
         }
@@ -121,7 +119,7 @@ public struct VStack : View {
                     $0.set_fillHeightModifier(fillHeightModifier)
                     return ComposeResult.ok
                 } in: {
-                    arguments.composer?.willCompose()
+                    var lastViewWasText: Bool? = nil
                     for view in state {
                         let id = arguments.idMap(view)
                         var modifier: Modifier = Modifier
@@ -132,13 +130,34 @@ public struct VStack : View {
                             let exit = transition.asExitTransition(spec: spec)
                             modifier = modifier.animateEnterExit(enter: enter, exit: exit)
                         }
-                        let contentContext = context.content(modifier: modifier, composer: arguments.composer)
-                        view.Compose(context: contentContext)
+                        let contentContext = context.content(modifier: modifier)
+                        lastViewWasText = ComposeSpaced(view: view, lastViewWasText: lastViewWasText, context: contentContext)
                     }
-                    arguments.composer?.didCompose(result: ComposeResult.ok)
                 }
             }
         }, label: "VStack")
+    }
+
+    @Composable private func ComposeSpaced(view: View, lastViewWasText: Bool?, context: ComposeContext) -> Bool? {
+        guard !view.isSwiftUIEmptyView else {
+            return lastViewWasText
+        }
+        guard spacing == nil else {
+            view.Compose(context: context)
+            return lastViewWasText
+        }
+
+        let defaultSpacing = 8.0
+        // SwiftUI spaces adaptively based on font, etc, but this is at least closer to SwiftUI than our defaultSpacing
+        let textSpacing = 3.0
+        // If the Text has spacing modifiers, no longer special case its spacing
+        let isText = view.strippingModifiers(until: { $0.role == .spacing }) { $0 is Text }
+        if let lastViewWasText {
+            let spacing = lastViewWasText && isText ? textSpacing : defaultSpacing
+            androidx.compose.foundation.layout.Spacer(modifier: Modifier.height(spacing.dp))
+        }
+        view.Compose(context: context)
+        return isText
     }
     #else
     public var body: some View {
@@ -146,35 +165,6 @@ public struct VStack : View {
     }
     #endif
 }
-
-#if SKIP
-final class VStackComposer: RenderingComposer {
-    private static let defaultSpacing = 8.0
-    // SwiftUI spaces adaptively based on font, etc, but this is at least closer to SwiftUI than our defaultSpacing
-    private static let textSpacing = 3.0
-
-    private var lastViewWasText: Bool? = nil
-
-    override func willCompose() {
-        lastViewWasText = nil
-    }
-
-    @Composable override func Compose(view: View, context: (Bool) -> ComposeContext) {
-        guard !view.isSwiftUIEmptyView else {
-            return
-        }
-        // If the Text has spacing modifiers, no longer special case its spacing
-        let isText = view.strippingModifiers(until: { $0.role == .spacing }) { $0 is Text }
-        var contentContext = context(false)
-        if let lastViewWasText {
-            let spacing = lastViewWasText && isText ? Self.textSpacing : Self.defaultSpacing
-            androidx.compose.foundation.layout.Spacer(modifier: Modifier.height(spacing.dp))
-        }
-        view.ComposeContent(context: contentContext)
-        lastViewWasText = isText
-    }
-}
-#endif
 
 #if false
 /// A vertical container that you can use in conditional layouts.

--- a/Sources/SkipUI/SkipUI/Containers/ZStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/ZStack.swift
@@ -61,7 +61,7 @@ public struct ZStack : View {
             }
         } else {
             ComposeContainer(eraseAxis: true, modifier: context.modifier) { modifier in
-                let arguments = AnimatedContentArguments(views: views, idMap: idMap, ids: ids, rememberedIds: rememberedIds, newIds: newIds, rememberedNewIds: rememberedNewIds, composer: nil, isBridged: isBridged)
+                let arguments = AnimatedContentArguments(views: views, idMap: idMap, ids: ids, rememberedIds: rememberedIds, newIds: newIds, rememberedNewIds: rememberedNewIds, isBridged: isBridged)
                 ComposeAnimatedContent(context: context, modifier: modifier, arguments: arguments)
             }
         }

--- a/Sources/SkipUI/SkipUI/Controls/Button.swift
+++ b/Sources/SkipUI/SkipUI/Controls/Button.swift
@@ -140,6 +140,7 @@ public struct Button : View, ListItemAdapting {
                     } else {
                         $0.set_placement(placement.union(ViewPlacement.systemTextColor))
                     }
+                    return ComposeResult.ok
                 } in: {
                     FilledTonalButton(onClick: options.onClick, modifier: options.modifier, enabled: options.enabled, shape: options.shape, colors: options.colors, elevation: options.elevation, border: options.border, contentPadding: options.contentPadding, interactionSource: options.interactionSource) {
                         label.Compose(context: contentContext)
@@ -162,6 +163,7 @@ public struct Button : View, ListItemAdapting {
                 let contentContext = context.content()
                 EnvironmentValues.shared.setValues {
                     $0.set_placement(placement.union(ViewPlacement.systemTextColor).union(ViewPlacement.onPrimaryColor))
+                    return ComposeResult.ok
                 } in: {
                     androidx.compose.material3.Button(onClick: options.onClick, modifier: options.modifier, enabled: options.enabled, shape: options.shape, colors: options.colors, elevation: options.elevation, border: options.border, contentPadding: options.contentPadding, interactionSource: options.interactionSource) {
                         label.Compose(context: contentContext)
@@ -199,6 +201,7 @@ public struct Button : View, ListItemAdapting {
 
         EnvironmentValues.shared.setValues {
             $0.set_foregroundStyle(foregroundStyle)
+            return ComposeResult.ok
         } in: {
             label.Compose(context: contentContext)
         }

--- a/Sources/SkipUI/SkipUI/Controls/Picker.swift
+++ b/Sources/SkipUI/SkipUI/Controls/Picker.swift
@@ -286,6 +286,7 @@ extension View {
 
     EnvironmentValues.shared.setValues {
         $0.set_placement(ViewPlacement.tagged)
+        return ComposeResult.ok
     } in: {
         content.Compose(viewCollector)
     }

--- a/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
+++ b/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
@@ -69,7 +69,7 @@ public final class EnvironmentValues {
     ///
     /// - Seealso: ``View/environment(_:)``
     /// - Warning: Setting environment values should only be done within the `execute` block of this function.
-    @Composable func setValues(_ execute: @Composable (EnvironmentValues) -> Void, in content: @Composable () -> Void) {
+    @Composable func setValues(_ execute: @Composable (EnvironmentValues) -> ComposeResult, in content: @Composable () -> Unit) {
         // Set the values in EnvironmentValues to keep any user-defined setter logic in place, then retrieve and clear the last set values
         execute(self)
         for action in lastSetActions {
@@ -82,7 +82,7 @@ public final class EnvironmentValues {
         }.toTypedArray()
         lastSetValues.clear()
         CompositionLocalProvider(*provided) {
-            content()
+            let _ = content()
         }
     }
 
@@ -176,6 +176,7 @@ extension View {
         return ComposeModifierView(contentView: self) { view, context in
             EnvironmentValues.shared.setValues {
                 _ in setValue(value)
+                return ComposeResult.ok
             } in: {
                 view.Compose(context: context)
             }
@@ -191,6 +192,7 @@ extension View {
         return ComposeModifierView(contentView: self) { view, context in
             EnvironmentValues.shared.setValues {
                 $0.setBridged(key: bridgedKey, value: value)
+                return ComposeResult.ok
             } in: {
                 view.Compose(context: context)
             }

--- a/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
+++ b/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
@@ -69,7 +69,7 @@ public final class EnvironmentValues {
     ///
     /// - Seealso: ``View/environment(_:)``
     /// - Warning: Setting environment values should only be done within the `execute` block of this function.
-    @Composable func setValues(_ execute: @Composable (EnvironmentValues) -> ComposeResult, in content: @Composable () -> Unit) {
+    @Composable func setValues(_ execute: @Composable (EnvironmentValues) -> ComposeResult, in content: @Composable () -> Void) {
         // Set the values in EnvironmentValues to keep any user-defined setter logic in place, then retrieve and clear the last set values
         execute(self)
         for action in lastSetActions {
@@ -82,7 +82,7 @@ public final class EnvironmentValues {
         }.toTypedArray()
         lastSetValues.clear()
         CompositionLocalProvider(*provided) {
-            let _ = content()
+            content()
         }
     }
 

--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -159,6 +159,7 @@ let overlayPresentationCornerRadius = 16.0
                             $0.set_sheetDepth(sheetDepth + 1)
                         }
                         $0.setdismiss(DismissAction(action: { isPresented.set(false) }))
+                        return ComposeResult.ok
                     } in: {
                         PreferenceValues.shared.collectPreferences([interactiveDismissDisabledCollector, detentPreferencesCollector]) {
                             contentViews.forEach { $0.Compose(context: context) }
@@ -1050,6 +1051,7 @@ final class PresentationModifierView: ComposeModifierView {
             EnvironmentValues.shared.setValues {
                 $0.set_animation(nil)
                 $0.set_searchableState(nil)
+                return ComposeResult.ok
             } in: {
                 presentation(context.content())
             }

--- a/Sources/SkipUI/SkipUI/Text/Font.swift
+++ b/Sources/SkipUI/SkipUI/Text/Font.swift
@@ -94,6 +94,14 @@ public struct Font : Hashable {
         let lineHeight = style.lineHeight == TextUnit.Unspecified ? style.lineHeight : (style.lineHeight.value + amount).sp
         return style.copy(fontSize: fontSize, lineHeight: lineHeight)
     }
+
+    public static func ==(lhs: Font, rhs: Font) -> Bool {
+        return lhs === rhs
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.hashCode())
+    }
     #endif
 
     public enum TextStyle : Int, CaseIterable, Codable, Hashable {

--- a/Sources/SkipUI/SkipUI/Text/Font.swift
+++ b/Sources/SkipUI/SkipUI/Text/Font.swift
@@ -94,14 +94,6 @@ public struct Font : Hashable {
         let lineHeight = style.lineHeight == TextUnit.Unspecified ? style.lineHeight : (style.lineHeight.value + amount).sp
         return style.copy(fontSize: fontSize, lineHeight: lineHeight)
     }
-
-    public static func ==(lhs: Font, rhs: Font) -> Bool {
-        return lhs === rhs
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(self.hashCode())
-    }
     #endif
 
     public enum TextStyle : Int, CaseIterable, Codable, Hashable {

--- a/Sources/SkipUI/SkipUI/Text/Label.swift
+++ b/Sources/SkipUI/SkipUI/Text/Label.swift
@@ -100,6 +100,7 @@ public struct Label : View {
         if let imageColor {
             EnvironmentValues.shared.setValues {
                 $0.set_foregroundStyle(imageColor)
+                return ComposeResult.ok
             } in: {
                 image.Compose(context: context)
             }

--- a/Sources/SkipUI/SkipUI/Text/Text.swift
+++ b/Sources/SkipUI/SkipUI/Text/Text.swift
@@ -552,6 +552,7 @@ func textEnvironment(for view: View, update: (inout TextEnvironment) -> Void) ->
             var textEnvironment = $0._textEnvironment
             update(&textEnvironment)
             $0.set_textEnvironment(textEnvironment)
+            return ComposeResult.ok
         } in: {
             view.Compose(context: context)
         }

--- a/Sources/SkipUI/SkipUI/Text/Text.swift
+++ b/Sources/SkipUI/SkipUI/Text/Text.swift
@@ -173,7 +173,11 @@ public struct Text: View, Equatable {
 
     // SKIP @bridge
     public static func ==(lhs: Text, rhs: Text) -> Bool {
+        #if SKIP
+        return lhs.textView == rhs.textView && lhs.modifiedView == rhs.modifiedView
+        #else
         return lhs.textView == rhs.textView
+        #endif
     }
 
     // Text-specific implementations of View modifiers

--- a/Sources/SkipUI/SkipUI/Text/TextField.swift
+++ b/Sources/SkipUI/SkipUI/Text/TextField.swift
@@ -154,6 +154,7 @@ public struct TextField : View {
         }
         EnvironmentValues.shared.setValues {
             $0.set_foregroundStyle(Color(colorImpl: { Color.primary.colorImpl().copy(alpha: ContentAlpha.disabled) }))
+            return ComposeResult.ok
         } in: {
             prompt.Compose(context: context)
         }
@@ -212,6 +213,7 @@ extension View {
             let updatedState = state == nil ? OnSubmitState(triggers: triggers, action: action) : state!.appending(triggers: triggers, action: action)
             EnvironmentValues.shared.setValues {
                 $0.set_onSubmitState(updatedState)
+                return ComposeResult.ok
             } in: {
                 view.Compose(context: context)
             }
@@ -309,6 +311,7 @@ extension View {
             let updatedOptions = update(options)
             EnvironmentValues.shared.setValues {
                 $0.set_keyboardOptions(updatedOptions)
+                return ComposeResult.ok
             } in: {
                 view.Compose(context: context)
             }


### PR DESCRIPTION
- Fix our Environment implementation to make sure the block that sets the environment values doesn't get skipped.
- Fixed Text.equals implementation to ensure Texts with different modifiers don't compare equal, which can prevent the UI from updating when the Text modifiers are changed.
- Removed use of custom Composers by VStack (where we saw issues with content that used Transitions) and TabView in favor of collectViews() and manual Compose() calls.
- This allowed us to remove the willCompose/didCompose callbacks in RenderingComposers, which will potentially simplify things for future fixes to Group/Section/ForEach/etc modifier support.
