### PR TITLE
add scrollview modifiers scrollDisabled, scrollIndicators(.hidden)

### DIFF
--- a/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
+++ b/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
@@ -808,6 +808,16 @@ extension EnvironmentValues {
         set { setBuiltinValue(key: "_scrollContentBackground", value: newValue, defaultValue: { nil }) }
     }
 
+    var _scrollDisabled: Bool {
+        get { builtinValue(key: "_scrollDisabled", defaultValue: { false }) as! Bool }
+        set { setBuiltinValue(key: "_scrollDisabled", value: newValue, defaultValue: { false }) }
+    }
+
+    var _scrollIndicatorVisibility: ScrollIndicatorVisibility {
+        get { builtinValue(key: "_scrollIndicatorVisibility", defaultValue: { ScrollIndicatorVisibility.automatic }) as! ScrollIndicatorVisibility }
+        set { setBuiltinValue(key: "_scrollIndicatorVisibility", value: newValue, defaultValue: { ScrollIndicatorVisibility.automatic }) }
+    }
+
     var _scrollTargetBehavior: ScrollTargetBehavior? {
         get { builtinValue(key: "_scrollTargetBehavior", defaultValue: { nil }) as! ScrollTargetBehavior? }
         set { setBuiltinValue(key: "_scrollTargetBehavior", value: newValue, defaultValue: { nil }) }


### PR DESCRIPTION
scroll indicators are hidden by default on android, so this is just for API completeness

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

