### PR TITLE
Add descriptions for Edge.Set and EdgeInsets (for logging)

### DIFF
--- a/Sources/SkipUI/SkipUI/Layout/Edge.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Edge.swift
@@ -8,7 +8,7 @@ public enum Edge : Int, Hashable, CaseIterable {
     case bottom = 4 // For bridging
     case trailing = 8 // For bridging
 
-    public struct Set : OptionSet, Equatable {
+    public struct Set : OptionSet, Equatable, CustomStringConvertible {
         public let rawValue: Int
 
         public init(rawValue: Int) {
@@ -26,6 +26,26 @@ public enum Edge : Int, Hashable, CaseIterable {
 
         public init(_ e: Edge) {
             self.rawValue = e.rawValue
+        }
+        
+        public var description: String {
+            var edges: [String] = []
+            if self.contains(Edge.Set.top) {
+                edges.append("top")
+            }
+            if self.contains(Edge.Set.leading) {
+                edges.append("leading")
+            }
+            if self.contains(Edge.Set.bottom) {
+                edges.append("bottom")
+            }
+            if self.contains(Edge.Set.trailing) {
+                edges.append("trailing")
+            }
+            if edges.isEmpty {
+                return "[]"
+            }
+            return "[\(edges.joined(separator: ","))]"
         }
     }
 }

--- a/Sources/SkipUI/SkipUI/Layout/EdgeInsets.swift
+++ b/Sources/SkipUI/SkipUI/Layout/EdgeInsets.swift
@@ -9,7 +9,7 @@ import androidx.compose.ui.unit.dp
 import struct CoreGraphics.CGFloat
 #endif
 
-public struct EdgeInsets : Equatable {
+public struct EdgeInsets : Equatable, CustomStringConvertible {
     public var top: CGFloat
     public var leading: CGFloat
     public var bottom: CGFloat
@@ -27,6 +27,10 @@ public struct EdgeInsets : Equatable {
         return PaddingValues(start: leading.dp, top: top.dp, end: trailing.dp, bottom: bottom.dp)
     }
     #endif
+
+    public var description: String {
+        return "EdgeInsets(top: \(top), leading: \(leading), bottom: \(bottom), trailing: \(trailing))"
+    }
 }
 
 #endif


### PR DESCRIPTION
These make easier to log edge sets and EdgeInsets objects on Android. Now, you can just `print("edges: \(edges)")` and it'll do the right thing.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

