### PR TITLE
Added support for multilineTextAlignment for text fields

### DIFF
--- a/Sources/SkipUI/SkipUI/Text/TextField.swift
+++ b/Sources/SkipUI/SkipUI/Text/TextField.swift
@@ -4,7 +4,6 @@
 import Foundation
 #if SKIP
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions


### PR DESCRIPTION
This PR adds support for the `.multilineTextAlignment` view modifier for text fields.

**Before:**
<img width="400" height="210" alt="Bildschirmfoto 2025-12-15 um 01 14 41" src="https://github.com/user-attachments/assets/6cbe4711-a7cb-41ac-a4ae-dd2c5bc46253" />

**After:**
<img width="400" height="210" alt="image" src="https://github.com/user-attachments/assets/8609043a-a084-470b-a28a-087597f243c8" />

**Example:**
```swift
TextField(".multilineTextAlignment(.leading)", text: $text)
    .multilineTextAlignment(.leading)
TextField(".multilineTextAlignment(.center)", text: $text)
    .multilineTextAlignment(.center)
TextField(".multilineTextAlignment(.trailing)", text: $text)
    .multilineTextAlignment(.trailing)
```

---

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

