### PR TITLE
Add badge, symbolVariant, blendMode, drawingGroup, luminanceToAlpha, and allowsHitTesting modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1364,6 +1364,10 @@ Support levels:
       <td><code>.alert</code></td>
     </tr>
     <tr>
+      <td>✅</td>
+      <td><code>.allowsHitTesting</code></td>
+    </tr>
+    <tr>
       <td>🟡</td>
       <td>
             <details>
@@ -1408,6 +1412,17 @@ Support levels:
       <td>🟢</td>
       <td>
           <details>
+              <summary><code>.blendMode</code></summary>
+              <ul>
+                  <li><code>.plusDarker</code> and <code>.plusLighter</code> both map to Compose <code>Plus</code></li>
+              </ul>
+          </details>
+       </td>
+    </tr>
+    <tr>
+      <td>🟢</td>
+      <td>
+          <details>
               <summary><code>.blur</code></summary>
               <ul>
                   <li><code>opaque</code> parameter is ignored</li>
@@ -1422,6 +1437,10 @@ Support levels:
     <tr>
       <td>✅</td>
       <td><code>.border</code> (<a href="https://skip.tools/docs/components/border/">example</a>)</td>
+    </tr>
+    <tr>
+      <td>✅</td>
+      <td><code>.brightness</code></td>
     </tr>
     <tr>
       <td>🟢</td>
@@ -1462,12 +1481,20 @@ Support levels:
               <ul>
                   <li>See also <a href="#colorscheme">ColorScheme</a></li>
               </ul>
-          </details> 
+          </details>
       </td>
     </tr>
     <tr>
       <td>✅</td>
+      <td><code>.colorMultiply</code></td>
+    </tr>
+    <tr>
+      <td>✅</td>
       <td><code>.confirmationDialog</code> (<a href="https://skip.tools/docs/components/confirmationdialog/">example</a>)</td>
+    </tr>
+    <tr>
+      <td>✅</td>
+      <td><code>.contrast</code></td>
     </tr>
     <tr>
       <td>✅</td>
@@ -1493,6 +1520,17 @@ Support levels:
     <tr>
       <td>✅</td>
       <td><code>.disabled</code></td>
+    </tr>
+    <tr>
+      <td>🟢</td>
+      <td>
+          <details>
+              <summary><code>.drawingGroup</code></summary>
+              <ul>
+                  <li><code>opaque</code> and <code>colorMode</code> parameters are ignored</li>
+              </ul>
+          </details>
+       </td>
     </tr>
     <tr>
       <td>✅</td>
@@ -1567,6 +1605,10 @@ Support levels:
     <tr>
       <td>✅</td>
       <td><code>.hidden</code></td>
+    </tr>
+    <tr>
+      <td>✅</td>
+      <td><code>.hueRotation</code></td>
     </tr>
     <tr>
       <td>🟢</td>
@@ -1652,6 +1694,10 @@ Support levels:
     <tr>
       <td>✅</td>
       <td><code>.listStyle</code></td>
+    </tr>
+    <tr>
+      <td>✅</td>
+      <td><code>.luminanceToAlpha</code></td>
     </tr>
     <tr>
       <td>✅</td>
@@ -1879,8 +1925,12 @@ Support levels:
               <ul>
                   <li><code>func rotation3DEffect(_ angle: Angle, axis: (x: CGFloat, y: CGFloat, z: CGFloat), perspective: CGFloat = 1.0) -> some View</code></li>
               </ul>
-          </details>      
+          </details>
        </td>
+    </tr>
+    <tr>
+      <td>✅</td>
+      <td><code>.saturation</code></td>
     </tr>
     <tr>
       <td>🟢</td>
@@ -1891,7 +1941,7 @@ Support levels:
                   <li><code>func scale(_ scale: CGFloat) -> any Shape</code></li>
                   <li><code>func scale(x: CGFloat = 1.0, y: CGFloat = 1.0) -> any Shape</code></li>
               </ul>
-          </details>      
+          </details>
        </td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -1409,6 +1409,18 @@ Support levels:
       <td><code>.backgroundStyle</code></td>
     </tr>
     <tr>
