### PR TITLE
Remove use of default value in overridable Compose function

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/LazyHGrid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyHGrid.swift
@@ -61,7 +61,7 @@ public struct LazyHGrid: View, Renderable {
         let scrollAxes: Axis.Set = isScrollEnabled ? Axis.Set.horizontal : []
         let scrollTargetBehavior = EnvironmentValues.shared._scrollTargetBehavior
 
-        let renderables = content.EvaluateLazyItems(context: context)
+        let renderables = content.EvaluateLazyItems(level: 0, context: context)
         let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
         ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true, fillHeight: false) { modifier in

--- a/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
@@ -53,7 +53,7 @@ public struct LazyHStack : View, Renderable {
         let scrollAxes: Axis.Set = isScrollEnabled ? Axis.Set.horizontal : []
         let scrollTargetBehavior = EnvironmentValues.shared._scrollTargetBehavior
 
-        let renderables = content.EvaluateLazyItems(context: context)
+        let renderables = content.EvaluateLazyItems(level: 0, context: context)
         let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
         ComposeContainer(axis: .horizontal, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true, fillHeight: false) { modifier in

--- a/Sources/SkipUI/SkipUI/Containers/LazySupport.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazySupport.swift
@@ -26,7 +26,7 @@ extension LazyItemFactory {
 
 extension View {
     /// Expands views with the given lazy item level set in the environment.
-    @Composable public func EvaluateLazyItems(level: Int = 0, context: ComposeContext) -> kotlin.collections.List<Renderable> {
+    @Composable public final func EvaluateLazyItems(level: Int, context: ComposeContext) -> kotlin.collections.List<Renderable> {
         let renderables = Evaluate(context: context, options: EvaluateOptions(lazyItemLevel: level).value)
         guard level > 0 else {
             return renderables

--- a/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
@@ -68,7 +68,7 @@ public struct LazyVGrid: View, Renderable {
         let searchableState = EnvironmentValues.shared._searchableState
         let isSearchable = searchableState?.isOnNavigationStack == false
 
-        let renderables = content.EvaluateLazyItems(context: context)
+        let renderables = content.EvaluateLazyItems(level: 0, context: context)
         let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
         ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true, fillHeight: false) { modifier in

--- a/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
@@ -61,7 +61,7 @@ public struct LazyVStack : View, Renderable {
         let searchableState = EnvironmentValues.shared._searchableState
         let isSearchable = searchableState?.isOnNavigationStack == false
 
-        let renderables = content.EvaluateLazyItems(context: context)
+        let renderables = content.EvaluateLazyItems(level: 0, context: context)
         let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
         ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true, fillHeight: false) { modifier in

--- a/Sources/SkipUI/SkipUI/Containers/List.swift
+++ b/Sources/SkipUI/SkipUI/Containers/List.swift
@@ -160,9 +160,9 @@ public final class List : View, Renderable {
     @Composable private func RenderList(context: ComposeContext, styling: ListStyling, arguments: ListArguments) {
         let renderables: kotlin.collections.List<Renderable>
         if let forEach {
-            renderables = forEach.EvaluateLazyItems(context: context)
+            renderables = forEach.EvaluateLazyItems(level: 0, context: context)
         } else if let fixedContent {
-            renderables = fixedContent.EvaluateLazyItems(context: context)
+            renderables = fixedContent.EvaluateLazyItems(level: 0, context: context)
         } else {
             renderables = listOf()
         }


### PR DESCRIPTION
This is only supported in recent Kotlin versions and does not compile for users who have pinned skip-unit to a previous version
