### PR TITLE
Bugfix: Status bar does not update when a sheet is presented on Android

### DIFF
--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -38,7 +38,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.key
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -56,11 +56,14 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogWindowProvider
+import androidx.core.view.WindowCompat
 #elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 #endif
@@ -100,89 +103,89 @@ let overlayPresentationCornerRadius = 16.0
         let onDismissRequest = {
             isPresented.set(false)
         }
-        let dark = MaterialTheme.colorScheme.background.luminance() < 0.5
-        key(dark) {
-            let properties = ModalBottomSheetProperties(shouldDismissOnBackPress: !backDismissDisabled, isAppearanceLightStatusBars = !dark, isAppearanceLightNavigationBars = !dark)
-            ModalBottomSheet(onDismissRequest: onDismissRequest, sheetState: sheetState, sheetMaxWidth: sheetMaxWidth, sheetGesturesEnabled: !interactiveDismissDisabled, containerColor: androidx.compose.ui.graphics.Color.Unspecified, shape: shape, dragHandle: nil, contentWindowInsets: { WindowInsets(0.dp, 0.dp, 0.dp, 0.dp) }, properties: properties) {
-                let verticalSizeClass = EnvironmentValues.shared.verticalSizeClass
-                let isEdgeToEdge = EnvironmentValues.shared._isEdgeToEdge == true
-                let sheetDepth = EnvironmentValues.shared._sheetDepth
-                var systemBarEdges: Edge.Set = isFullScreen ? .all : [.top, .bottom]
+        let properties = ModalBottomSheetProperties(shouldDismissOnBackPress: !backDismissDisabled)
+        ModalBottomSheet(onDismissRequest: onDismissRequest, sheetState: sheetState, sheetMaxWidth: sheetMaxWidth, sheetGesturesEnabled: !interactiveDismissDisabled, containerColor: androidx.compose.ui.graphics.Color.Unspecified, shape: shape, dragHandle: nil, contentWindowInsets: { WindowInsets(0.dp, 0.dp, 0.dp, 0.dp) }, properties: properties) {
+            
+            SyncSystemBarsWithTheme()
+            
+            let verticalSizeClass = EnvironmentValues.shared.verticalSizeClass
+            let isEdgeToEdge = EnvironmentValues.shared._isEdgeToEdge == true
+            let sheetDepth = EnvironmentValues.shared._sheetDepth
+            var systemBarEdges: Edge.Set = isFullScreen ? .all : [.top, .bottom]
 
-                let detentPreferences = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<PresentationDetentPreferences>, Any>) { mutableStateOf(Preference<PresentationDetentPreferences>(key: PresentationDetentPreferenceKey.self)) }
-                let detentPreferencesCollector = PreferenceCollector<PresentationDetentPreferences>(key: PresentationDetentPreferences.self, state: detentPreferences)
-                let reducedDetentPreferences = detentPreferences.value.reduced
+            let detentPreferences = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<PresentationDetentPreferences>, Any>) { mutableStateOf(Preference<PresentationDetentPreferences>(key: PresentationDetentPreferenceKey.self)) }
+            let detentPreferencesCollector = PreferenceCollector<PresentationDetentPreferences>(key: PresentationDetentPreferences.self, state: detentPreferences)
+            let reducedDetentPreferences = detentPreferences.value.reduced
 
-                if !isFullScreen && verticalSizeClass != .compact {
-                    systemBarEdges.remove(.top)
-                    if !isEdgeToEdge {
-                        systemBarEdges.remove(.bottom)
-                    }
-
-                    // TODO: add custom cases
-                    // Add inset depending on the presentation detent
-                    let inset: Dp
-                    let screenHeight = LocalConfiguration.current.screenHeightDp.dp
-                    let detent: PresentationDetent = reducedDetentPreferences.detent
-                    switch detent {
-                    case .medium:
-                        inset = screenHeight / 2
-                    case let .height(h):
-                        inset = screenHeight - h.dp
-                    case let .fraction(f):
-                        inset = screenHeight * Float(1 - f)
-                    default:
-                        // We have to delay access to WindowInsets until inside the ModalBottomSheet composable to get accurate values
-                        let topBarHeight = WindowInsets.safeDrawing.asPaddingValues().calculateTopPadding()
-                        // Add 44 for draggable area in case content is not draggable
-                        inset = topBarHeight + (24 * sheetDepth).dp + 44.dp
-                    }
-
-                    topInset.value = inset
-                    // Draw the drag handle and the presentation root content area below it
-                    androidx.compose.foundation.layout.Spacer(modifier: Modifier.height(inset - handleHeight - handlePadding))
-                    Row(modifier: Modifier.fillMaxWidth(), horizontalArrangement: Arrangement.Center) {
-                        Capsule().fill(Color.primary.opacity(0.4)).frame(width: 60.0, height: Double(handleHeight.value)).Compose(context: context)
-                    }
-                    androidx.compose.foundation.layout.Spacer(modifier: Modifier.height(handlePadding))
-                } else if !isEdgeToEdge {
-                    systemBarEdges.remove(.top)
+            if !isFullScreen && verticalSizeClass != .compact {
+                systemBarEdges.remove(.top)
+                if !isEdgeToEdge {
                     systemBarEdges.remove(.bottom)
-                    let inset = WindowInsets.safeDrawing.asPaddingValues().calculateTopPadding()
-                    topInset.value = inset
-                    // Push the presentation root content area below the top bar
-                    androidx.compose.foundation.layout.Spacer(modifier: Modifier.height(inset))
-                } else {
-                    topInset.value = 0.dp
                 }
 
-                let clipShape = RoundedCornerShape(topStart: isFullScreen ? 0.dp : overlayPresentationCornerRadius.dp, topEnd: isFullScreen ? 0.dp : overlayPresentationCornerRadius.dp)
-                Box(modifier: Modifier.weight(Float(1.0)).clip(clipShape).nestedScroll(DisableScrollToDismissConnection())) {
-                    // Place outside of PresentationRoot recomposes
-                    let stateSaver = remember { ComposeStateSaver() }
-                    let presentationContext = context.content(stateSaver: stateSaver)
-                    // Place inside of ModalBottomSheet, which renders content async
-                    PresentationRoot(context: presentationContext, absoluteSystemBarEdges: systemBarEdges) { context in
-                        EnvironmentValues.shared.setValues {
-                            if !isFullScreen {
-                                $0.set_sheetDepth(sheetDepth + 1)
-                            }
-                            $0.setdismiss(DismissAction(action: { isPresented.set(false) }))
-                            return ComposeResult.ok
-                        } in: {
-                            PreferenceValues.shared.collectPreferences([interactiveDismissDisabledCollector, detentPreferencesCollector]) {
-                                for renderable in contentRenderables {
-                                    renderable.Render(context: context)
-                                }
+                // TODO: add custom cases
+                // Add inset depending on the presentation detent
+                let inset: Dp
+                let screenHeight = LocalConfiguration.current.screenHeightDp.dp
+                let detent: PresentationDetent = reducedDetentPreferences.detent
+                switch detent {
+                case .medium:
+                    inset = screenHeight / 2
+                case let .height(h):
+                    inset = screenHeight - h.dp
+                case let .fraction(f):
+                    inset = screenHeight * Float(1 - f)
+                default:
+                    // We have to delay access to WindowInsets until inside the ModalBottomSheet composable to get accurate values
+                    let topBarHeight = WindowInsets.safeDrawing.asPaddingValues().calculateTopPadding()
+                    // Add 44 for draggable area in case content is not draggable
+                    inset = topBarHeight + (24 * sheetDepth).dp + 44.dp
+                }
+
+                topInset.value = inset
+                // Draw the drag handle and the presentation root content area below it
+                androidx.compose.foundation.layout.Spacer(modifier: Modifier.height(inset - handleHeight - handlePadding))
+                Row(modifier: Modifier.fillMaxWidth(), horizontalArrangement: Arrangement.Center) {
+                    Capsule().fill(Color.primary.opacity(0.4)).frame(width: 60.0, height: Double(handleHeight.value)).Compose(context: context)
+                }
+                androidx.compose.foundation.layout.Spacer(modifier: Modifier.height(handlePadding))
+            } else if !isEdgeToEdge {
+                systemBarEdges.remove(.top)
+                systemBarEdges.remove(.bottom)
+                let inset = WindowInsets.safeDrawing.asPaddingValues().calculateTopPadding()
+                topInset.value = inset
+                // Push the presentation root content area below the top bar
+                androidx.compose.foundation.layout.Spacer(modifier: Modifier.height(inset))
+            } else {
+                topInset.value = 0.dp
+            }
+
+            let clipShape = RoundedCornerShape(topStart: isFullScreen ? 0.dp : overlayPresentationCornerRadius.dp, topEnd: isFullScreen ? 0.dp : overlayPresentationCornerRadius.dp)
+            Box(modifier: Modifier.weight(Float(1.0)).clip(clipShape).nestedScroll(DisableScrollToDismissConnection())) {
+                // Place outside of PresentationRoot recomposes
+                let stateSaver = remember { ComposeStateSaver() }
+                let presentationContext = context.content(stateSaver: stateSaver)
+                // Place inside of ModalBottomSheet, which renders content async
+                PresentationRoot(context: presentationContext, absoluteSystemBarEdges: systemBarEdges) { context in
+                    EnvironmentValues.shared.setValues {
+                        if !isFullScreen {
+                            $0.set_sheetDepth(sheetDepth + 1)
+                        }
+                        $0.setdismiss(DismissAction(action: { isPresented.set(false) }))
+                        return ComposeResult.ok
+                    } in: {
+                        PreferenceValues.shared.collectPreferences([interactiveDismissDisabledCollector, detentPreferencesCollector]) {
+                            for renderable in contentRenderables {
+                                renderable.Render(context: context)
                             }
                         }
                     }
                 }
-                if !isEdgeToEdge {
-                    // Move the presentation root content area above the bottom bar
-                    let inset = max(0.dp, WindowInsets.systemBars.asPaddingValues().calculateBottomPadding() - WindowInsets.ime.asPaddingValues().calculateBottomPadding())
-                    androidx.compose.foundation.layout.Spacer(modifier: Modifier.height(inset))
-                }
+            }
+            if !isEdgeToEdge {
+                // Move the presentation root content area above the bottom bar
+                let inset = max(0.dp, WindowInsets.systemBars.asPaddingValues().calculateBottomPadding() - WindowInsets.ime.asPaddingValues().calculateBottomPadding())
+                androidx.compose.foundation.layout.Spacer(modifier: Modifier.height(inset))
             }
         }
     }
@@ -202,6 +205,20 @@ let overlayPresentationCornerRadius = 16.0
                 onDismissState.value?()
             }
         }
+    }
+}
+
+@Composable private func SyncSystemBarsWithTheme() {
+    let view = LocalView.current
+    let dark = MaterialTheme.colorScheme.background.luminance() < 0.5
+    DisposableEffect(dark) {
+        if let window = (view.parent as? DialogWindowProvider)?.window {
+            WindowCompat.getInsetsController(window, view).apply {
+                isAppearanceLightStatusBars = !dark
+                isAppearanceLightNavigationBars = !dark
+            }
+        }
+        onDispose { }
     }
 }
 


### PR DESCRIPTION
Currently, when a sheet is presented on Android, the status bar style does not update accordingly. Instead of using black icons / text in light mode and white icons / text in dark mode, the icons always use the light mode variant, making the status bar basically invisible in dark mode.

Steps to Reproduce:
- Run the "Skip Showcase" app on Android
- Navigate to "Showcase" => "Sheet" and open any of the examples
- Switch the system appearance from light to dark mode (or vice versa)
- Observe the status bar icons
  => The status bar icons always use the light mode variant (dark icons / text) and do not adapt to the system theme ⚡

This PR solves the issue by updating the status bar style of the dialog window that presents the sheet depending on the current system appearance (similar to this [PR](https://github.com/skiptools/skipapp-showcase/pull/50)).

**Example (Before):**
![Before](https://github.com/user-attachments/assets/a826d955-a60c-409f-8b7b-4f3aa24cb62f)

**Example (After):**
![After](https://github.com/user-attachments/assets/6244c7b5-0697-4d6a-9752-4d1ee980b617)

---

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