+      <td>🟡</td>
+      <td>
+          <details>
+              <summary><code>.badge</code></summary>
+              <ul>
+                  <li>Supported on <code>List</code> items</li>
+                  <li>Not yet supported on <code>TabView</code></li>
+              </ul>
+          </details>
+      </td>
+    </tr>
+    <tr>
       <td>🟢</td>
       <td>
           <details>
@@ -1547,6 +1559,10 @@ Support levels:
     <tr>
       <td>✅</td>
       <td><code>.focused</code></td>
+    </tr>
+    <tr>
+      <td>✅</td>
+      <td><code>.flipsForRightToLeftLayoutDirection</code></td>
     </tr>
     <tr>
       <td>✅</td>
@@ -2075,6 +2091,10 @@ Support levels:
     <tr>
       <td>✅</td>
       <td><code>.submitLabel</code></td>
+    </tr>
+    <tr>
+      <td>✅</td>
+      <td><code>.symbolVariant</code></td>
     </tr>
     <tr>
       <td>✅</td>

--- a/Sources/SkipUI/SkipUI/Components/Image.swift
+++ b/Sources/SkipUI/SkipUI/Components/Image.swift
@@ -359,21 +359,25 @@ public struct Image : View, Renderable, Equatable {
     }
 
     @Composable private func RenderSystem(systemName: String, aspectRatio: Double?, contentMode: ContentMode?, context: ComposeContext) {
+        // Apply symbol variants from the environment
+        let symbolVariants = EnvironmentValues.shared._symbolVariants
+        let effectiveName = symbolVariants.applied(to: systemName)
+
         // we first check to see if there is a bundled symbol with the name in any of the asset catalogs, in which case we will use that symbol
         // note that we can only use the `main` (i.e., top-level) bundle to look up image resources, since Image(systemName:) does not accept a bundle
-        if let symbolResourceURL = rememberCachedAsset(contentsCache, AssetKey(name: systemName)) { _ in symbolResourceURL(name: systemName, bundle: Bundle.main) } {
-            RenderSymbolImage(name: systemName, url: symbolResourceURL, label: nil, aspectRatio: aspectRatio, contentMode: contentMode, context: context)
+        if let symbolResourceURL = rememberCachedAsset(contentsCache, AssetKey(name: effectiveName)) { _ in symbolResourceURL(name: effectiveName, bundle: Bundle.main) } {
+            RenderSymbolImage(name: effectiveName, url: symbolResourceURL, label: nil, aspectRatio: aspectRatio, contentMode: contentMode, context: context)
             return
        }
 
         // fall back to default symbol names
-        guard let image = Self.composeImageVector(named: systemName) else {
-            logger.warning("Unable to find system image named: \(systemName)")
+        guard let image = Self.composeImageVector(named: effectiveName) else {
+            logger.warning("Unable to find system image named: \(effectiveName)")
             Icon(imageVector: Icons.Default.Warning, contentDescription: "missing icon")
             return
         }
 
-        RenderScaledImageVector(image: image, name: systemName, aspectRatio: aspectRatio, contentMode: contentMode, context: context)
+        RenderScaledImageVector(image: image, name: effectiveName, aspectRatio: aspectRatio, contentMode: contentMode, context: context)
     }
 
     @Composable private func RenderScaledImageVector(image: ImageVector, name: String, aspectRatio: Double?, contentMode: ContentMode?, context: ComposeContext) {

--- a/Sources/SkipUI/SkipUI/Compose/ComposeModifiers.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeModifiers.swift
@@ -222,4 +222,28 @@ class ColorMultiplyModifier : DrawModifier {
         }
     }
 }
+
+class LuminanceToAlphaModifier : DrawModifier {
+    // SKIP DECLARE: override fun ContentDrawScope.draw()
+    override func draw() {
+        // Luminance to alpha matrix: converts RGB luminance to alpha channel
+        // Formula: alpha = 0.2126*R + 0.7152*G + 0.0722*B (standard luminance coefficients)
+        // The matrix sets RGB to 0 and moves luminance to alpha
+        let luminanceMatrix = ColorMatrix(floatArrayOf(
+            Float(0), Float(0), Float(0), Float(0), Float(0),
+            Float(0), Float(0), Float(0), Float(0), Float(0),
+            Float(0), Float(0), Float(0), Float(0), Float(0),
+            Float(0.2126), Float(0.7152), Float(0.0722), Float(0), Float(0)
+        ))
+        let luminanceFilter = ColorFilter.colorMatrix(luminanceMatrix)
+        let paint = Paint().apply {
+            colorFilter = luminanceFilter
+        }
+        drawIntoCanvas {
+            $0.saveLayer(Rect(Float(0.0), Float(0.0), size.width, size.height), paint)
+            drawContent()
+            $0.restore()
+        }
+    }
+}
 #endif

--- a/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
+++ b/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
@@ -844,6 +844,21 @@ extension EnvironmentValues {
         get { builtinValue(key: "_tint", defaultValue: { nil }) as! Color? }
         set { setBuiltinValue(key: "_tint", value: newValue, defaultValue: { nil }) }
     }
+
+    var _badge: Text? {
+        get { builtinValue(key: "_badge", defaultValue: { nil }) as! Text? }
+        set { setBuiltinValue(key: "_badge", value: newValue, defaultValue: { nil }) }
+    }
+
+    var _badgeProminence: BadgeProminence {
+        get { builtinValue(key: "_badgeProminence", defaultValue: { BadgeProminence.standard }) as! BadgeProminence }
+        set { setBuiltinValue(key: "_badgeProminence", value: newValue, defaultValue: { BadgeProminence.standard }) }
+    }
+
+    var _symbolVariants: SymbolVariants {
+        get { builtinValue(key: "_symbolVariants", defaultValue: { SymbolVariants.none }) as! SymbolVariants }
+        set { setBuiltinValue(key: "_symbolVariants", value: newValue, defaultValue: { SymbolVariants.none }) }
+    }
 }
 #endif
 

