### PR TITLE
More SwiftUI-like layout

### DIFF
--- a/Sources/SkipUI/Skip/StackLayouts.kt
+++ b/Sources/SkipUI/Skip/StackLayouts.kt
@@ -1,0 +1,1532 @@
+// Copyright 2024–2025 Skip
+// SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
+package skip.ui
+
+import androidx.annotation.FloatRange
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.LayoutScopeMarker
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.AlignmentLine
+import androidx.compose.ui.layout.FirstBaseline
+import androidx.compose.ui.layout.HorizontalAlignmentLine
+import androidx.compose.ui.layout.IntrinsicMeasurable
+import androidx.compose.ui.layout.IntrinsicMeasureScope
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.layout.Measured
+import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.layout.VerticalAlignmentLine
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.ParentDataModifierNode
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.util.fastCoerceAtLeast
+import androidx.compose.ui.util.fastRoundToInt
+import kotlin.collections.List
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * This file contains heavily modified versions of Compose's `Row` and `Column` layouts to provide
+ * more SwiftUI-like layout behavior.
+ *
+ * The general structure and supporting code has been intentionally left as close to the original
+ * `Row` and `Column` as possible for multiple reasons:
+ *
+ * - So that we can also maintain our previous `Row` and `Column` implementations for users who
+ *   rely on their behavior, and in case we need to revert after finding problems.
+ * - To take advantage of `Row` and `Column`'s well-tested implementations.
+ * - In case we need to assimilate functionality that gets added to `Row` and `Column` in future
+ *   Compose releases.
+ *
+ * But that means that this code also retains many `Row` and `Column` limitations. It must be combined
+ * with additional workarounds in `ComposeContainer`, `HStack` and `VStack` to approximate SwiftUI layout.
+ */
+
+/**
+ * Expand to fill.
+ */
+val Float.Companion.flexibleFill: Float
+    get() = -1f
+
+/**
+ * Expand to fill with space - lower priority than `flexibleFill`.
+ */
+val Float.Companion.flexibleSpace: Float
+    get() = -2f
+
+/**
+ * Unknown non-expanding flexible size.
+ */
+val Float.Companion.flexibleUnknownNonExpanding: Float
+    get() = -3f
+
+/**
+ * Unknown flexible size that expands due to a `flexibleSpace`.
+ */
+val Float.Companion.flexibleUnknownWithSpace: Float
+    get() = -4f
+
+/**
+ * Whether this is some expanding flexible value.
+ */
+val Float.isFlexibleExpanding: Boolean
+    get() = this == Float.flexibleFill || this == Float.flexibleSpace || this == Float.flexibleUnknownWithSpace
+
+/**
+ * Whether this is some non-expanding minimum flexible value.
+ */
+val Float.isFlexibleNonExpandingMin: Boolean
+    get() = this > 0f || this == Float.flexibleUnknownNonExpanding
+
+/**
+ * Whether this is some non-expanding maximum flexible value.
+ */
+val Float.isFlexibleNonExpandingMax: Boolean
+    get() = this >= 0f || this == Float.flexibleUnknownNonExpanding
+
+/*
+ * Modified version of Row.kt
+ */
+
+@Composable
+internal inline fun HStackRow(
+    modifier: Modifier = Modifier,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
+    verticalAlignment: Alignment.Vertical = Alignment.Top,
+    content: @Composable HStackRowScope.() -> Unit,
+) {
+    val measurePolicy = rowMeasurePolicy(horizontalArrangement, verticalAlignment)
+    Layout(
+        content = { HStackRowScopeInstance.content() },
+        measurePolicy = measurePolicy,
+        modifier = modifier,
+    )
+}
+
+@PublishedApi
+internal val DefaultRowMeasurePolicy: MeasurePolicy =
+    RowMeasurePolicy(horizontalArrangement = Arrangement.Start, verticalAlignment = Alignment.Top)
+
+@PublishedApi
+@Composable
+internal fun rowMeasurePolicy(
+    horizontalArrangement: Arrangement.Horizontal,
+    verticalAlignment: Alignment.Vertical,
+): MeasurePolicy =
+    if (horizontalArrangement == Arrangement.Start && verticalAlignment == Alignment.Top) {
+        DefaultRowMeasurePolicy
+    } else {
+        remember(horizontalArrangement, verticalAlignment) {
+            RowMeasurePolicy(
+                horizontalArrangement = horizontalArrangement,
+                verticalAlignment = verticalAlignment,
+            )
+        }
+    }
+
+internal data class RowMeasurePolicy(
+    private val horizontalArrangement: Arrangement.Horizontal,
+    private val verticalAlignment: Alignment.Vertical,
+) : MeasurePolicy, RowColumnMeasurePolicy {
+    override fun Placeable.mainAxisConstrainedSize() = width
+    override fun Placeable.mainAxisMeasuredSize() = measuredWidth
+
+    override fun Placeable.crossAxisConstrainedSize() = height
+    override fun Placeable.crossAxisMeasuredSize() = measuredHeight
+
+    override fun Measurable.intrinsicMainAxisSize(crossAxisSize: Int) = maxIntrinsicWidth(crossAxisSize)
+
+    override fun MeasureScope.measure(
+        measurables: List<Measurable>,
+        constraints: Constraints,
+    ): MeasureResult {
+        return measure(
+            constraints.minWidth,
+            constraints.minHeight,
+            constraints.maxWidth,
+            constraints.maxHeight,
+            horizontalArrangement.spacing.roundToPx(),
+            this,
+            measurables,
+            arrayOfNulls(measurables.size),
+            0,
+            measurables.size
+        )
+    }
+
+    override fun populateMainAxisPositions(
+        mainAxisLayoutSize: Int,
+        children: List<RowColumnChildInfo>,
+        mainAxisPositions: IntArray,
+        measureScope: MeasureScope,
+    ) {
+        with(horizontalArrangement) {
+            measureScope.arrange(
+                mainAxisLayoutSize,
+                children.map { it.mainAxisMeasuredSize }.toIntArray(),
+                measureScope.layoutDirection,
+                mainAxisPositions,
+            )
+        }
+        // The arrange function will center the difference when any child's measured size is not the
+        // same as its constrained size. We want each child to actually align to its assigned position
+        for (i in 0..<children.size) {
+            val diff = children[i].mainAxisMeasuredSize - children[i].mainAxisConstrainedSize
+            mainAxisPositions[i] += diff / 2
+        }
+    }
+
+    override fun placeHelper(
+        placeables: Array<Placeable?>,
+        measureScope: MeasureScope,
+        beforeCrossAxisAlignmentLine: Int,
+        mainAxisPositions: IntArray,
+        mainAxisLayoutSize: Int,
+        crossAxisLayoutSize: Int,
+        crossAxisOffset: IntArray?,
+        currentLineIndex: Int,
+        startIndex: Int,
+        endIndex: Int,
+    ): MeasureResult {
+        return with(measureScope) {
+            layout(mainAxisLayoutSize, crossAxisLayoutSize) {
+                placeables.forEachIndexed { i, placeable ->
+                    val crossAxisPosition =
+                        getCrossAxisPosition(
+                            placeable!!,
+                            placeable.rowColumnParentData,
+                            crossAxisLayoutSize,
+                            beforeCrossAxisAlignmentLine,
+                        )
+                    placeable.place(mainAxisPositions[i], crossAxisPosition)
+                }
+            }
+        }
+    }
+
+    override fun createConstraints(
+        mainAxisMin: Int,
+        crossAxisMin: Int,
+        mainAxisMax: Int,
+        crossAxisMax: Int,
+        isPrioritizing: Boolean,
+    ): Constraints {
+        return createRowConstraints(
+            isPrioritizing,
+            mainAxisMin,
+            crossAxisMin,
+            mainAxisMax,
+            crossAxisMax,
+        )
+    }
+
+    private fun getCrossAxisPosition(
+        placeable: Placeable,
+        parentData: RowColumnParentData?,
+        crossAxisLayoutSize: Int,
+        beforeCrossAxisAlignmentLine: Int,
+    ): Int {
+        val childCrossAlignment = parentData?.crossAxisAlignment
+        return childCrossAlignment?.align(
+            size = crossAxisLayoutSize - placeable.measuredHeight,
+            layoutDirection = LayoutDirection.Ltr,
+            placeable = placeable,
+            beforeCrossAxisAlignmentLine = beforeCrossAxisAlignmentLine,
+        ) ?: verticalAlignment.align(placeable.measuredHeight, crossAxisLayoutSize)
+    }
+
+    override fun IntrinsicMeasureScope.minIntrinsicWidth(
+        measurables: List<IntrinsicMeasurable>,
+        height: Int,
+    ) =
+        IntrinsicMeasureBlocks.HorizontalMinWidth(
+            measurables,
+            height,
+            horizontalArrangement.spacing.roundToPx(),
+        )
+
+    override fun IntrinsicMeasureScope.minIntrinsicHeight(
+        measurables: List<IntrinsicMeasurable>,
+        width: Int,
+    ) =
+        IntrinsicMeasureBlocks.HorizontalMinHeight(
+            measurables,
+            width,
+            horizontalArrangement.spacing.roundToPx(),
+        )
+
+    override fun IntrinsicMeasureScope.maxIntrinsicWidth(
+        measurables: List<IntrinsicMeasurable>,
+        height: Int,
+    ) =
+        IntrinsicMeasureBlocks.HorizontalMaxWidth(
+            measurables,
+            height,
+            horizontalArrangement.spacing.roundToPx(),
+        )
+
+    override fun IntrinsicMeasureScope.maxIntrinsicHeight(
+        measurables: List<IntrinsicMeasurable>,
+        width: Int,
+    ) =
+        IntrinsicMeasureBlocks.HorizontalMaxHeight(
+            measurables,
+            width,
+            horizontalArrangement.spacing.roundToPx(),
+        )
+}
+
+internal fun createRowConstraints(
+    isPrioritizing: Boolean,
+    mainAxisMin: Int,
+    crossAxisMin: Int,
+    mainAxisMax: Int,
+    crossAxisMax: Int,
+): Constraints {
+    return if (!isPrioritizing) {
+        Constraints(
+            maxWidth = mainAxisMax,
+            maxHeight = crossAxisMax,
+            minWidth = mainAxisMin,
+            minHeight = crossAxisMin,
+        )
+    } else {
+        Constraints.fitPrioritizingWidth(
+            maxWidth = mainAxisMax,
+            maxHeight = crossAxisMax,
+            minWidth = mainAxisMin,
+            minHeight = crossAxisMin,
+        )
+    }
+}
+
+@LayoutScopeMarker
+@Immutable
+interface HStackRowScope {
+    /**
+     * SwiftUI-like flexible sizing.
+     */
+    @Stable
+    fun Modifier.flexible(ideal: Float? = null, min: Float? = null, max: Float? = null): Modifier
+
+    @Stable fun Modifier.align(alignment: Alignment.Vertical): Modifier
+
+    @Stable fun Modifier.alignBy(alignmentLine: HorizontalAlignmentLine): Modifier
+
+    @Stable fun Modifier.alignByBaseline(): Modifier
+
+    @Stable fun Modifier.alignBy(alignmentLineBlock: (Measured) -> Int): Modifier
+}
+
+internal object HStackRowScopeInstance : HStackRowScope {
+    @Stable
+    override fun Modifier.flexible(ideal: Float?, min: Float?, max: Float?): Modifier {
+        return this.then(
+            LayoutFlexibleElement(
+                ideal = ideal,
+                min = min,
+                max = max
+            )
+        ).applyNonExpandingFlexibleWidth(ideal = ideal, min = min, max = max)
+    }
+
+    @Stable
+    override fun Modifier.align(alignment: Alignment.Vertical) =
+        this.then(VerticalAlignElement(alignment))
+
+    @Stable
+    override fun Modifier.alignBy(alignmentLine: HorizontalAlignmentLine) =
+        this.then(WithAlignmentLineElement(alignmentLine = alignmentLine))
+
+    @Stable override fun Modifier.alignByBaseline() = alignBy(FirstBaseline)
+
+    override fun Modifier.alignBy(alignmentLineBlock: (Measured) -> Int) =
+        this.then(WithAlignmentLineBlockElement(block = alignmentLineBlock))
+}
+
+/*
+ * Modified version of Column.kt
+ */
+
+@Composable
+inline fun VStackColumn(
+    modifier: Modifier = Modifier,
+    verticalArrangement: Arrangement.Vertical = Arrangement.Top,
+    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
+    content: @Composable VStackColumnScope.() -> Unit,
+) {
+    val measurePolicy = columnMeasurePolicy(verticalArrangement, horizontalAlignment)
+    Layout(
+        content = { VStackColumnScopeInstance.content() },
+        measurePolicy = measurePolicy,
+        modifier = modifier,
+    )
+}
+
+@PublishedApi
+internal val DefaultColumnMeasurePolicy: MeasurePolicy =
+    ColumnMeasurePolicy(
+        verticalArrangement = Arrangement.Top,
+        horizontalAlignment = Alignment.Start,
+    )
+
+@PublishedApi
+@Composable
+internal fun columnMeasurePolicy(
+    verticalArrangement: Arrangement.Vertical,
+    horizontalAlignment: Alignment.Horizontal,
+): MeasurePolicy =
+    if (verticalArrangement == Arrangement.Top && horizontalAlignment == Alignment.Start) {
+        DefaultColumnMeasurePolicy
+    } else {
+        remember(verticalArrangement, horizontalAlignment) {
+            ColumnMeasurePolicy(
+                verticalArrangement = verticalArrangement,
+                horizontalAlignment = horizontalAlignment,
+            )
+        }
+    }
+
+internal data class ColumnMeasurePolicy(
+    private val verticalArrangement: Arrangement.Vertical,
+    private val horizontalAlignment: Alignment.Horizontal,
+) : MeasurePolicy, RowColumnMeasurePolicy {
+
+    override fun Measurable.intrinsicMainAxisSize(crossAxisSize: Int) = maxIntrinsicHeight(crossAxisSize)
+
+    override fun Placeable.mainAxisConstrainedSize(): Int = height
+    override fun Placeable.mainAxisMeasuredSize(): Int = measuredHeight
+
+    override fun Placeable.crossAxisConstrainedSize(): Int = width
+    override fun Placeable.crossAxisMeasuredSize(): Int = measuredWidth
+
+    override fun populateMainAxisPositions(
+        mainAxisLayoutSize: Int,
+        children: List<RowColumnChildInfo>,
+        mainAxisPositions: IntArray,
+        measureScope: MeasureScope,
+    ) {
+        with(verticalArrangement) {
+            measureScope.arrange(
+                mainAxisLayoutSize,
+                children.map { it.mainAxisMeasuredSize }.toIntArray(),
+                mainAxisPositions
+            )
+        }
+        // The arrange function will center the difference when any child's measured size is not the
+        // same as its constrained size. We want each child to actually align to its assigned position
+        for (i in 0..<children.size) {
+            val diff = children[i].mainAxisMeasuredSize - children[i].mainAxisConstrainedSize
+            mainAxisPositions[i] += diff / 2
+        }
+    }
+
+    override fun placeHelper(
+        placeables: Array<Placeable?>,
+        measureScope: MeasureScope,
+        beforeCrossAxisAlignmentLine: Int,
+        mainAxisPositions: IntArray,
+        mainAxisLayoutSize: Int,
+        crossAxisLayoutSize: Int,
+        crossAxisOffset: IntArray?,
+        currentLineIndex: Int,
+        startIndex: Int,
+        endIndex: Int,
+    ): MeasureResult {
+        return with(measureScope) {
+            layout(crossAxisLayoutSize, mainAxisLayoutSize) {
+                placeables.forEachIndexed { i, placeable ->
+                    val crossAxisPosition =
+                        getCrossAxisPosition(
+                            placeable!!,
+                            placeable.rowColumnParentData,
+                            crossAxisLayoutSize,
+                            beforeCrossAxisAlignmentLine,
+                            measureScope.layoutDirection,
+                        )
+                    placeable.place(crossAxisPosition, mainAxisPositions[i])
+                }
+            }
+        }
+    }
+
+    private fun getCrossAxisPosition(
+        placeable: Placeable,
+        parentData: RowColumnParentData?,
+        crossAxisLayoutSize: Int,
+        beforeCrossAxisAlignmentLine: Int,
+        layoutDirection: LayoutDirection,
+    ): Int {
+        val childCrossAlignment = parentData?.crossAxisAlignment
+        return childCrossAlignment?.align(
+            size = crossAxisLayoutSize - placeable.measuredWidth,
+            layoutDirection = layoutDirection,
+            placeable = placeable,
+            beforeCrossAxisAlignmentLine = beforeCrossAxisAlignmentLine,
+        ) ?: horizontalAlignment.align(placeable.measuredWidth, crossAxisLayoutSize, layoutDirection)
+    }
+
+    override fun createConstraints(
+        mainAxisMin: Int,
+        crossAxisMin: Int,
+        mainAxisMax: Int,
+        crossAxisMax: Int,
+        isPrioritizing: Boolean,
+    ): Constraints {
+        return createColumnConstraints(
+            isPrioritizing,
+            mainAxisMin,
+            crossAxisMin,
+            mainAxisMax,
+            crossAxisMax,
+        )
+    }
+
+    override fun MeasureScope.measure(
+        measurables: List<Measurable>,
+        constraints: Constraints,
+    ): MeasureResult {
+        return measure(
+            constraints.minHeight,
+            constraints.minWidth,
+            constraints.maxHeight,
+            constraints.maxWidth,
+            verticalArrangement.spacing.roundToPx(),
+            this,
+            measurables,
+            arrayOfNulls(measurables.size),
+            0,
+            measurables.size
+        )
+    }
+
+    override fun IntrinsicMeasureScope.minIntrinsicWidth(
+        measurables: List<IntrinsicMeasurable>,
+        height: Int,
+    ) =
+        IntrinsicMeasureBlocks.VerticalMinWidth(
+            measurables,
+            height,
+            verticalArrangement.spacing.roundToPx(),
+        )
+
+    override fun IntrinsicMeasureScope.minIntrinsicHeight(
+        measurables: List<IntrinsicMeasurable>,
+        width: Int,
+    ) =
+        IntrinsicMeasureBlocks.VerticalMinHeight(
+            measurables,
+            width,
+            verticalArrangement.spacing.roundToPx(),
+        )
+
+    override fun IntrinsicMeasureScope.maxIntrinsicWidth(
+        measurables: List<IntrinsicMeasurable>,
+        height: Int,
+    ) =
+        IntrinsicMeasureBlocks.VerticalMaxWidth(
+            measurables,
+            height,
+            verticalArrangement.spacing.roundToPx(),
+        )
+
+    override fun IntrinsicMeasureScope.maxIntrinsicHeight(
+        measurables: List<IntrinsicMeasurable>,
+        width: Int,
+    ) =
+        IntrinsicMeasureBlocks.VerticalMaxHeight(
+            measurables,
+            width,
+            verticalArrangement.spacing.roundToPx(),
+        )
+}
+
+internal fun createColumnConstraints(
+    isPrioritizing: Boolean,
+    mainAxisMin: Int,
+    crossAxisMin: Int,
+    mainAxisMax: Int,
+    crossAxisMax: Int,
+): Constraints {
+    return if (!isPrioritizing) {
+        Constraints(
+            minHeight = mainAxisMin,
+            minWidth = crossAxisMin,
+            maxHeight = mainAxisMax,
+            maxWidth = crossAxisMax,
+        )
+    } else {
+        Constraints.fitPrioritizingHeight(
+            minHeight = mainAxisMin,
+            minWidth = crossAxisMin,
+            maxHeight = mainAxisMax,
+            maxWidth = crossAxisMax,
+        )
+    }
+}
+
+@LayoutScopeMarker
+@Immutable
+interface VStackColumnScope {
+    /**
+     * SwiftUI-like flexible sizing.
+     */
+    @Stable
+    fun Modifier.flexible(ideal: Float? = null, min: Float? = null, max: Float? = null): Modifier
+
+    @Stable fun Modifier.align(alignment: Alignment.Horizontal): Modifier
+
+    @Stable fun Modifier.alignBy(alignmentLine: VerticalAlignmentLine): Modifier
+
+    @Stable fun Modifier.alignBy(alignmentLineBlock: (Measured) -> Int): Modifier
+}
+
+internal object VStackColumnScopeInstance : VStackColumnScope {
+    @Stable
+    override fun Modifier.flexible(ideal: Float?, min: Float?, max: Float?): Modifier {
+        return this.then(
+            LayoutFlexibleElement(
+                ideal = ideal,
+                min = min,
+                max = max
+            )
+        ).applyNonExpandingFlexibleHeight(ideal = ideal, min = min, max = max)
+    }
+
+    @Stable
+    override fun Modifier.align(alignment: Alignment.Horizontal) =
+        this.then(HorizontalAlignElement(horizontal = alignment))
+
+    @Stable
+    override fun Modifier.alignBy(alignmentLine: VerticalAlignmentLine) =
+        this.then(WithAlignmentLineElement(alignmentLine = alignmentLine))
+
+    @Stable
+    override fun Modifier.alignBy(alignmentLineBlock: (Measured) -> Int) =
+        this.then(WithAlignmentLineBlockElement(block = alignmentLineBlock))
+}
+
+/*
+ * Modified version of RowColumnMeasurePolicy.kt
+ */
+
+internal interface RowColumnMeasurePolicy {
+    fun Measurable.intrinsicMainAxisSize(crossAxisSize: Int): Int
+
+    fun Placeable.mainAxisConstrainedSize(): Int
+    fun Placeable.mainAxisMeasuredSize(): Int
+
+    fun Placeable.crossAxisConstrainedSize(): Int
+    fun Placeable.crossAxisMeasuredSize(): Int
+
+    fun populateMainAxisPositions(
+        mainAxisLayoutSize: Int,
+        children: List<RowColumnChildInfo>,
+        mainAxisPositions: IntArray,
+        measureScope: MeasureScope,
+    )
+
+    fun placeHelper(
+        placeables: Array<Placeable?>,
+        measureScope: MeasureScope,
+        beforeCrossAxisAlignmentLine: Int,
+        mainAxisPositions: IntArray,
+        mainAxisLayoutSize: Int,
+        crossAxisLayoutSize: Int,
+        crossAxisOffset: IntArray?,
+        currentLineIndex: Int,
+        startIndex: Int,
+        endIndex: Int,
+    ): MeasureResult
+
+    fun createConstraints(
+        mainAxisMin: Int,
+        crossAxisMin: Int,
+        mainAxisMax: Int,
+        crossAxisMax: Int,
+        isPrioritizing: Boolean = false,
+    ): Constraints
+}
+
+internal data class RowColumnChildInfo(val index: Int, var mainAxisConstrainedSize: Int = 0, var mainAxisMeasuredSize: Int = 0, var intrinsic: Int? = null, var measured: Boolean = false)
+
+internal data class RowColumnMeasureInfo(var anyAlignBy: Boolean = false, var crossAxisMeasuredSize: Int = 0, var remainingFlexibleChildrenCount: Int = 0, var flexibleSize: Int = 0)
+
+internal fun RowColumnMeasurePolicy.measure(
+    mainAxisMin: Int,
+    crossAxisMin: Int,
+    mainAxisMax: Int,
+    crossAxisMax: Int,
+    arrangementSpacing: Int,
+    measureScope: MeasureScope,
+    measurables: List<Measurable>,
+    placeables: Array<Placeable?>,
+    startIndex: Int,
+    endIndex: Int,
+    crossAxisOffset: IntArray? = null,
+    currentLineIndex: Int = 0
+): MeasureResult {
+    val children = (startIndex until endIndex).map { RowColumnChildInfo(it) }
+    val measureInfo = RowColumnMeasureInfo()
+    val totalSpacing = arrangementSpacing * (children.size - 1)
+
+    // First measure children whose width is fixed
+    var fixedSize = 0
+    var spaceChildrenMinSize = 0
+    var spaceChildrenCount = 0
+    for (child in children) {
+        val measurable = measurables[child.index]
+        val parentData = measurable.rowColumnParentData
+        if (parentData?.flexibleMax != null) {
+            measureInfo.remainingFlexibleChildrenCount++
+            if (parentData.flexibleMax == Float.flexibleSpace) {
+                spaceChildrenCount++
+                if (parentData.flexibleMin != null && parentData.flexibleMin!! > 0f) {
+                    spaceChildrenMinSize += (parentData.flexibleMin!! * measureScope.density).roundToInt()
+                }
+            }
+            continue
+        }
+
+        measureInfo.anyAlignBy = measureInfo.anyAlignBy || parentData.isRelative
+        val crossAxisDesiredSize = if (crossAxisMax == Constraints.Infinity) null else {
+            parentData?.flowLayoutData?.let {
+                (it.fillCrossAxisFraction * crossAxisMax).fastRoundToInt()
+            }
+        }
+        val remainingSize = mainAxisMax - totalSpacing - fixedSize
+        val placeable = placeables[child.index] ?: measurable.measure(
+            createConstraints(
+                mainAxisMin = 0,
+                crossAxisMin = crossAxisDesiredSize ?: 0,
+                mainAxisMax = if (mainAxisMax == Constraints.Infinity) {
+                    Constraints.Infinity
+                } else {
+                    remainingSize.fastCoerceAtLeast(0)
+                },
+                crossAxisMax = crossAxisDesiredSize ?: crossAxisMax,
+            )
+        )
+        placeables[child.index] = placeable
+        child.measured = true
+        child.mainAxisConstrainedSize = placeable.mainAxisConstrainedSize()
+        child.mainAxisMeasuredSize = placeable.mainAxisMeasuredSize()
+        fixedSize += child.mainAxisMeasuredSize
+        measureInfo.crossAxisMeasuredSize = max(measureInfo.crossAxisMeasuredSize, placeable.crossAxisMeasuredSize())
+    }
+
+    // Measure children with a max that may be under the unit size so that we can allocate the
+    // unused space to other children
+    while (true) {
+        val measuredChildrenCount = measureFlexible(
+            children = children,
+            measurables = measurables,
+            placeables = placeables,
+            measureInfo = measureInfo,
+            mainAxisMin = mainAxisMin,
+            mainAxisMax = mainAxisMax,
+            crossAxisMax = crossAxisMax,
+            fixedSize = fixedSize,
+            includeSpacers = false,
+            totalSpacing = totalSpacing,
+            spaceChildrenCount = spaceChildrenCount,
+            spaceChildrenMinSize = spaceChildrenMinSize
+        ) l@{ child, measurable, parentData, flexibleUnitSize ->
+            if (flexibleUnitSize <= 0 || parentData?.flexibleMax?.isFlexibleNonExpandingMax != true) {
+                return@l false
+            }
+            var flexibleMaxPx: Int? = null
+            if (parentData.flexibleMax!! >= 0f) {
+                flexibleMaxPx = (parentData.flexibleMax!! * measureScope.density).roundToInt()
+            } else if (parentData.flexibleMax == Float.flexibleUnknownNonExpanding) {
+                if (child.intrinsic == null) {
+                    val crossAxisDesiredSize = if (crossAxisMax == Constraints.Infinity) null else {
+                        parentData.flowLayoutData?.let {
+                            (it.fillCrossAxisFraction * crossAxisMax).fastRoundToInt()
+                        }
+                    }
+                    child.intrinsic = measurable.intrinsicMainAxisSize(crossAxisDesiredSize ?: crossAxisMax)
+                }
+                flexibleMaxPx = child.intrinsic
+            }
+            return@l flexibleMaxPx != null && flexibleMaxPx <= flexibleUnitSize
+        }
+        if (measuredChildrenCount == 0) {
+            break
+        }
+    }
+
+    // Measure remaining non-expanding children
+    measureFlexible(
+        children = children,
+        measurables = measurables,
+        placeables = placeables,
+        measureInfo = measureInfo,
+        mainAxisMin = mainAxisMin,
+        mainAxisMax = mainAxisMax,
+        crossAxisMax = crossAxisMax,
+        fixedSize = fixedSize,
+        includeSpacers = false,
+        totalSpacing = totalSpacing,
+        spaceChildrenCount = spaceChildrenCount,
+        spaceChildrenMinSize = spaceChildrenMinSize
+    ) { _, _, parentData, _ ->
+        parentData?.flexibleMax?.isFlexibleExpanding != true
+    }
+
+    // Measure non-space children
+    measureFlexible(
+        children = children,
+        measurables = measurables,
+        placeables = placeables,
+        measureInfo = measureInfo,
+        mainAxisMin = mainAxisMin,
+        mainAxisMax = mainAxisMax,
+        crossAxisMax = crossAxisMax,
+        fixedSize = fixedSize,
+        includeSpacers = false,
+        totalSpacing = totalSpacing,
+        spaceChildrenCount = spaceChildrenCount,
+        spaceChildrenMinSize = spaceChildrenMinSize
+    ) { _, _, parentData, _ ->
+        parentData?.flexibleMax != Float.flexibleSpace
+    }
+
+    // Measure remaining (space) children
+    measureFlexible(
+        children = children,
+        measurables = measurables,
+        placeables = placeables,
+        measureInfo = measureInfo,
+        mainAxisMin = mainAxisMin,
+        mainAxisMax = mainAxisMax,
+        crossAxisMax = crossAxisMax,
+        fixedSize = fixedSize,
+        includeSpacers = true,
+        totalSpacing = totalSpacing,
+        spaceChildrenCount = spaceChildrenCount,
+        spaceChildrenMinSize = spaceChildrenMinSize
+    ) { _, _, _, _ ->
+        true
+    }
+
+    var beforeCrossAxisAlignmentLine = 0
+    var afterCrossAxisAlignmentLine = 0
+    if (measureInfo.anyAlignBy) {
+        for (i in startIndex until endIndex) {
+            val placeable = placeables[i]
+            val parentData = placeable!!.rowColumnParentData
+            val alignmentLinePosition = parentData.crossAxisAlignment?.calculateAlignmentLinePosition(placeable)
+            alignmentLinePosition?.let {
+                val placeableCrossAxisMeasuredSize = placeable.crossAxisMeasuredSize()
+                beforeCrossAxisAlignmentLine = max(
+                    beforeCrossAxisAlignmentLine,
+                    if (it != AlignmentLine.Unspecified) alignmentLinePosition else 0
+                )
+                afterCrossAxisAlignmentLine = max(
+                    afterCrossAxisAlignmentLine,
+                    placeableCrossAxisMeasuredSize - if (it != AlignmentLine.Unspecified) it else placeableCrossAxisMeasuredSize
+                )
+            }
+        }
+    }
+
+    // Compute the Row or Column size and position the children.
+    val mainAxisLayoutSize = max((fixedSize + measureInfo.flexibleSize + totalSpacing).fastCoerceAtLeast(0), mainAxisMin)
+    val crossAxisLayoutSize = maxOf(
+        measureInfo.crossAxisMeasuredSize,
+        crossAxisMin,
+        beforeCrossAxisAlignmentLine + afterCrossAxisAlignmentLine
+    )
+    val mainAxisPositions = IntArray(endIndex - startIndex)
+    populateMainAxisPositions(
+        mainAxisLayoutSize,
+        children,
+        mainAxisPositions,
+        measureScope,
+    )
+
+    return placeHelper(
+        placeables,
+        measureScope,
+        beforeCrossAxisAlignmentLine,
+        mainAxisPositions,
+        mainAxisLayoutSize,
+        crossAxisLayoutSize,
+        crossAxisOffset,
+        currentLineIndex,
+        startIndex,
+        endIndex,
+    )
+}
+
+private fun RowColumnMeasurePolicy.measureFlexible(
+    children: List<RowColumnChildInfo>,
+    measurables: List<Measurable>,
+    placeables: Array<Placeable?>,
+    measureInfo: RowColumnMeasureInfo,
+    mainAxisMin: Int,
+    mainAxisMax: Int,
+    crossAxisMax: Int,
+    fixedSize: Int,
+    totalSpacing: Int,
+    includeSpacers: Boolean,
+    spaceChildrenCount: Int,
+    spaceChildrenMinSize: Int,
+    shouldMeasure: (RowColumnChildInfo, Measurable, RowColumnParentData?, Int) -> Boolean
+): Int {
+    val childrenCount = if (includeSpacers) measureInfo.remainingFlexibleChildrenCount else measureInfo.remainingFlexibleChildrenCount - spaceChildrenCount
+    if (childrenCount <= 0) {
+        return 0
+    }
+    val targetSize = if (mainAxisMax != Constraints.Infinity) mainAxisMax else mainAxisMin
+    val remainingSize = (targetSize - totalSpacing - fixedSize - measureInfo.flexibleSize - spaceChildrenMinSize).fastCoerceAtLeast(0)
+    val roundedUnitSize = remainingSize / childrenCount
+    val roundSlopCount = remainingSize - (roundedUnitSize * childrenCount)
+    var measuredChildren = 0
+    for (child in children) {
+        if (child.measured) {
+            continue
+        }
+        val measurable = measurables[child.index]
+        val parentData = measurable.rowColumnParentData
+        var flexibleUnitSize = roundedUnitSize
+        if (measuredChildren < roundSlopCount) {
+            flexibleUnitSize += 1
+        }
+        if (!shouldMeasure(child, measurables[child.index], parentData, flexibleUnitSize)) {
+            continue
+        }
+
+        measureInfo.anyAlignBy = measureInfo.anyAlignBy || parentData.isRelative
+        val crossAxisDesiredSize = if (crossAxisMax == Constraints.Infinity) null else {
+            parentData?.flowLayoutData?.let {
+                (it.fillCrossAxisFraction * crossAxisMax).fastRoundToInt()
+            }
+        }
+
+        val constrainedCrossAxisMin = crossAxisDesiredSize ?: 0
+        val constrainedCrossAxisMax = crossAxisDesiredSize ?: crossAxisMax
+        var constrainedMainAxisMin = if (parentData?.flexibleMax?.isFlexibleExpanding == true) flexibleUnitSize else 0
+        var constrainedMainAxisMax = flexibleUnitSize
+        // If we have infinite space (e.g. an element of a scroll view), use our intrinsic size
+        if (mainAxisMax == Constraints.Infinity) {
+            if (child.intrinsic == null) {
+                child.intrinsic = measurable.intrinsicMainAxisSize(constrainedCrossAxisMax)
+            }
+            constrainedMainAxisMax = child.intrinsic!!
+        }
+
+        val placeable = placeables[child.index] ?: measurable.measure(
+            createConstraints(
+                mainAxisMin = constrainedMainAxisMin,
+                crossAxisMin = constrainedCrossAxisMin,
+                mainAxisMax = constrainedMainAxisMax,
+                crossAxisMax = constrainedCrossAxisMax
+            )
+        )
+        placeables[child.index] = placeable
+        child.measured = true
+        child.mainAxisConstrainedSize = placeable.mainAxisConstrainedSize()
+        child.mainAxisMeasuredSize = placeable.mainAxisMeasuredSize()
+        measureInfo.flexibleSize += child.mainAxisMeasuredSize
+        measureInfo.crossAxisMeasuredSize = max(measureInfo.crossAxisMeasuredSize, placeable.crossAxisMeasuredSize())
+
+        ++measuredChildren
+    }
+    measureInfo.remainingFlexibleChildrenCount -= measuredChildren
+    return measuredChildren
+}
+
+/*
+ * Modified ersion of RowColumnImpl.kt
+ */
+
+internal enum class LayoutOrientation {
+    Horizontal,
+    Vertical,
+}
+
+//@Immutable
+internal sealed class CrossAxisAlignment {
+    internal abstract fun align(
+        size: Int,
+        layoutDirection: LayoutDirection,
+        placeable: Placeable,
+        beforeCrossAxisAlignmentLine: Int,
+    ): Int
+
+    internal open val isRelative: Boolean
+        get() = false
+
+    internal open fun calculateAlignmentLinePosition(placeable: Placeable): Int? = null
+
+    companion object {
+        @Stable val Center: CrossAxisAlignment = CenterCrossAxisAlignment
+
+        @Stable val Start: CrossAxisAlignment = StartCrossAxisAlignment
+
+        @Stable val End: CrossAxisAlignment = EndCrossAxisAlignment
+
+        fun AlignmentLine(alignmentLine: AlignmentLine): CrossAxisAlignment =
+            AlignmentLineCrossAxisAlignment(AlignmentLineProvider.Value(alignmentLine))
+
+        internal fun Relative(alignmentLineProvider: AlignmentLineProvider): CrossAxisAlignment =
+            AlignmentLineCrossAxisAlignment(alignmentLineProvider)
+
+        internal fun vertical(vertical: Alignment.Vertical): CrossAxisAlignment =
+            VerticalCrossAxisAlignment(vertical)
+
+        internal fun horizontal(horizontal: Alignment.Horizontal): CrossAxisAlignment =
+            HorizontalCrossAxisAlignment(horizontal)
+    }
+
+    private object CenterCrossAxisAlignment : CrossAxisAlignment() {
+        override fun align(
+            size: Int,
+            layoutDirection: LayoutDirection,
+            placeable: Placeable,
+            beforeCrossAxisAlignmentLine: Int,
+        ): Int {
+            return size / 2
+        }
+    }
+
+    private object StartCrossAxisAlignment : CrossAxisAlignment() {
+        override fun align(
+            size: Int,
+            layoutDirection: LayoutDirection,
+            placeable: Placeable,
+            beforeCrossAxisAlignmentLine: Int,
+        ): Int {
+            return if (layoutDirection == LayoutDirection.Ltr) 0 else size
+        }
+    }
+
+    private object EndCrossAxisAlignment : CrossAxisAlignment() {
+        override fun align(
+            size: Int,
+            layoutDirection: LayoutDirection,
+            placeable: Placeable,
+            beforeCrossAxisAlignmentLine: Int,
+        ): Int {
+            return if (layoutDirection == LayoutDirection.Ltr) size else 0
+        }
+    }
+
+    private class AlignmentLineCrossAxisAlignment(
+        val alignmentLineProvider: AlignmentLineProvider
+    ) : CrossAxisAlignment() {
+        override val isRelative: Boolean
+            get() = true
+
+        override fun calculateAlignmentLinePosition(placeable: Placeable): Int {
+            return alignmentLineProvider.calculateAlignmentLinePosition(placeable)
+        }
+
+        override fun align(
+            size: Int,
+            layoutDirection: LayoutDirection,
+            placeable: Placeable,
+            beforeCrossAxisAlignmentLine: Int,
+        ): Int {
+            val alignmentLinePosition =
+                alignmentLineProvider.calculateAlignmentLinePosition(placeable)
+            return if (alignmentLinePosition != AlignmentLine.Unspecified) {
+                val line = beforeCrossAxisAlignmentLine - alignmentLinePosition
+                if (layoutDirection == LayoutDirection.Rtl) {
+                    size - line
+                } else {
+                    line
+                }
+            } else {
+                0
+            }
+        }
+    }
+
+    private data class VerticalCrossAxisAlignment(val vertical: Alignment.Vertical) :
+        CrossAxisAlignment() {
+        override fun align(
+            size: Int,
+            layoutDirection: LayoutDirection,
+            placeable: Placeable,
+            beforeCrossAxisAlignmentLine: Int,
+        ): Int {
+            return vertical.align(0, size)
+        }
+    }
+
+    private data class HorizontalCrossAxisAlignment(val horizontal: Alignment.Horizontal) :
+        CrossAxisAlignment() {
+        override fun align(
+            size: Int,
+            layoutDirection: LayoutDirection,
+            placeable: Placeable,
+            beforeCrossAxisAlignmentLine: Int,
+        ): Int {
+            return horizontal.align(0, size, layoutDirection)
+        }
+    }
+}
+
+@JvmInline
+internal value class OrientationIndependentConstraints
+private constructor(private val value: Constraints) {
+    inline val mainAxisMin: Int
+        get() = value.minWidth
+
+    inline val mainAxisMax: Int
+        get() = value.maxWidth
+
+    inline val crossAxisMin: Int
+        get() = value.minHeight
+
+    inline val crossAxisMax: Int
+        get() = value.maxHeight
+
+    constructor(
+        mainAxisMin: Int,
+        mainAxisMax: Int,
+        crossAxisMin: Int,
+        crossAxisMax: Int,
+    ) : this(
+        Constraints(
+            minWidth = mainAxisMin,
+            maxWidth = mainAxisMax,
+            minHeight = crossAxisMin,
+            maxHeight = crossAxisMax,
+        )
+    )
+
+    constructor(
+        c: Constraints,
+        orientation: LayoutOrientation,
+    ) : this(
+        if (orientation === LayoutOrientation.Horizontal) c.minWidth else c.minHeight,
+        if (orientation === LayoutOrientation.Horizontal) c.maxWidth else c.maxHeight,
+        if (orientation === LayoutOrientation.Horizontal) c.minHeight else c.minWidth,
+        if (orientation === LayoutOrientation.Horizontal) c.maxHeight else c.maxWidth,
+    )
+
+    // Creates a new instance with the same main axis constraints and maximum tight cross axis.
+    fun stretchCrossAxis() =
+        OrientationIndependentConstraints(
+            mainAxisMin,
+            mainAxisMax,
+            if (crossAxisMax != Constraints.Infinity) crossAxisMax else crossAxisMin,
+            crossAxisMax,
+        )
+
+    // Given an orientation, resolves the current instance to traditional constraints.
+    fun toBoxConstraints(orientation: LayoutOrientation) =
+        if (orientation === LayoutOrientation.Horizontal) {
+            Constraints(mainAxisMin, mainAxisMax, crossAxisMin, crossAxisMax)
+        } else {
+            Constraints(crossAxisMin, crossAxisMax, mainAxisMin, mainAxisMax)
+        }
+
+    // Given an orientation, resolves the max width constraint this instance represents.
+    fun maxWidth(orientation: LayoutOrientation) =
+        if (orientation === LayoutOrientation.Horizontal) {
+            mainAxisMax
+        } else {
+            crossAxisMax
+        }
+
+    // Given an orientation, resolves the max height constraint this instance represents.
+    fun maxHeight(orientation: LayoutOrientation) =
+        if (orientation === LayoutOrientation.Horizontal) {
+            crossAxisMax
+        } else {
+            mainAxisMax
+        }
+
+    fun copy(
+        mainAxisMin: Int = this.mainAxisMin,
+        mainAxisMax: Int = this.mainAxisMax,
+        crossAxisMin: Int = this.crossAxisMin,
+        crossAxisMax: Int = this.crossAxisMax,
+    ): OrientationIndependentConstraints =
+        OrientationIndependentConstraints(mainAxisMin, mainAxisMax, crossAxisMin, crossAxisMax)
+}
+
+internal val IntrinsicMeasurable.rowColumnParentData: RowColumnParentData?
+    get() = parentData as? RowColumnParentData
+
+internal val Placeable.rowColumnParentData: RowColumnParentData?
+    get() = parentData as? RowColumnParentData
+
+internal val RowColumnParentData?.crossAxisAlignment: CrossAxisAlignment?
+    get() = this?.crossAxisAlignment
+
+internal val RowColumnParentData?.isRelative: Boolean
+    get() = this.crossAxisAlignment?.isRelative ?: false
+
+internal object IntrinsicMeasureBlocks {
+    fun HorizontalMinWidth(
+        measurables: List<IntrinsicMeasurable>,
+        availableHeight: Int,
+        mainAxisSpacing: Int,
+    ): Int {
+        return intrinsicMainAxisSize(
+            measurables,
+            { h -> minIntrinsicWidth(h) },
+            availableHeight,
+            mainAxisSpacing,
+        )
+    }
+
+    fun VerticalMinWidth(
+        measurables: List<IntrinsicMeasurable>,
+        availableHeight: Int,
+        mainAxisSpacing: Int,
+    ): Int {
+        return intrinsicCrossAxisSize(
+            measurables,
+            { w -> maxIntrinsicHeight(w) },
+            { h -> minIntrinsicWidth(h) },
+            availableHeight,
+            mainAxisSpacing,
+        )
+    }
+
+    fun HorizontalMinHeight(
+        measurables: List<IntrinsicMeasurable>,
+        availableWidth: Int,
+        mainAxisSpacing: Int,
+    ): Int {
+        return intrinsicCrossAxisSize(
+            measurables,
+            { h -> maxIntrinsicWidth(h) },
+            { w -> minIntrinsicHeight(w) },
+            availableWidth,
+            mainAxisSpacing,
+        )
+    }
+
+    fun VerticalMinHeight(
+        measurables: List<IntrinsicMeasurable>,
+        availableWidth: Int,
+        mainAxisSpacing: Int,
+    ): Int {
+        return intrinsicMainAxisSize(
+            measurables,
+            { w -> minIntrinsicHeight(w) },
+            availableWidth,
+            mainAxisSpacing,
+        )
+    }
+
+    fun HorizontalMaxWidth(
+        measurables: List<IntrinsicMeasurable>,
+        availableHeight: Int,
+        mainAxisSpacing: Int,
+    ): Int {
+        return intrinsicMainAxisSize(
+            measurables,
+            { h -> maxIntrinsicWidth(h) },
+            availableHeight,
+            mainAxisSpacing,
+        )
+    }
+
+    fun VerticalMaxWidth(
+        measurables: List<IntrinsicMeasurable>,
+        availableHeight: Int,
+        mainAxisSpacing: Int,
+    ): Int {
+        return intrinsicCrossAxisSize(
+            measurables,
+            { w -> maxIntrinsicHeight(w) },
+            { h -> maxIntrinsicWidth(h) },
+            availableHeight,
+            mainAxisSpacing,
+        )
+    }
+
+    fun HorizontalMaxHeight(
+        measurables: List<IntrinsicMeasurable>,
+        availableWidth: Int,
+        mainAxisSpacing: Int,
+    ): Int {
+        return intrinsicCrossAxisSize(
+            measurables,
+            { h -> maxIntrinsicWidth(h) },
+            { w -> maxIntrinsicHeight(w) },
+            availableWidth,
+            mainAxisSpacing,
+        )
+    }
+
+    fun VerticalMaxHeight(
+        measurables: List<IntrinsicMeasurable>,
+        availableWidth: Int,
+        mainAxisSpacing: Int,
+    ): Int {
+        return intrinsicMainAxisSize(
+            measurables,
+            { w -> maxIntrinsicHeight(w) },
+            availableWidth,
+            mainAxisSpacing,
+        )
+    }
+}
+
+private inline fun intrinsicMainAxisSize(
+    children: List<IntrinsicMeasurable>,
+    mainAxisSize: IntrinsicMeasurable.(Int) -> Int,
+    crossAxisAvailable: Int,
+    mainAxisSpacing: Int,
+): Int {
+    if (children.isEmpty()) return 0
+    val totalSpacing = (children.size - 1) * mainAxisSpacing
+    return totalSpacing + children.sumOf { it.mainAxisSize(crossAxisAvailable) }
+}
+
+private inline fun intrinsicCrossAxisSize(
+    children: List<IntrinsicMeasurable>,
+    mainAxisSize: IntrinsicMeasurable.(Int) -> Int,
+    crossAxisSize: IntrinsicMeasurable.(Int) -> Int,
+    mainAxisAvailable: Int,
+    mainAxisSpacing: Int,
+): Int {
+    if (children.isEmpty()) return 0
+    var fixedSpace = min((children.size - 1) * mainAxisSpacing, mainAxisAvailable)
+    var crossAxisMax = 0
+    children.forEach { child ->
+        // Ask the child how much main axis space it wants to occupy. This cannot be more
+        // than the remaining available space.
+        val remaining = if (mainAxisAvailable == Constraints.Infinity) Constraints.Infinity else mainAxisAvailable - fixedSpace
+        val mainAxisSpace = min(child.mainAxisSize(Constraints.Infinity), remaining)
+        fixedSpace += mainAxisSpace
+        // Now that the assigned main axis space is known, ask about the cross axis space.
+        crossAxisMax = max(crossAxisMax, child.crossAxisSize(mainAxisSpace))
+    }
+    return crossAxisMax
+}
+
+internal class LayoutFlexibleElement(val ideal: Float?, val min: Float?, val max: Float?):
+    ModifierNodeElement<LayoutFlexibleNode>() {
+    override fun create(): LayoutFlexibleNode {
+        return LayoutFlexibleNode(ideal, min, max)
+    }
+
+    override fun update(node: LayoutFlexibleNode) {
+        node.ideal = ideal ?: node.ideal
+        node.min = min ?: node.min
+        node.max = max ?: node.max
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "flexible"
+        value = Triple(ideal, min, max)
+        properties["ideal"] = ideal
+        properties["min"] = min
+        properties["max"] = max
+    }
+
+    override fun hashCode(): Int {
+        var result = ideal.hashCode()
+        result = 31 * result + min.hashCode()
+        result = 31 * result + max.hashCode()
+        return result
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        val otherModifier = other as? LayoutFlexibleElement ?: return false
+        return ideal == otherModifier.ideal && min == otherModifier.min && max == otherModifier.max
+    }
+}
+
+internal class LayoutFlexibleNode(var ideal: Float?, var min: Float?, var max: Float?) :
+    ParentDataModifierNode, Modifier.Node() {
+    override fun Density.modifyParentData(parentData: Any?) =
+        ((parentData as? RowColumnParentData) ?: RowColumnParentData()).also {
+            it.flexibleIdeal = ideal ?: it.flexibleIdeal
+            it.flexibleMin = min ?: it.flexibleMin
+            it.flexibleMax = max ?: it.flexibleMax
+        }
+}
+
+internal class WithAlignmentLineBlockElement(val block: (Measured) -> Int) :
+    ModifierNodeElement<SiblingsAlignedNode.WithAlignmentLineBlockNode>() {
+    override fun create(): SiblingsAlignedNode.WithAlignmentLineBlockNode {
+        return SiblingsAlignedNode.WithAlignmentLineBlockNode(block)
+    }
+
+    override fun update(node: SiblingsAlignedNode.WithAlignmentLineBlockNode) {
+        node.block = block
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        val otherModifier = other as? WithAlignmentLineBlockElement ?: return false
+        return block === otherModifier.block
+    }
+
+    override fun hashCode(): Int = block.hashCode()
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "alignBy"
+        value = block
+    }
+}
+
+internal class WithAlignmentLineElement(val alignmentLine: AlignmentLine) :
+    ModifierNodeElement<SiblingsAlignedNode.WithAlignmentLineNode>() {
+    override fun create(): SiblingsAlignedNode.WithAlignmentLineNode {
+        return SiblingsAlignedNode.WithAlignmentLineNode(alignmentLine)
+    }
+
+    override fun update(node: SiblingsAlignedNode.WithAlignmentLineNode) {
+        node.alignmentLine = alignmentLine
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "alignBy"
+        value = alignmentLine
+    }
+
+    override fun hashCode(): Int = alignmentLine.hashCode()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        val otherModifier = other as? WithAlignmentLineElement ?: return false
+        return alignmentLine == otherModifier.alignmentLine
+    }
+}
+
+internal sealed class SiblingsAlignedNode : ParentDataModifierNode, Modifier.Node() {
+    abstract override fun Density.modifyParentData(parentData: Any?): Any?
+
+    internal class WithAlignmentLineBlockNode(var block: (Measured) -> Int) :
+        SiblingsAlignedNode() {
+        override fun Density.modifyParentData(parentData: Any?): Any {
+            return ((parentData as? RowColumnParentData) ?: RowColumnParentData()).also {
+                it.crossAxisAlignment =
+                    CrossAxisAlignment.Relative(AlignmentLineProvider.Block(block))
+            }
+        }
+    }
+
+    internal class WithAlignmentLineNode(var alignmentLine: AlignmentLine) : SiblingsAlignedNode() {
+        override fun Density.modifyParentData(parentData: Any?): Any {
+            return ((parentData as? RowColumnParentData) ?: RowColumnParentData()).also {
+                it.crossAxisAlignment =
+                    CrossAxisAlignment.Relative(AlignmentLineProvider.Value(alignmentLine))
+            }
+        }
+    }
+}
+
+internal class HorizontalAlignElement(val horizontal: Alignment.Horizontal) :
+    ModifierNodeElement<HorizontalAlignNode>() {
+    override fun create(): HorizontalAlignNode {
+        return HorizontalAlignNode(horizontal)
+    }
+
+    override fun update(node: HorizontalAlignNode) {
+        node.horizontal = horizontal
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "align"
+        value = horizontal
+    }
+
+    override fun hashCode(): Int = horizontal.hashCode()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        val otherModifier = other as? HorizontalAlignElement ?: return false
+        return horizontal == otherModifier.horizontal
+    }
+}
+
+internal class HorizontalAlignNode(var horizontal: Alignment.Horizontal) :
+    ParentDataModifierNode, Modifier.Node() {
+    override fun Density.modifyParentData(parentData: Any?): RowColumnParentData {
+        return ((parentData as? RowColumnParentData) ?: RowColumnParentData()).also {
+            it.crossAxisAlignment = CrossAxisAlignment.horizontal(horizontal)
+        }
+    }
+}
+
+internal class VerticalAlignElement(val alignment: Alignment.Vertical) :
+    ModifierNodeElement<VerticalAlignNode>() {
+    override fun create(): VerticalAlignNode {
+        return VerticalAlignNode(alignment)
+    }
+
+    override fun update(node: VerticalAlignNode) {
+        node.vertical = alignment
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "align"
+        value = alignment
+    }
+
+    override fun hashCode(): Int = alignment.hashCode()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        val otherModifier = other as? VerticalAlignElement ?: return false
+        return alignment == otherModifier.alignment
+    }
+}
+
+internal class VerticalAlignNode(var vertical: Alignment.Vertical) :
+    ParentDataModifierNode, Modifier.Node() {
+    override fun Density.modifyParentData(parentData: Any?): RowColumnParentData {
+        return ((parentData as? RowColumnParentData) ?: RowColumnParentData()).also {
+            it.crossAxisAlignment = CrossAxisAlignment.vertical(vertical)
+        }
+    }
+}
+
+internal data class RowColumnParentData(
+    var fill: Boolean = true,
+    var flexibleIdeal: Float? = null,
+    var flexibleMin: Float? = null,
+    var flexibleMax: Float? = null,
+    var crossAxisAlignment: CrossAxisAlignment? = null,
+    var flowLayoutData: FlowLayoutData? = null,
+)
+
+internal sealed class AlignmentLineProvider {
+    abstract fun calculateAlignmentLinePosition(placeable: Placeable): Int
+
+    data class Block(val lineProviderBlock: (Measured) -> Int) : AlignmentLineProvider() {
+        override fun calculateAlignmentLinePosition(placeable: Placeable): Int {
+            return lineProviderBlock(placeable)
+        }
+    }
+
+    data class Value(val alignmentLine: AlignmentLine) : AlignmentLineProvider() {
+        override fun calculateAlignmentLinePosition(placeable: Placeable): Int {
+            return placeable[alignmentLine]
+        }
+    }
+}
+
+/*
+ * Modified version of FlowLayout.kt
+ */
+
+internal data class FlowLayoutData(var fillCrossAxisFraction: Float)

