### PR TITLE
Added support for alert without title

### DIFF
--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -657,21 +657,21 @@ extension View {
     }
 
     public func alert(_ titleKey: LocalizedStringKey, isPresented: Binding<Bool>, @ViewBuilder actions: () -> any View, @ViewBuilder message: () -> any View) -> any View {
-        return alert(titleKey.patternFormat.isEmpty ? nil : Text(titleKey), isPresented: isPresented, actions: actions, message: message)
+        return alert(Text(titleKey), isPresented: isPresented, actions: actions, message: message)
     }
 
     public func alert(_ titleResource: LocalizedStringResource, isPresented: Binding<Bool>, @ViewBuilder actions: () -> any View, @ViewBuilder message: () -> any View) -> any View {
-        return alert(titleResource.key.isEmpty ? nil : Text(titleResource), isPresented: isPresented, actions: actions, message: message)
+        return alert(Text(titleResource), isPresented: isPresented, actions: actions, message: message)
     }
 
     public func alert(_ title: String, isPresented: Binding<Bool>, @ViewBuilder actions: () -> any View, @ViewBuilder message: () -> any View) -> any View {
-        return alert(title.isEmpty ? nil : Text(verbatim: title), isPresented: isPresented, actions: actions, message: message)
+        return alert(Text(verbatim: title), isPresented: isPresented, actions: actions, message: message)
     }
 
-    public func alert(_ title: Text?, isPresented: Binding<Bool>, @ViewBuilder actions: () -> any View, @ViewBuilder message: () -> any View) -> any View {
+    public func alert(_ title: Text, isPresented: Binding<Bool>, @ViewBuilder actions: () -> any View, @ViewBuilder message: () -> any View) -> any View {
         #if SKIP
         return ModifiedContent(content: self, modifier: PresentationModifier(providesNavigation: true) { context in
-            AlertPresentation(title: title, isPresented: isPresented, context: context, actions: actions(), message: message())
+            AlertPresentation(title: title.localizedTextString().isEmpty ? nil : title, isPresented: isPresented, context: context, actions: actions(), message: message())
         })
         #else
         return self


### PR DESCRIPTION
This PR changes the `alert` view modifier to match the iOS behavior if no / an empty title is used.

**Example SwiftUI code to test the changes:**
```
struct ExampleView: View {
    @State private var showAlert: Bool = false
    
    var body: some View {
        Button("Show Alert") {
            self.showAlert = true
        }.alert("", isPresented: self.$showAlert) {
            Button("Yes") { }
            Button("No") { }
            Button("Cancel", role: .cancel) { }
        }
    }
}
```

**iOS:**
<img width="1206" height="685" src="https://github.com/user-attachments/assets/71633bd2-934e-47f9-bccc-51bddae1cb89" />

**Android (Before):**
<img width="1080" height="669"  src="https://github.com/user-attachments/assets/041dea2c-47db-4888-ab24-9581cc915f22" />

**Android (After):**
<img width="1080" height="484" src="https://github.com/user-attachments/assets/f9a88f26-e58a-44e9-bfef-5581e5a14bde" />

---

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