--- a/Sources/SkipUI/SkipUI/Graphics/BlendMode.swift
+++ b/Sources/SkipUI/SkipUI/Graphics/BlendMode.swift
@@ -2,28 +2,57 @@
 // SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
 #if !SKIP_BRIDGE
 
-public enum BlendMode : Hashable {
-    case normal
-    case multiply
-    case screen
-    case overlay
-    case darken
-    case lighten
-    case colorDodge
-    case colorBurn
-    case softLight
-    case hardLight
-    case difference
-    case exclusion
-    case hue
-    case saturation
-    case color
-    case luminosity
-    case sourceAtop
-    case destinationOver
-    case destinationOut
-    case plusDarker
-    case plusLighter
+public enum BlendMode : Int, Hashable, CaseIterable {
+    case normal = 0
+    case multiply = 1
+    case screen = 2
+    case overlay = 3
+    case darken = 4
+    case lighten = 5
+    case colorDodge = 6
+    case colorBurn = 7
+    case softLight = 8
+    case hardLight = 9
+    case difference = 10
+    case exclusion = 11
+    case hue = 12
+    case saturation = 13
+    case color = 14
+    case luminosity = 15
+    case sourceAtop = 16
+    case destinationOver = 17
+    case destinationOut = 18
+    case plusDarker = 19
+    case plusLighter = 20
 }
+
+#if SKIP
+extension BlendMode {
+    func asComposeBlendMode() -> androidx.compose.ui.graphics.BlendMode {
+        switch self {
+        case .normal: return androidx.compose.ui.graphics.BlendMode.SrcOver
+        case .multiply: return androidx.compose.ui.graphics.BlendMode.Multiply
+        case .screen: return androidx.compose.ui.graphics.BlendMode.Screen
+        case .overlay: return androidx.compose.ui.graphics.BlendMode.Overlay
+        case .darken: return androidx.compose.ui.graphics.BlendMode.Darken
+        case .lighten: return androidx.compose.ui.graphics.BlendMode.Lighten
+        case .colorDodge: return androidx.compose.ui.graphics.BlendMode.ColorDodge
+        case .colorBurn: return androidx.compose.ui.graphics.BlendMode.ColorBurn
+        case .softLight: return androidx.compose.ui.graphics.BlendMode.Softlight
+        case .hardLight: return androidx.compose.ui.graphics.BlendMode.Hardlight
+        case .difference: return androidx.compose.ui.graphics.BlendMode.Difference
+        case .exclusion: return androidx.compose.ui.graphics.BlendMode.Exclusion
+        case .hue: return androidx.compose.ui.graphics.BlendMode.Hue
+        case .saturation: return androidx.compose.ui.graphics.BlendMode.Saturation
+        case .color: return androidx.compose.ui.graphics.BlendMode.Color
+        case .luminosity: return androidx.compose.ui.graphics.BlendMode.Luminosity
+        case .sourceAtop: return androidx.compose.ui.graphics.BlendMode.SrcAtop
+        case .destinationOver: return androidx.compose.ui.graphics.BlendMode.DstOver
+        case .destinationOut: return androidx.compose.ui.graphics.BlendMode.DstOut
+        case .plusDarker, .plusLighter: return androidx.compose.ui.graphics.BlendMode.Plus
+        }
+    }
+}
+#endif
 
 #endif

--- a/Sources/SkipUI/SkipUI/System/BadgeProminence.swift
+++ b/Sources/SkipUI/SkipUI/System/BadgeProminence.swift
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
 #if !SKIP_BRIDGE
 
-public enum BadgeProminence : Hashable {
-    case decreased
-    case standard
-    case increased
+public enum BadgeProminence : Int, Hashable, Sendable {
+    case decreased = 0
+    case standard = 1
+    case increased = 2
 }
 
 #endif

--- a/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
+++ b/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
@@ -155,19 +155,30 @@ extension View {
         #endif
     }
 
-    @available(*, unavailable)
-    public func badge(_ count: Int) -> some View {
+    // SKIP @bridge
+    public func badge(_ count: Int) -> any View {
+        #if SKIP
+        if count == 0 {
+            return ModifiedContent(content: self, modifier: BadgeModifier(badge: nil))
+        } else {
+            return ModifiedContent(content: self, modifier: BadgeModifier(badge: Text(verbatim: String(count))))
+        }
+        #else
         return self
+        #endif
     }
 
-    @available(*, unavailable)
-    public func badge(_ label: Text?) -> some View {
+    // SKIP @bridge
+    public func badge(_ label: Text?) -> any View {
+        #if SKIP
+        return ModifiedContent(content: self, modifier: BadgeModifier(badge: label))
+        #else
         return self
+        #endif
     }
 
-    @available(*, unavailable)
-    public func badge(_ key: LocalizedStringKey) -> some View {
-        return self
+    public func badge(_ key: LocalizedStringKey) -> any View {
+        return badge(Text(key))
     }
 
     @available(*, unavailable)
@@ -175,14 +186,22 @@ extension View {
         return self
     }
 
-    @available(*, unavailable)
-    public func badge(_ label: String) -> some View {
-        return self
+    // SKIP @bridge
+    public func badge(_ label: String) -> any View {
+        return badge(Text(verbatim: label))
     }
 
-    @available(*, unavailable)
-    public func badgeProminence(_ prominence: BadgeProminence) -> some View {
+    public func badgeProminence(_ prominence: BadgeProminence) -> any View {
+        #if SKIP
+        return ModifiedContent(content: self, modifier: BadgeModifier(prominence: prominence))
+        #else
         return self
+        #endif
+    }
+
+    // SKIP @bridge
+    public func badgeProminence(bridgedRawValue: Int) -> any View {
+        return badgeProminence(BadgeProminence(rawValue: bridgedRawValue) ?? .standard)
     }
 
     public func blendMode(_ blendMode: BlendMode) -> any View {

--- a/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
+++ b/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
@@ -31,6 +31,7 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -291,7 +292,13 @@ extension View {
 
     // SKIP @bridge
     public func compositingGroup() -> any View {
+        #if SKIP
+        return ModifiedContent(content: self, modifier: RenderModifier {
+            return $0.modifier.graphicsLayer(compositingStrategy: CompositingStrategy.Offscreen)
+        })
+        #else
         return self
+        #endif
     }
 
     @available(*, unavailable)
@@ -471,9 +478,23 @@ extension View {
         return self
     }
 
-    @available(*, unavailable)
-    public func flipsForRightToLeftLayoutDirection(_ enabled: Bool) -> some View {
+    // SKIP @bridge
+    public func flipsForRightToLeftLayoutDirection(_ enabled: Bool) -> any View {
+        #if SKIP
+        if !enabled {
+            return self
+        }
+        return ModifiedContent(content: self, modifier: RenderModifier { context in
+            let isRTL = LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
+            if isRTL {
+                return context.modifier.scale(scaleX: Float(-1), scaleY: Float(1))
+            } else {
+                return context.modifier
+            }
+        })
+        #else
         return self
+        #endif
     }
 
     // SKIP @bridge

--- a/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
+++ b/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
@@ -22,7 +22,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
@@ -47,9 +46,19 @@ import struct Foundation.URL
 #endif
 
 extension View {
-    @available(*, unavailable)
-    public func allowsHitTesting(_ enabled: Bool) -> some View {
+    // SKIP @bridge
+    public func allowsHitTesting(_ enabled: Bool) -> any View {
+        #if SKIP
+        if enabled {
+            return self
+        } else {
+            return ModifiedContent(content: self, modifier: RenderModifier {
+                return $0.modifier.clickable(enabled: false, onClick: {})
+            })
+        }
+        #else
         return self
+        #endif
     }
 
     public func aspectRatio(_ ratio: CGFloat? = nil, contentMode: ContentMode) -> any View {
@@ -175,9 +184,22 @@ extension View {
         return self
     }
 
-    @available(*, unavailable)
-    public func blendMode(_ blendMode: BlendMode) -> some View {
+    public func blendMode(_ blendMode: BlendMode) -> any View {
+        #if SKIP
+        return ModifiedContent(content: self, modifier: RenderModifier {
+            return $0.modifier.graphicsLayer(
+                compositingStrategy: CompositingStrategy.Offscreen,
+                blendMode: blendMode.asComposeBlendMode()
+            )
+        })
+        #else
         return self
+        #endif
+    }
+
+    // SKIP @bridge
+    public func blendMode(bridgedRawValue: Int) -> any View {
+        return blendMode(BlendMode(rawValue: bridgedRawValue) ?? .normal)
     }
 
     // SKIP @bridge
@@ -397,9 +419,21 @@ extension View {
         #endif
     }
 
-    @available(*, unavailable)
-    public func drawingGroup(opaque: Bool = false, colorMode: ColorRenderingMode = .nonLinear) -> some View {
+    public func drawingGroup(opaque: Bool = false, colorMode: ColorRenderingMode = .nonLinear) -> any View {
+        #if SKIP
+        // Android ignores opaque and colorMode
+        // drawingGroup forces offscreen rendering - Compose equivalent is CompositingStrategy.Offscreen
+        return ModifiedContent(content: self, modifier: RenderModifier {
+            return $0.modifier.graphicsLayer(compositingStrategy: CompositingStrategy.Offscreen)
+        })
+        #else
         return self
+        #endif
+    }
+
+    // SKIP @bridge
+    public func drawingGroup() -> any View {
+        return drawingGroup(opaque: false, colorMode: .nonLinear)
     }
 
     // No need to @bridge
@@ -667,9 +701,15 @@ extension View {
         #endif
     }
 
-    @available(*, unavailable)
-    public func luminanceToAlpha() -> some View {
+    // SKIP @bridge
+    public func luminanceToAlpha() -> any View {
+        #if SKIP
+        return ModifiedContent(content: self, modifier: RenderModifier {
+            return $0.modifier.then(LuminanceToAlphaModifier())
+        })
+        #else
         return self
+        #endif
     }
 
     public func mask(_ mask: any View, alignment: Alignment = .center) -> any View {

--- a/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
+++ b/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
@@ -292,13 +292,9 @@ extension View {
 
     // SKIP @bridge
     public func compositingGroup() -> any View {
-        #if SKIP
-        return ModifiedContent(content: self, modifier: RenderModifier {
-            return $0.modifier.graphicsLayer(compositingStrategy: CompositingStrategy.Offscreen)
-        })
-        #else
+        // Android: Not currently working - would require opacity modifier to detect
+        // compositingGroup and use saveLayer with alpha instead of graphicsLayer
         return self
-        #endif
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
- blendMode: Maps SwiftUI blend modes to Compose BlendMode via graphicsLayer
- drawingGroup: Forces offscreen rendering using CompositingStrategy.Offscreen
- luminanceToAlpha: Converts RGB luminance to alpha using ColorMatrix filter
- allowsHitTesting: Disables touch interaction via clickable(enabled: false)

Also added raw value Int conformance to BlendMode enum for bridging support and updated README

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

