### PR TITLE
Enable toolbarTitleMenu in skip-ui

### DIFF
--- a/Sources/SkipUI/SkipUI/Commands/Toolbar.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Toolbar.swift
@@ -446,10 +446,9 @@ extension View {
         return toolbarTitleDisplayMode(ToolbarTitleDisplayMode(rawValue: bridgedMode) ?? .automatic)
     }
 
-    @available(*, unavailable)
     public func toolbarTitleMenu(@ViewBuilder content: () -> any View) -> some View {
         #if SKIP
-        return preference(key: ToolbarContentPreferenceKey.self, value: ToolbarContentPreferences(titleMenu: content()))
+        return preference(key: ToolbarContentPreferenceKey.self, value: ToolbarContentPreferences(titleMenu: ComposeBuilder.from(content)))
         #else
         return self
         #endif
@@ -556,9 +555,9 @@ struct ToolbarContentPreferenceKey: PreferenceKey {
 
 struct ToolbarContentPreferences: Equatable {
     let content: [View]?
-    let titleMenu: View?
+    let titleMenu: ComposeBuilder?
 
-    init(content: [View]? = nil, titleMenu: View? = nil) {
+    init(content: [View]? = nil, titleMenu: ComposeBuilder? = nil) {
         self.content = content
         self.titleMenu = titleMenu
     }

--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -33,8 +33,11 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.outlined.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.KeyboardArrowLeft
+import androidx.compose.material.icons.outlined.ArrowDropDown
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.BottomAppBarDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -345,7 +348,42 @@ public struct NavigationStack : View {
                         titleContentColor: MaterialTheme.colorScheme.onSurface
                     )
                     let topBarTitle: @Composable () -> Void = {
-                        androidx.compose.material3.Text(arguments.title.localizedTextString(), maxLines: 1, overflow: TextOverflow.Ellipsis)
+                        let titleMenu = toolbarContent.value.reduced.titleMenu
+                        if let titleMenu = titleMenu {
+                            let isMenuExpanded = remember { mutableStateOf(false) }
+                            
+                            Box {
+                                Row(verticalAlignment: androidx.compose.ui.Alignment.CenterVertically,
+                                    modifier = Modifier.clickable {
+                                        isMenuExpanded.value = !isMenuExpanded.value 
+                                    }
+                                ) {
+                                    androidx.compose.material3.Text(
+                                        text = arguments.title.localizedTextString(),
+                                        maxLines = 1, 
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                    Icon(
+                                        imageVector = Icons.Outlined.ArrowDropDown,
+                                        contentDescription = "Menu"
+                                    )
+                                }
+                                
+                                DropdownMenu(
+                                    expanded = isMenuExpanded.value,
+                                    onDismissRequest = { isMenuExpanded.value = false }
+                                ) {
+                                    let menuContext = context.content()
+                                    let itemViews = titleMenu.collectViews(context: menuContext)
+                                    let replaceMenu: (Menu?) -> Void = { menu in
+                                        isMenuExpanded.value = false
+                                    }
+                                    Menu.ComposeDropdownMenuItems(for: itemViews, context: menuContext, replaceMenu: replaceMenu)
+                                }
+                            }
+                        } else {
+                            androidx.compose.material3.Text(arguments.title.localizedTextString(), maxLines: 1, overflow: TextOverflow.Ellipsis)
+                        }
                     }
                     let topBarNavigationIcon: @Composable () -> Void = {
                         let hasBackButton = !arguments.isRoot && arguments.toolbarPreferences.backButtonHidden != true


### PR DESCRIPTION
Enable the .toolbarTileMenu in SkipUI. This is the minimum to get something functional for my project, I'm not sure what else would be required to get it over the line. I tried using the already exist `class Menu: View` but I couldn't get it working. Instead we'll just grab the tooling that makes the menuItems. This required the ToolbarContent to change to use a ComposeBuilder. There might be a better way to approach this so the ToolbarContent doesn't change.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

