### PR TITLE
Support custom PreferenceKeys and onPreferenceChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -1686,6 +1686,11 @@ Support levels:
     </tr>
     <tr>
       <td>✅</td>
+      <td><code>.onPreferenceChange</code></td>
+    </tr>
+   <tr>
+    <tr>
+      <td>✅</td>
       <td><code>.onReceive</code></td>
     </tr>
     <tr>
@@ -1733,6 +1738,10 @@ Support levels:
     <tr>
       <td>✅</td>
       <td><code>.position</code></td>
+    </tr>
+    <tr>
+      <td>✅</td>
+      <td><code>.preference</code></td>
     </tr>
    <tr>
       <td>✅</td>

--- a/Sources/SkipUI/SkipUI/Color/ColorScheme.swift
+++ b/Sources/SkipUI/SkipUI/Color/ColorScheme.swift
@@ -103,14 +103,10 @@ extension View {
 }
 
 struct PreferredColorSchemePreferenceKey: PreferenceKey {
-    typealias Value = PreferredColorScheme
+    static let defaultValue = PreferredColorScheme(colorScheme: nil)
 
-    // SKIP DECLARE: companion object: PreferenceKeyCompanion<PreferredColorScheme>
-    final class Companion: PreferenceKeyCompanion {
-        let defaultValue = PreferredColorScheme(colorScheme: nil)
-        func reduce(value: inout PreferredColorScheme, nextValue: () -> PreferredColorScheme) {
-            value = nextValue()
-        }
+    static func reduce(value: inout PreferredColorScheme, nextValue: () -> PreferredColorScheme) {
+        value = nextValue()
     }
 }
 

--- a/Sources/SkipUI/SkipUI/Commands/Search.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Search.swift
@@ -218,14 +218,10 @@ final class SearchableStateModifier: RenderModifier {
 }
 
 struct SearchableStatePreferenceKey: PreferenceKey {
-    typealias Value = SearchableState?
+    static let defaultValue: SearchableState? = nil
 
-    // SKIP DECLARE: companion object: PreferenceKeyCompanion<SearchableState?>
-    class Companion: PreferenceKeyCompanion {
-        let defaultValue: SearchableState? = nil
-        func reduce(value: inout SearchableState?, nextValue: () -> SearchableState?) {
-            value = nextValue()
-        }
+    static func reduce(value: inout SearchableState?, nextValue: () -> SearchableState?) {
+        value = nextValue()
     }
 }
 

--- a/Sources/SkipUI/SkipUI/Commands/Toolbar.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Toolbar.swift
@@ -483,14 +483,10 @@ extension View {
 
 #if SKIP
 struct ToolbarPreferenceKey: PreferenceKey {
-    typealias Value = ToolbarPreferences
+    static let defaultValue = ToolbarPreferences()
 
-    // SKIP DECLARE: companion object: PreferenceKeyCompanion<ToolbarPreferences>
-    class Companion: PreferenceKeyCompanion {
-        let defaultValue = ToolbarPreferences()
-        func reduce(value: inout ToolbarPreferences, nextValue: () -> ToolbarPreferences) {
-            value = value.reduce(nextValue())
-        }
+    static func reduce(value: inout ToolbarPreferences, nextValue: () -> ToolbarPreferences) {
+        value = value.reduce(nextValue())
     }
 }
 
@@ -563,14 +559,10 @@ struct ToolbarBarPreferences: Equatable {
 }
 
 struct ToolbarContentPreferenceKey: PreferenceKey {
-    typealias Value = ToolbarContentPreferences
+    static let defaultValue = ToolbarContentPreferences()
 
-    // SKIP DECLARE: companion object: PreferenceKeyCompanion<ToolbarContentPreferences>
-    class Companion: PreferenceKeyCompanion {
-        let defaultValue = ToolbarContentPreferences()
-        func reduce(value: inout ToolbarContentPreferences, nextValue: () -> ToolbarContentPreferences) {
-            value = value.reduce(nextValue())
-        }
+    static func reduce(value: inout ToolbarContentPreferences, nextValue: () -> ToolbarContentPreferences) {
+        value = value.reduce(nextValue())
     }
 }
 

--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -1138,28 +1138,20 @@ public struct Material3BottomAppBarOptions {
 }
 
 struct NavigationDestinationsPreferenceKey: PreferenceKey {
-    typealias Value = NavigationDestinations
+    static let defaultValue: NavigationDestinations = [:]
 
-    // SKIP DECLARE: companion object: PreferenceKeyCompanion<NavigationDestinations>
-    final class Companion: PreferenceKeyCompanion {
-        let defaultValue: NavigationDestinations = [:]
-        func reduce(value: inout NavigationDestinations, nextValue: () -> NavigationDestinations) {
-            for (type, destination) in nextValue() {
-                value[type] = destination
-            }
+    static func reduce(value: inout NavigationDestinations, nextValue: () -> NavigationDestinations) {
+        for (type, destination) in nextValue() {
+            value[type] = destination
         }
     }
 }
 
 struct NavigationTitlePreferenceKey: PreferenceKey {
-    typealias Value = Text
+    static let defaultValue = Text("")
 
-    // SKIP DECLARE: companion object: PreferenceKeyCompanion<Text>
-    final class Companion: PreferenceKeyCompanion {
-        let defaultValue = Text("")
-        func reduce(value: inout Text, nextValue: () -> Text) {
-            value = nextValue()
-        }
+    static func reduce(value: inout Text, nextValue: () -> Text) {
+        value = nextValue()
     }
 }
 #endif

--- a/Sources/SkipUI/SkipUI/Containers/ScrollView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/ScrollView.swift
@@ -193,14 +193,10 @@ public struct ScrollViewReader : View, Renderable {
 
 #if SKIP
 struct ScrollToTopPreferenceKey: PreferenceKey {
-    typealias Value = ScrollToTopAction
+    static let defaultValue = ScrollToTopAction(key: nil, action: { })
 
-    // SKIP DECLARE: companion object: PreferenceKeyCompanion<ScrollToTopAction>
-    final class Companion: PreferenceKeyCompanion {
-        let defaultValue = ScrollToTopAction(key: nil, action: { })
-        func reduce(value: inout ScrollToTopAction, nextValue: () -> ScrollToTopAction) {
-            value = nextValue()
-        }
+    static func reduce(value: inout ScrollToTopAction, nextValue: () -> ScrollToTopAction) {
+        value = nextValue()
     }
 }
 
@@ -216,14 +212,10 @@ struct ScrollToTopAction : Equatable {
 }
 
 struct ScrollToIDPreferenceKey: PreferenceKey {
-    typealias Value = ScrollToIDAction
+    static let defaultValue = ScrollToIDAction(key: nil, action: { _ in })
 
-    // SKIP DECLARE: companion object: PreferenceKeyCompanion<ScrollToIDAction>
-    final class Companion: PreferenceKeyCompanion {
-        let defaultValue = ScrollToIDAction(key: nil, action: { _ in })
-        func reduce(value: inout ScrollToIDAction, nextValue: () -> ScrollToIDAction) {
-            value = nextValue()
-        }
+    static func reduce(value: inout ScrollToIDAction, nextValue: () -> ScrollToIDAction) {
+        value = nextValue()
     }
 }
 
@@ -239,14 +231,10 @@ struct ScrollToIDAction : Equatable {
 }
 
 struct BuiltinScrollAxisSetPreferenceKey: PreferenceKey {
-    typealias Value = Axis.Set
+    static let defaultValue: Axis.Set = []
 
-    // SKIP DECLARE: companion object: PreferenceKeyCompanion<Axis.Set>
-    final class Companion: PreferenceKeyCompanion {
-        let defaultValue: Axis.Set = []
-        func reduce(value: inout Axis.Set, nextValue: () -> Axis.Set) {
-            value.formUnion(nextValue())
-        }
+    static func reduce(value: inout Axis.Set, nextValue: () -> Axis.Set) {
+        value.formUnion(nextValue())
     }
 }
 #endif

--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -518,14 +518,10 @@ public struct TabView : View, Renderable {
 }
 
 struct TabBarPreferenceKey: PreferenceKey {
-    typealias Value = ToolbarBarPreferences
+    static let defaultValue = ToolbarBarPreferences()
 
-    // SKIP DECLARE: companion object: PreferenceKeyCompanion<ToolbarBarPreferences>
-    class Companion: PreferenceKeyCompanion {
-        let defaultValue = ToolbarBarPreferences()
-        func reduce(value: inout ToolbarBarPreferences, nextValue: () -> ToolbarBarPreferences) {
-            value = value.reduce(nextValue())
-        }
+    static func reduce(value: inout ToolbarBarPreferences, nextValue: () -> ToolbarBarPreferences) {
+        value = value.reduce(nextValue())
     }
 }
 

--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -599,14 +599,10 @@ public protocol CustomPresentationDetent {
 
 #if SKIP
 struct PresentationDetentPreferenceKey: PreferenceKey {
-    typealias Value = PresentationDetentPreferences
+    static let defaultValue = PresentationDetentPreferences()
 
-    // SKIP DECLARE: companion object: PreferenceKeyCompanion<PresentationDetentPreferences>
-    class Companion: PreferenceKeyCompanion {
-        let defaultValue = PresentationDetentPreferences()
-        func reduce(value: inout PresentationDetentPreferences, nextValue: () -> PresentationDetentPreferences) {
-            value = value.reduce(nextValue())
-        }
+    static func reduce(value: inout PresentationDetentPreferences, nextValue: () -> PresentationDetentPreferences) {
+        value = value.reduce(nextValue())
     }
 }
 
@@ -1100,14 +1096,10 @@ final class BackDismissDisabledModifier: RenderModifier {
 }
 
 struct InteractiveDismissDisabledPreferenceKey: PreferenceKey {
-    typealias Value = Bool
+    static let defaultValue = false
 
-    // SKIP DECLARE: companion object: PreferenceKeyCompanion<Boolean>
-    final class Companion: PreferenceKeyCompanion {
-        let defaultValue = false
-        func reduce(value: inout Bool, nextValue: () -> Bool) {
-            value = nextValue()
-        }
+    static func reduce(value: inout Bool, nextValue: () -> Bool) {
+        value = nextValue()
     }
 }
 #endif


### PR DESCRIPTION
We also generalize the preference-related functions to handle nil preference values and for bridging them to SkipFuseUI.

The onPreferenceChange implementation was taken from  the following PR:
https://github.com/skiptools/skip-ui/pull/210

This patch requires transpiler support! See corresponding skipstone patch.
