### PR TITLE
Changed KeyboardType.numberPad mapping to KeyboardType.NumberPassword

### DIFF
--- a/Sources/SkipUI/SkipUI/UIKit/UIKeyboardType.swift
+++ b/Sources/SkipUI/SkipUI/UIKit/UIKeyboardType.swift
@@ -32,7 +32,7 @@ public enum UIKeyboardType: Int {
         case .URL:
             return KeyboardType.Uri
         case .numberPad:
-            return KeyboardType.Number
+            return KeyboardType.NumberPassword
         case .phonePad:
             return KeyboardType.Phone
         case .namePhonePad:


### PR DESCRIPTION
This PR changes the mapped iOS `KeyboardType.numberPad` from the Compose variant `KeyboardType.Number` to `KeyboardType.NumberPassword`, as the latter fits the iOS style better, in my opinion.

**iOS:**
<img width="1206" height="740" alt="image" src="https://github.com/user-attachments/assets/b8d19408-b9ed-415b-a955-e6580df65158" />

**Android (Before):**
<img width="1080" height="766" alt="image" src="https://github.com/user-attachments/assets/a7cc34ed-e4ae-4702-b874-2e3ed262859d" />

**Android (After):**
<img width="1080" height="760" alt="image" src="https://github.com/user-attachments/assets/4695de1c-72bf-4fc8-b46d-4b30dedbbc10" />

In case the user needs a keyboard with a decimal separator, he should use `KeyboardType.decimalPad` instead.

---

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

