### PR TITLE
Added support for truncation mode

### DIFF
--- a/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
+++ b/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
@@ -318,6 +318,8 @@ extension EnvironmentValues {
             return EnvironmentSupport(builtinValue: scrollDismissesKeyboardMode.rawValue)
         case "timeZone":
             return EnvironmentSupport(builtinValue: timeZone.identifier)
+        case "truncationMode":
+            return EnvironmentSupport(builtinValue: truncationMode?.rawValue)
         case "verticalSizeClass":
             return EnvironmentSupport(builtinValue: verticalSizeClass?.rawValue)
         default:
@@ -375,6 +377,11 @@ extension EnvironmentValues {
         case "timeZone":
             if let identifier = value?.builtinValue as? String, let timeZone = TimeZone(identifier: identifier) {
                 settimeZone(timeZone)
+            }
+            return true
+        case "truncationMode":
+            if let rawValue = value?.builtinValue as? Int {
+                settruncationMode(Text.TruncationMode(rawValue: rawValue))
             }
             return true
         case "verticalSizeClass":
@@ -436,7 +443,7 @@ extension EnvironmentValues {
         get { builtinValue(key: "lineLimit", defaultValue: { nil }) as! Int? }
         set { setBuiltinValue(key: "lineLimit", value: newValue, defaultValue: { nil }) }
     }
-
+    
     public var locale: Locale {
         get { Locale(LocalConfiguration.current.locales[0]) }
         set {
@@ -493,6 +500,11 @@ extension EnvironmentValues {
     public var timeZone: TimeZone {
         get { builtinValue(key: "timeZone", defaultValue: { TimeZone.current }) as! TimeZone }
         set { setBuiltinValue(key: "timeZone", value: newValue, defaultValue: { TimeZone.current }) }
+    }
+    
+    public var truncationMode: Text.TruncationMode? {
+        get { builtinValue(key: "truncationMode", defaultValue: { nil }) as! Text.TruncationMode? }
+        set { setBuiltinValue(key: "truncationMode", value: newValue, defaultValue: { nil }) }
     }
 
     public var verticalSizeClass: UserInterfaceSizeClass? {
@@ -570,7 +582,6 @@ extension EnvironmentValues {
     var lineSpacing: CGFloat
     var minimumScaleFactor: CGFloat
     var textCase: Text.Case?
-    var truncationMode: Text.TruncationMode
 
     var allowedDynamicRange: Image.DynamicRange?
     var backgroundMaterial: Material?


### PR DESCRIPTION
Currently the Text does not support the `truncationMode` modifier.
This PR adds support for it by extending the Text and EnvironmentValues structs.

**Example SwiftUI code to test the changes:**
```
let text = "This is a very long text that does not fit into the available space."
Text(text).lineLimit(1).truncationMode(.head)
Text(text).lineLimit(1).truncationMode(.middle)
Text(text).lineLimit(1).truncationMode(.tail)
Text(text + " Multi-line text will also be truncated.").lineLimit(2).truncationMode(.tail)
```

**Example (iOS):**
<img width="1206" height="720" alt="iOS" src="https://github.com/user-attachments/assets/07f77722-ca99-4523-be0e-b55bf8a5c776" />

**Example (Android):**
<img width="1080" height="576" alt="Android" src="https://github.com/user-attachments/assets/3da6e53f-0d86-4e68-81e4-a8da840269f8" />

---

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