--- a/Sources/SkipUI/SkipUI/Commands/Toolbar.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Toolbar.swift
@@ -3,6 +3,7 @@
 #if !SKIP_BRIDGE
 #if SKIP
 import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -189,7 +190,7 @@ public struct ToolbarSpacer : ToolbarContent, CustomizableToolbarContent, View, 
         if sizing == .fixed {
             modifier = Modifier.width(8.dp)
         } else {
-            modifier = EnvironmentValues.shared._fillWidth?() ?? Modifier
+            modifier = EnvironmentValues.shared._flexibleWidth?(nil, nil, Float.flexibleSpace) ?? Modifier
         }
         androidx.compose.foundation.layout.Spacer(modifier: modifier)
     }

--- a/Sources/SkipUI/SkipUI/Components/ProgressView.swift
+++ b/Sources/SkipUI/SkipUI/Components/ProgressView.swift
@@ -107,7 +107,7 @@ public struct ProgressView : View, Renderable {
     }
 
     @Composable private func RenderLinearProgress(context: ComposeContext) {
-        let modifier = Modifier.fillWidth().then(context.modifier)
+        let modifier = Modifier.flexibleWidth().then(context.modifier)
         let color = EnvironmentValues.shared._tint?.colorImpl() ?? ProgressIndicatorDefaults.linearColor
         if value == nil || total == nil {
             LinearProgressIndicator(modifier: modifier, color: color)

--- a/Sources/SkipUI/SkipUI/Components/Spacer.swift
+++ b/Sources/SkipUI/SkipUI/Components/Spacer.swift
@@ -12,8 +12,9 @@ import androidx.compose.ui.unit.dp
 import struct CoreGraphics.CGFloat
 #endif
 
+// We use a class rather than struct to be able to mutate the `positionalMinLength` for layout.
 // SKIP @bridge
-public struct Spacer : View, Renderable {
+public final class Spacer : View, Renderable {
     let minLength: CGFloat?
 
     // SKIP @bridge
@@ -22,19 +23,23 @@ public struct Spacer : View, Renderable {
     }
 
     #if SKIP
+    /// When we layout an `HStack` or `VStack` we apply a positional min length to spacers between elements.
+    var positionalMinLength: CGFloat?
+
     @Composable override func Render(context: ComposeContext) {
-        let axis = EnvironmentValues.shared._layoutAxis
-        let minLength: Float? = minLength != nil && minLength! > 0.0 ? Float(minLength!) : nil
         let layoutImplementationVersion = EnvironmentValues.shared._layoutImplementationVersion
+        let axis = EnvironmentValues.shared._layoutAxis
+        let effectiveMinLength = minLength ?? positionalMinLength
+        let minLengthFloat: Float? = effectiveMinLength != nil && effectiveMinLength! > 0.0 ? Float(effectiveMinLength!) : nil
         if layoutImplementationVersion == 0 {
             // Maintain previous layout behavior for users who opt in
-            if let minLength, minLength > 0.0 {
+            if let minLengthFloat {
                 let minModifier: Modifier
                 switch axis {
                 case .horizontal:
-                    minModifier = Modifier.width(minLength.dp)
+                    minModifier = Modifier.width(minLengthFloat.dp)
                 case .vertical:
-                    minModifier = Modifier.height(minLength.dp)
+                    minModifier = Modifier.height(minLengthFloat.dp)
                 case nil:
                     minModifier = Modifier
                 }
@@ -56,13 +61,13 @@ public struct Spacer : View, Renderable {
             switch axis {
             case .horizontal:
                 if let flexibleWidth = EnvironmentValues.shared._flexibleWidth {
-                    modifier = flexibleWidth(nil, minLength, Float.flexibleSpace)
+                    modifier = flexibleWidth(nil, minLengthFloat, Float.flexibleSpace)
                 } else {
                     modifier = Modifier
                 }
             case .vertical:
                 if let flexibleHeight = EnvironmentValues.shared._flexibleHeight {
-                    modifier = flexibleHeight(nil, minLength, Float.flexibleSpace)
+                    modifier = flexibleHeight(nil, minLengthFloat, Float.flexibleSpace)
                 } else {
                     modifier = Modifier
                 }

--- a/Sources/SkipUI/SkipUI/Compose/ComposeContainer.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeContainer.swift
@@ -17,55 +17,67 @@ import androidx.compose.ui.Modifier
 
 /// Composable to handle sizing and layout in a SwiftUI-like way for containers that compose child content.
 ///
-/// Compose's behavior differs from SwiftUI's when dealing with filling space. A SwiftUI container will give each child the
-/// space it needs to display, then automatically divide the remainder between children that want to expand. In Compose, on
-/// the other hand, a single 'fillMaxWidth' child will consume all remaining space, pushing subsequent children out. To get
-/// SwiftUI's behavior, all children that want to expand must use the `weight` modifier, which is only available in a Row or
-/// Column scope. We've abstracted the fact that 'weight' for a given dimension may or may not be available depending on scope
-/// behind our `Modifier.fillWidth` and `Modifier.fillHeight` extension functions.
-///
-/// Having to explicitly set a certain modifier in order to expand within a parent is problematic for containers that want to
-/// fit content. The container only wants to expand if it has content that wants to expand. It can't know this until it composes
-/// its content. The code in this function sets triggers on the environment values that we use in 'fillWidth' and 'fillHeight' so
-/// that if the container content uses them, the container itself can recompose with the appropriate expansion to match its
-/// content. Note that this generally only affects final layout when an expanding child is in a container that is itself in a
-/// container, and it has to share space with other members of the parent container.
-@Composable public func ComposeContainer(axis: Axis? = nil, eraseAxis: Bool = false, scrollAxes: Axis.Set = [], modifier: Modifier = Modifier, fillWidth: Bool = false, fixedWidth: Bool = false, minWidth: Bool = false, fillHeight: Bool = false, fixedHeight: Bool = false, minHeight: Bool = false, then: Modifier = Modifier, content: @Composable (Modifier) -> Void) {
-    // Use remembered expansion values to recompose on change
-    let isFillWidth = remember { mutableStateOf(fillWidth) }
-    let isFillHeight = remember { mutableStateOf(fillHeight) }
+/// - Seealso: `ComposeFlexibleContainer(...)`
+@Composable public func ComposeContainer(axis: Axis? = nil, eraseAxis: Bool = false, scrollAxes: Axis.Set = [], modifier: Modifier = Modifier, fixedWidth: Bool = false, fillWidth: Bool = false, fixedHeight: Bool = false, fillHeight: Bool = false, then: Modifier = Modifier, content: @Composable (Modifier) -> Void) {
+    ComposeFlexibleContainer(axis: axis, eraseAxis: eraseAxis, scrollAxes: scrollAxes, modifier: modifier, fixedWidth: fixedWidth, flexibleWidthMax: fillWidth ? Float.flexibleFill : nil, fixedHeight: fixedHeight, flexibleHeightMax: fillHeight ? Float.flexibleFill : nil, then: then, content: content)
+}
 
-    // Create the correct modifier for the current values. We must use IntrinsicSize.Max for fills in a scroll direction
-    // because Compose's fillMax modifiers have no effect in the scroll direction. We can't use IntrinsicSize for scrolling
-    // containers, however
+/// Composable to handle sizing and layout in a SwiftUI-like way for containers that compose child content.
+///
+/// In Compose, containers are not perfectly layout neutral. A container that wants to expand must use the proper
+/// modifier, rather than relying on its content. Additionally, a single 'fillMaxWidth' child will consume all
+/// remaining space, pushing subsequent children out.
+///
+/// Having to explicitly set a modifier in order to expand within a parent in Compose is problematic for containers that
+/// want to fit content. The container only wants to expand if it has content that wants to expand. It can't know this
+/// until it composes its content. The code in this function sets triggers on the environment values that we use in
+/// flexible layout so that if the container content uses them, the container itself can recompose with the appropriate
+/// expansion to match its content. Note that this generally only affects final layout when an expanding child is in a
+/// container that is itself in a container, and it has to share space with other members of the parent container.
+@Composable public func ComposeFlexibleContainer(axis: Axis? = nil, eraseAxis: Bool = false, scrollAxes: Axis.Set = [], modifier: Modifier = Modifier, fixedWidth: Bool = false, flexibleWidthIdeal: Float? = nil, flexibleWidthMin: Float? = nil, flexibleWidthMax: Float? = nil, fixedHeight: Bool = false, flexibleHeightIdeal: Float? = nil, flexibleHeightMin: Float? = nil, flexibleHeightMax: Float? = nil, then: Modifier = Modifier, content: @Composable (Modifier) -> Void) {
+    // Use remembered flexible values to recompose on change
+    let contentFlexibleWidthMax = remember { mutableStateOf(flexibleWidthMax) }
+    let contentFlexibleHeightMax = remember { mutableStateOf(flexibleHeightMax) }
+
+    // Create the correct modifier for the current values and content
     var modifier = modifier
     let inheritedLayoutScrollAxes = EnvironmentValues.shared._layoutScrollAxes
     var totalLayoutScrollAxes = inheritedLayoutScrollAxes
-    if fixedWidth || minWidth || axis == .vertical {
+    if fixedWidth || flexibleWidthMax?.isFlexibleNonExpandingMax == true || flexibleWidthMin?.isFlexibleNonExpandingMin == true || axis == .vertical {
         totalLayoutScrollAxes.remove(Axis.Set.horizontal)
     }
-    if !fixedWidth && isFillWidth.value {
-        if fillWidth {
-            modifier = modifier.fillWidth()
-        } else if inheritedLayoutScrollAxes.contains(Axis.Set.horizontal) {
-            modifier = modifier.width(IntrinsicSize.Max)
+    if !fixedWidth {
+        if flexibleWidthMax?.isFlexibleExpanding != true && contentFlexibleWidthMax.value?.isFlexibleExpanding == true && inheritedLayoutScrollAxes.contains(Axis.Set.horizontal) {
+            // We must use IntrinsicSize.Max for fills in a scroll direction because Compose's fillMax modifiers
+            // have no effect in the scroll direction. Flexible values can influence intrinsic measurement
+            let minValue = flexibleWidthMin?.isFlexibleNonExpandingMin == true ? flexibleWidthMin : nil
+            let maxValue = flexibleWidthMax?.isFlexibleNonExpandingMax == true ? flexibleWidthMax : nil
+            modifier = modifier.flexibleWidth(min: minValue, max: maxValue).width(IntrinsicSize.Max)
         } else {
-            modifier = modifier.fillWidth()
+            let max: Float? = flexibleWidthMax ?? contentFlexibleWidthMax.value
+            if flexibleWidthIdeal != nil || flexibleWidthMin != nil || max != nil {
+                modifier = modifier.flexibleWidth(ideal: flexibleWidthIdeal, min: flexibleWidthMin, max: max)
+            }
         }
     }
-    if fixedHeight || minHeight || axis == .horizontal {
+    if fixedHeight || flexibleHeightMax?.isFlexibleNonExpandingMax == true || flexibleHeightMin?.isFlexibleNonExpandingMin == true || axis == .horizontal {
         totalLayoutScrollAxes.remove(Axis.Set.vertical)
     }
-    if !fixedHeight && isFillHeight.value {
-        if fillHeight {
-            modifier = modifier.fillHeight()
-        } else if inheritedLayoutScrollAxes.contains(Axis.Set.vertical) {
-            modifier = modifier.height(IntrinsicSize.Max)
+    if !fixedHeight {
+        if flexibleHeightMax?.isFlexibleExpanding != true && contentFlexibleHeightMax.value?.isFlexibleExpanding == true && inheritedLayoutScrollAxes.contains(Axis.Set.vertical) {
+            // We must use IntrinsicSize.Max for fills in a scroll direction because Compose's fillMax modifiers
+            // have no effect in the scroll direction. Flexible values can influence intrinsic measurement
+            let minValue = flexibleHeightMin?.isFlexibleNonExpandingMin == true ? flexibleHeightMin : nil
+            let maxValue = flexibleHeightMax?.isFlexibleNonExpandingMax == true ? flexibleHeightMax : nil
+            modifier = modifier.flexibleHeight(min: minValue, max: maxValue).height(IntrinsicSize.Max)
         } else {
-            modifier = modifier.fillHeight()
+            let max: Float? = flexibleHeightMax ?? contentFlexibleHeightMax.value
+            if flexibleHeightIdeal != nil || flexibleHeightMin != nil || max != nil {
+                modifier = modifier.flexibleHeight(ideal: flexibleHeightIdeal, min: flexibleHeightMin, max: max)
+            }
         }
     }
-    
+
     totalLayoutScrollAxes.formUnion(scrollAxes)
     let inheritedScrollAxes = EnvironmentValues.shared._scrollAxes
     let totalScrollAxes = inheritedScrollAxes.union(scrollAxes)
@@ -87,26 +99,42 @@ import androidx.compose.ui.Modifier
 
         // Reset the container layout because this is a new container. A directional container like 'HStack' or 'VStack' will set
         // the correct layout before rendering in the content block below, so that its own children can distribute available space
-        $0.set_fillWidthModifier(nil)
-        $0.set_fillHeightModifier(nil)
+        $0.set_flexibleWidthModifier(nil)
+        $0.set_flexibleHeightModifier(nil)
 
-        // Set the 'fillWidth' and 'fillHeight' blocks to trigger a side effect to update our container's expansion state, which can
-        // cause it to recompose and recalculate its own modifier. We must use `SideEffect` or the recomposition never happens
-        $0.set_fillWidth {
-            if !isFillWidth.value {
-                SideEffect {
-                    isFillWidth.value = true
+        // Set the 'flexibleWidth' and 'flexibleHeight' blocks to trigger a side effect to update our container's expansion state, which
+        // can cause it to recompose and recalculate its own modifier. We must use `SideEffect` or the recomposition never happens
+        $0.set_flexibleWidth { ideal, min, max in
+            var defaultModifier: Modifier = Modifier
+            if max?.isFlexibleExpanding == true {
+                if max == Float.flexibleFill {
+                    SideEffect { contentFlexibleWidthMax.value = Float.flexibleFill }
+                } else if contentFlexibleWidthMax.value != Float.flexibleFill {
+                    // max must be flexibleSpace or flexibleUnknownWithSpace
+                    SideEffect { contentFlexibleWidthMax.value = Float.flexibleUnknownWithSpace }
                 }
+                defaultModifier = Modifier.fillMaxWidth()
+            } else if max != nil && contentFlexibleWidthMax.value == nil {
+                SideEffect { contentFlexibleWidthMax.value = Float.flexibleUnknownNonExpanding }
             }
-            return EnvironmentValues.shared._fillWidthModifier ?? Modifier.fillMaxWidth()
+            return EnvironmentValues.shared._flexibleWidthModifier?(ideal, min, max)
+                ?? defaultModifier.applyNonExpandingFlexibleWidth(ideal: ideal, min: min, max: max)
         }
-        $0.set_fillHeight {
-            if !isFillHeight.value {
-                SideEffect {
-                    isFillHeight.value = true
+        $0.set_flexibleHeight { ideal, min, max in
+            var defaultModifier: Modifier = Modifier
+            if max?.isFlexibleExpanding == true {
+                if max == Float.flexibleFill {
+                    SideEffect { contentFlexibleHeightMax.value = Float.flexibleFill }
+                } else if contentFlexibleHeightMax.value != Float.flexibleFill {
+                    // max must be flexibleSpace or flexibleUnknownWithSpace
+                    SideEffect { contentFlexibleHeightMax.value = Float.flexibleUnknownWithSpace }
                 }
+                defaultModifier = Modifier.fillMaxHeight()
+            } else if max != nil && contentFlexibleHeightMax.value == nil {
+                SideEffect { contentFlexibleHeightMax.value = Float.flexibleUnknownNonExpanding }
             }
-            return EnvironmentValues.shared._fillHeightModifier ?? Modifier.fillMaxHeight()
+            return EnvironmentValues.shared._flexibleHeightModifier?(ideal, min, max)
+                ?? defaultModifier.applyNonExpandingFlexibleHeight(ideal: ideal, min: min, max: max)
         }
         return ComposeResult.ok
     } in: {

--- a/Sources/SkipUI/SkipUI/Compose/ComposeExtensions.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeExtensions.swift
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeightIn
+import androidx.compose.foundation.layout.requiredWidthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
@@ -13,39 +15,82 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.dp
 
 extension Modifier {
-    /// Fill available remaining width.
+    /// Fill available width similar to `.frame(maxWidth: .infinity)`.
     ///
-    /// This is a replacement for `fillMaxWidth` designed for situations when the composable may be in an `HStack` and does not want to push other items out.
-    ///
-    /// - Warning: Containers with child content should use the `ComposeContainer` composable instead.
+    /// - Seealso: `flexibleWidth(ideal:min:max:)`
     @Composable public func fillWidth() -> Modifier {
-        guard let fill = EnvironmentValues.shared._fillWidth else {
-            return fillMaxWidth()
-        }
-        return then(fill())
+        return flexibleWidth(max: Float.flexibleFill)
     }
 
-    /// Fill available remaining height.
+    /// Fill available height similar to `.frame(maxHeight: .infinity)`.
     ///
-    /// This is a replacement for `fillMaxHeight` designed for situations when the composable may be in an `VStack` and does not want to push other items out.
-    ///
-    /// - Warning: Containers with child content should use the `ComposeContainer` composable instead.
+    /// - Seealso: `flexibleHeight(ideal:min:max:)`
     @Composable public func fillHeight() -> Modifier {
-        guard let fill = EnvironmentValues.shared._fillHeight else {
-            return fillMaxHeight()
-        }
-        return then(fill())
+        return flexibleHeight(max: Float.flexibleFill)
     }
 
-    /// Fill available remaining size.
+    /// Fill available size similar to `.frame(maxWidth: .infinity, maxHeight: .infinity)`.
     ///
-    /// This is a replacement for `fillMaxSize` designed for situations when the composable may be in an `HStack` or `VStack` and does not want to push other items out.
-    ///
-    /// - Warning: Containers with child content should use the `ComposeContainer` composable instead.
+    /// - Seealso: `flexibleWidth(ideal:min:max:)`
+    /// - Seealso: `flexibleHeight(ideal:min:max:)`
     @Composable public func fillSize() -> Modifier {
         return fillWidth().fillHeight()
+    }
+
+    /// SwiftUI-like flexible layout.
+    ///
+    /// - Seealso: `.frame(minWidth:idealWidth:maxWidth:)`
+    /// - Warning: Containers with child content should use the `ComposeContainer` composable instead.
+    @Composable public func flexibleWidth(ideal: Float? = nil, min: Float? = nil, max: Float? = nil) -> Modifier {
+        if let flexible = EnvironmentValues.shared._flexibleWidth {
+            return then(flexible(ideal, min, max))
+        } else {
+            let modifier = max == Float.flexibleFill ? fillMaxWidth() : self
+            return modifier.applyNonExpandingFlexibleWidth(ideal: ideal, min: min, max: max)
+        }
+    }
+
+    /// SwiftUI-like flexible layout.
+    ///
+    ///
+    /// - Seealso: `.frame(minHeight:idealHeight:maxHeight:)`
+    /// - Warning: Containers with child content should use the `ComposeContainer` composable instead.
+    @Composable public func flexibleHeight(ideal: Float? = nil, min: Float? = nil, max: Float? = nil) -> Modifier {
+        if let flexible = EnvironmentValues.shared._flexibleHeight {
+            return then(flexible(ideal, min, max))
+        } else {
+            let modifier = max == Float.flexibleFill ? fillMaxHeight() : self
+            return modifier.applyNonExpandingFlexibleHeight(ideal: ideal, min: min, max: max)
+        }
+    }
+
+    /// For internal use.
+    func applyNonExpandingFlexibleWidth(ideal: Float? = nil, min: Float? = nil, max: Float? = nil) -> Modifier {
+        if let min, min! > Float(0), let max, max! >= Float(0) {
+            return requiredWidthIn(min: min!.dp, max: max!.dp)
+        } else if let min, min! > Float(0) {
+            return requiredWidthIn(min: min!.dp)
+        } else if let max, max! >= Float(0) {
+            return requiredWidthIn(max: max!.dp)
+        } else {
+            return self
+        }
+    }
+
+    /// For internal use.
+    func applyNonExpandingFlexibleHeight(ideal: Float? = nil, min: Float? = nil, max: Float? = nil) -> Modifier {
+        if let min, min! > Float(0), let max, max! >= Float(0) {
+            return requiredHeightIn(min: min!.dp, max: max!.dp)
+        } else if let min, min! > Float(0) {
+            return requiredHeightIn(min: min!.dp)
+        } else if let max, max! >= Float(0) {
+            return requiredHeightIn(max: max!.dp)
+        } else {
+            return self
+        }
     }
 
     /// Add padding equivalent to the given safe area.

--- a/Sources/SkipUI/SkipUI/Compose/ComposeLayouts.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeLayouts.swift
@@ -3,9 +3,7 @@
 #if SKIP
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.requiredHeight
-import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.requiredWidth
-import androidx.compose.foundation.layout.requiredWidthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
@@ -19,7 +17,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntRect
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 /// Compose a view with the given frame.
@@ -46,27 +43,19 @@ import androidx.compose.ui.unit.dp
 
 /// Compose a view with the given frame.
 @Composable func FrameLayout(content: Renderable, context: ComposeContext, minWidth: CGFloat?, idealWidth: CGFloat?, maxWidth: CGFloat?, minHeight: CGFloat?, idealHeight: CGFloat?, maxHeight: CGFloat?, alignment: Alignment) {
-    var thenModifier: Modifier = Modifier
-    if maxWidth == .infinity {
-        if let minWidth, minWidth > 0.0 {
-            thenModifier = thenModifier.requiredWidthIn(min: minWidth.dp)
-        }
-    } else if minWidth != nil || maxWidth != nil {
-        thenModifier = thenModifier.requiredWidthIn(min: minWidth != nil ? minWidth!.dp : Dp.Unspecified, max: maxWidth != nil ? maxWidth!.dp : Dp.Unspecified)
-    }
-    if maxHeight == .infinity {
-        if let minHeight, minHeight > 0.0 {
-            thenModifier = thenModifier.requiredHeightIn(min: minHeight.dp)
-        }
-    } else if minHeight != nil || maxHeight != nil {
-        thenModifier = thenModifier.requiredHeightIn(min: minHeight != nil ? minHeight!.dp : Dp.Unspecified, max: maxHeight != nil ? maxHeight!.dp : Dp.Unspecified)
-    }
-    ComposeContainer(modifier: context.modifier, fillWidth: maxWidth == Double.infinity, fixedWidth: maxWidth != nil && maxWidth != Double.infinity, minWidth: minWidth != nil && minWidth != Double.infinity && minWidth! > 0.0, fillHeight: maxHeight == Double.infinity, fixedHeight: maxHeight != nil && maxHeight != Double.infinity, minHeight: minHeight != nil && minHeight != Double.infinity && minHeight! > 0.0, then: thenModifier) { modifier in
+    ComposeFlexibleContainer(modifier: context.modifier, flexibleWidthIdeal: flexibleLayoutFloat(idealWidth), flexibleWidthMin: flexibleLayoutFloat(minWidth), flexibleWidthMax: flexibleLayoutFloat(maxWidth), flexibleHeightIdeal: flexibleLayoutFloat(idealHeight), flexibleHeightMin: flexibleLayoutFloat(minHeight), flexibleHeightMax: flexibleLayoutFloat(maxHeight)) { modifier in
         let contentContext = context.content()
         Box(modifier: modifier, contentAlignment: alignment.asComposeAlignment()) {
             content.Render(context: contentContext)
         }
     }
+}
+
+private func flexibleLayoutFloat(_ value: CGFloat?) -> Float? {
+    guard let value else {
+        return nil
+    }
+    return value == Double.infinity ? Float.flexibleFill : Float(value)
 }
 
 /// Compose a view with the given background.

--- a/Sources/SkipUI/SkipUI/Containers/HStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/HStack.swift
@@ -12,6 +12,7 @@ import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -46,10 +47,20 @@ public struct HStack : View, Renderable {
 
     #if SKIP
     @Composable override func Render(context: ComposeContext) {
-        let rowAlignment = alignment.asComposeAlignment()
-        let rowArrangement = Arrangement.spacedBy((spacing ?? 8.0).dp, alignment: androidx.compose.ui.Alignment.CenterHorizontally)
-
         let renderables = content.Evaluate(context: context, options: 0).filter { !$0.isSwiftUIEmptyView }
+        let layoutImplementationVersion = EnvironmentValues.shared._layoutImplementationVersion
+
+        let rowAlignment = alignment.asComposeAlignment()
+        let rowArrangement: Arrangement.Horizontal
+        // Compose's internal arrangement code puts space between all elements, but we do not want to add space
+        // around `Spacers`. So we arrange with no spacing and add our own spacing elements
+        let adaptiveSpacing = spacing != 0.0 && layoutImplementationVersion != 0 && renderables.any { $0.strip() is Spacer }
+        if adaptiveSpacing {
+            rowArrangement = Arrangement.spacedBy(0.dp, alignment: androidx.compose.ui.Alignment.CenterHorizontally)
+        } else {
+            rowArrangement = Arrangement.spacedBy((spacing ?? 8.0).dp, alignment: androidx.compose.ui.Alignment.CenterHorizontally)
+        }
+
         let idMap: (Renderable) -> Any? = { TagModifier.on(content: $0, role: .id)?.value }
         let ids = renderables.mapNotNull(idMap)
         let rememberedIds = remember { mutableSetOf<Any>() }
@@ -64,14 +75,39 @@ public struct HStack : View, Renderable {
             rememberedNewIds.clear()
             let contentContext = context.content()
             ComposeContainer(axis: .horizontal, modifier: context.modifier) { modifier in
-                Row(modifier: modifier, horizontalArrangement: rowArrangement, verticalAlignment: rowAlignment) {
-                    let fillWidthModifier = Modifier.weight(Float(1.0)) // Only available in Row context
-                    EnvironmentValues.shared.setValues {
-                        $0.set_fillWidthModifier(fillWidthModifier)
-                        return ComposeResult.ok
-                    } in: {
-                        for renderable in renderables {
-                            renderable.Render(context: contentContext)
+                if layoutImplementationVersion == 0 {
+                    // Maintain previous layout behavior for users who opt in
+                    Row(modifier: modifier, horizontalArrangement: rowArrangement, verticalAlignment: rowAlignment) {
+                        let flexibleWidthModifier: (Float?, Float?, Float?) -> Modifier = { ideal, min, max in
+                            var modifier: Modifier = Modifier
+                            if max?.isFlexibleExpanding == true {
+                                modifier = modifier.weight(Float(1)) // Only available in Row context
+                            }
+                            return modifier.applyNonExpandingFlexibleWidth(ideal: ideal, min: min, max: max)
+                        }
+                        EnvironmentValues.shared.setValues {
+                            $0.set_flexibleWidthModifier(flexibleWidthModifier)
+                            return ComposeResult.ok
+                        } in: {
+                            var lastWasSpacer: Bool? = nil
+                            for renderable in renderables {
+                                lastWasSpacer = RenderSpaced(renderable: renderable, adaptiveSpacing: adaptiveSpacing, lastWasSpacer: lastWasSpacer, layoutImplementationVersion: layoutImplementationVersion, context: contentContext)
+                            }
+                        }
+                    }
+                } else {
+                    HStackRow(modifier: modifier, horizontalArrangement: rowArrangement, verticalAlignment: rowAlignment) {
+                        let flexibleWidthModifier: (Float?, Float?, Float?) -> Modifier = {
+                            return Modifier.flexible($0, $1, $2) // Only available in HStackRow context
+                        }
+                        EnvironmentValues.shared.setValues {
+                            $0.set_flexibleWidthModifier(flexibleWidthModifier)
+                            return ComposeResult.ok
+                        } in: {
+                            var lastWasSpacer: Bool? = nil
+                            for renderable in renderables {
+                                lastWasSpacer = RenderSpaced(renderable: renderable, adaptiveSpacing: adaptiveSpacing, lastWasSpacer: lastWasSpacer, layoutImplementationVersion: layoutImplementationVersion, context: contentContext)
+                            }
                         }
                     }
                 }
@@ -79,13 +115,13 @@ public struct HStack : View, Renderable {
         } else {
             ComposeContainer(axis: .horizontal, modifier: context.modifier) { modifier in
                 let arguments = AnimatedContentArguments(renderables: renderables, idMap: idMap, ids: ids, rememberedIds: rememberedIds, newIds: newIds, rememberedNewIds: rememberedNewIds, isBridged: isBridged)
-                RenderAnimatedContent(context: context, modifier: modifier, arguments: arguments, rowAlignment: rowAlignment, rowArrangement: rowArrangement)
+                RenderAnimatedContent(context: context, modifier: modifier, arguments: arguments, rowAlignment: rowAlignment, rowArrangement: rowArrangement, adaptiveSpacing: adaptiveSpacing, layoutImplementationVersion: layoutImplementationVersion)
             }
         }
     }
 
     // SKIP INSERT: @OptIn(ExperimentalAnimationApi::class)
-    @Composable private func RenderAnimatedContent(context: ComposeContext, modifier: Modifier, arguments: AnimatedContentArguments, rowAlignment: androidx.compose.ui.Alignment.Vertical, rowArrangement: Arrangement.Horizontal) {
+    @Composable private func RenderAnimatedContent(context: ComposeContext, modifier: Modifier, arguments: AnimatedContentArguments, rowAlignment: androidx.compose.ui.Alignment.Vertical, rowArrangement: Arrangement.Horizontal, adaptiveSpacing: Bool, layoutImplementationVersion: Int) {
         AnimatedContent(modifier: modifier, targetState: arguments.renderables, transitionSpec: {
             EnterTransition.None.togetherWith(ExitTransition.None).using(SizeTransform(clip: false) { initialSize, targetSize in
                  if initialSize.width <= 0 || initialSize.height <= 0 {
@@ -106,27 +142,78 @@ public struct HStack : View, Renderable {
             if animation == nil {
                 arguments.rememberedNewIds.clear()
             }
-            Row(horizontalArrangement: rowArrangement, verticalAlignment: rowAlignment) {
-                let fillWidthModifier = Modifier.weight(Float(1.0)) // Only available in Row context
-                EnvironmentValues.shared.setValues {
-                    $0.set_fillWidthModifier(fillWidthModifier)
-                    return ComposeResult.ok
-                } in: {
-                    for renderable in state {
-                        let id = arguments.idMap(renderable)
+            if layoutImplementationVersion == 0 {
+                // Maintain previous layout behavior for users who opt in
+                Row(horizontalArrangement: rowArrangement, verticalAlignment: rowAlignment) {
+                    let flexibleWidthModifier: (Float?, Float?, Float?) -> Modifier = { ideal, min, max in
                         var modifier: Modifier = Modifier
-                        if let animation, arguments.newIds.contains(id) || arguments.rememberedNewIds.contains(id) || !arguments.ids.contains(id) {
-                            let transition = TransitionModifier.transition(for: renderable) ?? OpacityTransition.shared
-                            let spec = animation.asAnimationSpec()
-                            let enter = transition.asEnterTransition(spec: spec)
-                            let exit = transition.asExitTransition(spec: spec)
-                            modifier = modifier.animateEnterExit(enter: enter, exit: exit)
+                        if max?.isFlexibleExpanding == true {
+                            modifier = modifier.weight(Float(1)) // Only available in Row context
                         }
-                        renderable.Render(context: context.content(modifier: modifier))
+                        return modifier.applyNonExpandingFlexibleWidth(ideal: ideal, min: min, max: max)
+                    }
+                    EnvironmentValues.shared.setValues {
+                        $0.set_flexibleWidthModifier(flexibleWidthModifier)
+                        return ComposeResult.ok
+                    } in: {
+                        var lastWasSpacer: Bool? = nil
+                        for renderable in state {
+                            let id = arguments.idMap(renderable)
+                            var modifier: Modifier = Modifier
+                            if let animation, arguments.newIds.contains(id) || arguments.rememberedNewIds.contains(id) || !arguments.ids.contains(id) {
+                                let transition = TransitionModifier.transition(for: renderable) ?? OpacityTransition.shared
+                                let spec = animation.asAnimationSpec()
+                                let enter = transition.asEnterTransition(spec: spec)
+                                let exit = transition.asExitTransition(spec: spec)
+                                modifier = modifier.animateEnterExit(enter: enter, exit: exit)
+                            }
+                            let contentContext = context.content(modifier: modifier)
+                            lastWasSpacer = RenderSpaced(renderable: renderable, adaptiveSpacing: adaptiveSpacing, lastWasSpacer: lastWasSpacer, layoutImplementationVersion: layoutImplementationVersion, context: contentContext)
+                        }
+                    }
+                }
+            } else {
+                HStackRow(horizontalArrangement: rowArrangement, verticalAlignment: rowAlignment) {
+                    let flexibleWidthModifier: (Float?, Float?, Float?) -> Modifier = {
+                        return Modifier.flexible($0, $1, $2) // Only available in HStackRow context
+                    }
+                    EnvironmentValues.shared.setValues {
+                        $0.set_flexibleWidthModifier(flexibleWidthModifier)
+                        return ComposeResult.ok
+                    } in: {
+                        var lastWasSpacer: Bool? = nil
+                        for renderable in state {
+                            let id = arguments.idMap(renderable)
+                            var modifier: Modifier = Modifier
+                            if let animation, arguments.newIds.contains(id) || arguments.rememberedNewIds.contains(id) || !arguments.ids.contains(id) {
+                                let transition = TransitionModifier.transition(for: renderable) ?? OpacityTransition.shared
+                                let spec = animation.asAnimationSpec()
+                                let enter = transition.asEnterTransition(spec: spec)
+                                let exit = transition.asExitTransition(spec: spec)
+                                modifier = modifier.animateEnterExit(enter: enter, exit: exit)
+                            }
+                            let contentContext = context.content(modifier: modifier)
+                            lastWasSpacer = RenderSpaced(renderable: renderable, adaptiveSpacing: adaptiveSpacing, lastWasSpacer: lastWasSpacer, layoutImplementationVersion: layoutImplementationVersion, context: contentContext)
+                        }
                     }
                 }
             }
         }, label: "HStack")
+    }
+
+    @Composable private func RenderSpaced(renderable: Renderable, adaptiveSpacing: Bool, lastWasSpacer: Bool?, layoutImplementationVersion: Int, context: ComposeContext) -> Bool? {
+        guard adaptiveSpacing else {
+            renderable.Render(context: context)
+            return nil
+        }
+
+        // Add spacing before any non-Spacer or Spacer without a minLength
+        let spacer = renderable.strip() as? Spacer
+        if spacer?.minLength == nil, lastWasSpacer == false || (lastWasSpacer == nil && spacer != nil) {
+            androidx.compose.foundation.layout.Spacer(modifier: Modifier.width((spacing ?? 8.0).dp))
+        }
+        renderable.Render(context: context)
+        return spacer != nil
     }
     #else
     public var body: some View {

--- a/Sources/SkipUI/SkipUI/Containers/LazyHGrid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyHGrid.swift
@@ -64,7 +64,7 @@ public struct LazyHGrid: View, Renderable {
         let renderables = content.EvaluateLazyItems(level: 0, context: context)
         let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
-        ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true, fillHeight: false) { modifier in
+        ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true) { modifier in
             // Integrate with our scroll-to-top and ScrollViewReader
             let gridState = rememberLazyGridState()
             let flingBehavior = scrollTargetBehavior is ViewAlignedScrollTargetBehavior ? rememberSnapFlingBehavior(gridState, SnapPosition.Start) : ScrollableDefaults.flingBehavior()

--- a/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
@@ -56,7 +56,7 @@ public struct LazyHStack : View, Renderable {
         let renderables = content.EvaluateLazyItems(level: 0, context: context)
         let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
-        ComposeContainer(axis: .horizontal, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true, fillHeight: false) { modifier in
+        ComposeContainer(axis: .horizontal, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true) { modifier in
             // Integrate with ScrollViewReader
             let listState = rememberLazyListState()
             let flingBehavior = scrollTargetBehavior is ViewAlignedScrollTargetBehavior ? rememberSnapFlingBehavior(listState, SnapPosition.Start) : ScrollableDefaults.flingBehavior()

--- a/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
@@ -71,7 +71,7 @@ public struct LazyVGrid: View, Renderable {
         let renderables = content.EvaluateLazyItems(level: 0, context: context)
         let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
-        ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true, fillHeight: false) { modifier in
+        ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true) { modifier in
             IgnoresSafeAreaLayout(expandInto: [], checkEdges: [.bottom], modifier: modifier) { _, safeAreaEdges in
                 // Integrate with our scroll-to-top and ScrollViewReader
                 let gridState = rememberLazyGridState(initialFirstVisibleItemIndex = isSearchable ? 1 : 0)

--- a/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
@@ -64,7 +64,7 @@ public struct LazyVStack : View, Renderable {
         let renderables = content.EvaluateLazyItems(level: 0, context: context)
         let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
-        ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true, fillHeight: false) { modifier in
+        ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true) { modifier in
             IgnoresSafeAreaLayout(expandInto: [], checkEdges: [.bottom], modifier: modifier) { _, safeAreaEdges in
                 // Integrate with our scroll-to-top and ScrollViewReader
                 let listState = rememberLazyListState(initialFirstVisibleItemIndex = isSearchable ? 1 : 0)

--- a/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
+++ b/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
@@ -609,24 +609,24 @@ extension EnvironmentValues {
         set { setBuiltinValue(key: "_contentPadding", value: newValue, defaultValue: { EdgeInsets() }) }
     }
 
-    var _fillHeight: (@Composable () -> Modifier)? {
-        get { builtinValue(key: "_fillHeight", defaultValue: { nil }) as! (@Composable () -> Modifier)? }
-        set { setBuiltinValue(key: "_fillHeight", value: newValue, defaultValue: { nil }) }
+    var _flexibleHeight: (@Composable (Float?, Float?, Float?) -> Modifier)? {
+        get { builtinValue(key: "_flexibleHeight", defaultValue: { nil }) as! (@Composable (Float?, Float?, Float?) -> Modifier)? }
+        set { setBuiltinValue(key: "_flexibleHeight", value: newValue, defaultValue: { nil }) }
     }
 
-    var _fillWidth: (@Composable () -> Modifier)? {
-        get { builtinValue(key: "_fillWidth", defaultValue: { nil }) as! (@Composable () -> Modifier)? }
-        set { setBuiltinValue(key: "_fillWidth", value: newValue, defaultValue: { nil }) }
+    var _flexibleWidth: (@Composable (Float?, Float?, Float?) -> Modifier)? {
+        get { builtinValue(key: "_flexibleWidth", defaultValue: { nil }) as! (@Composable (Float?, Float?, Float?) -> Modifier)? }
+        set { setBuiltinValue(key: "_flexibleWidth", value: newValue, defaultValue: { nil }) }
     }
 
-    var _fillHeightModifier: Modifier? {
-        get { builtinValue(key: "_fillHeightModifier", defaultValue: { nil }) as! Modifier? }
-        set { setBuiltinValue(key: "_fillHeightModifier", value: newValue, defaultValue: { nil }) }
+    var _flexibleHeightModifier: ((Float?, Float?, Float?) -> Modifier)? {
+        get { builtinValue(key: "_flexibleHeightModifier", defaultValue: { nil }) as! ((Float?, Float?, Float?) -> Modifier)? }
+        set { setBuiltinValue(key: "_flexibleHeightModifier", value: newValue, defaultValue: { nil }) }
     }
 
-    var _fillWidthModifier: Modifier? {
-        get { builtinValue(key: "_fillWidthModifier", defaultValue: { nil }) as! Modifier? }
-        set { setBuiltinValue(key: "_fillWidthModifier", value: newValue, defaultValue: { nil }) }
+    var _flexibleWidthModifier: ((Float?, Float?, Float?) -> Modifier)? {
+        get { builtinValue(key: "_flexibleWidthModifier", defaultValue: { nil }) as! ((Float?, Float?, Float?) -> Modifier)? }
+        set { setBuiltinValue(key: "_flexibleWidthModifier", value: newValue, defaultValue: { nil }) }
     }
 
     var _foregroundStyle: ShapeStyle? {
@@ -677,6 +677,12 @@ extension EnvironmentValues {
     var _layoutScrollAxes: Axis.Set {
         get { builtinValue(key: "_layoutScrollAxes", defaultValue: { Axis.Set(rawValue: 0) }) as! Axis.Set }
         set { setBuiltinValue(key: "_layoutScrollAxes", value: newValue, defaultValue: { Axis.Set(rawValue: 0) }) }
+    }
+
+    /// Allow users to revert to previous layout behavior.
+    var _layoutImplementationVersion: Int {
+        get { builtinValue(key: "_layoutImplementationVersion", defaultValue: { 1 }) as! Int }
+        set { setBuiltinValue(key: "_layoutImplementationVersion", value: newValue, defaultValue: { 1 }) }
     }
 
     var _lineLimitReservesSpace: Bool? {

--- a/Sources/SkipUI/SkipUI/Text/Text.swift
+++ b/Sources/SkipUI/SkipUI/Text/Text.swift
@@ -395,6 +395,7 @@ struct _Text: View, Renderable, Equatable {
         let redaction = EnvironmentValues.shared.redactionReasons
         let styleInfo = Text.styleInfo(textEnvironment: textEnvironment, redaction: redaction, context: context)
         let animatable = styleInfo.style.asAnimatable(context: context)
+        var modifier = Modifier.flexibleWidth(max: Float.flexibleUnknownNonExpanding).then(context.modifier)
         var options: Material3TextOptions
         if let locnode {
             let layoutResult = remember { mutableStateOf<TextLayoutResult?>(nil) }
@@ -405,7 +406,6 @@ struct _Text: View, Renderable, Equatable {
             }
             let annotatedText = annotatedString(markdown: locnode, interpolations: interpolations, linkColor: linkColor, isUppercased: styleInfo.isUppercased, isLowercased: styleInfo.isLowercased, isRedacted: isPlaceholder)
             let links = annotatedText.getUrlAnnotations(start: 0, end: annotatedText.length)
-            var modifier = context.modifier
             if !links.isEmpty() {
                 let currentText = rememberUpdatedState(annotatedText)
                 let currentHandler = rememberUpdatedState(EnvironmentValues.shared.openURL)
@@ -431,7 +431,7 @@ struct _Text: View, Renderable, Equatable {
             } else if styleInfo.isLowercased {
                 text = text.lowercased()
             }
-            options = Material3TextOptions(text: text, modifier: context.modifier, color: styleInfo.color ?? androidx.compose.ui.graphics.Color.Unspecified, maxLines: maxLines, minLines: minLines, style: animatable.value, textDecoration: textDecoration, textAlign: textAlign)
+            options = Material3TextOptions(text: text, modifier: modifier, color: styleInfo.color ?? androidx.compose.ui.graphics.Color.Unspecified, maxLines: maxLines, minLines: minLines, style: animatable.value, textDecoration: textDecoration, textAlign: textAlign)
         }
         if let updateOptions = EnvironmentValues.shared._material3Text {
             options = updateOptions(options)

--- a/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
+++ b/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
@@ -623,6 +623,16 @@ extension View {
         return self
     }
 
+    /// Allow users to revert to previous layout versions.
+    // SKIP @bridge
+    public func layoutImplementationVersion(_ version: Int) -> any View {
+        #if SKIP
+        return environment(\._layoutImplementationVersion, version)
+        #else
+        return self
+        #endif
+    }
+
     @available(*, unavailable)
     public func luminanceToAlpha() -> some View {
         return self

--- a/Sources/SkipUI/SkipUI/View/View.swift
+++ b/Sources/SkipUI/SkipUI/View/View.swift
@@ -54,7 +54,7 @@ extension View {
 
     /// This function provides a non-escaping compose context to avoid excessive recompositions when the calling code
     /// does not need to access the underlying `Renderables`.
-    @Composable private func _ComposeContent(context: ComposeContext) {
+    @Composable public func _ComposeContent(context: ComposeContext) {
         for renderable in Evaluate(context: context, options: 0) {
             renderable.Render(context: context)
         }

--- a/Tests/SkipUITests/LayoutTests.swift
+++ b/Tests/SkipUITests/LayoutTests.swift
@@ -577,19 +577,6 @@ final class LayoutTests: XCSnapshotTestCase {
 
         . . . . . . . . . . . .
         . . . . . . . . . . . .
-        """, android: """
-
-
-
-
-
-
-
-
-        . . . . . . . . . . . .
-        . . . . . . . . . . . .
-
-        . . . . . . . . . . . .
         """))
     }
 
@@ -614,19 +601,6 @@ final class LayoutTests: XCSnapshotTestCase {
         . .                 . .
         . .                 . .
         . .                 . .
-        """, android: """
-                        . . . .
-                        . . . .
-                        . . . .
-                        . . . .
-                        . . . .
-                        . . . .
-                        . . . .
-                        . . . .
-                        . . . .
-                        . . . .
-                        . . . .
-                        . . . .
         """))
     }
 


### PR DESCRIPTION
Improves HStack, VStack, Spacer, and .frame behavior.

To revert all or part of the app to using Skip's previous layout behavior, use the .layoutImplementationVersion(0) modifier on root of the View hierarchy to revert
