### PR TITLE
When no bars specified, toolbarVisibility should be .automatic

### DIFF
--- a/Sources/SkipUI/SkipUI/Commands/Toolbar.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Toolbar.swift
@@ -344,7 +344,7 @@ extension View {
         var view = self
         var bars = placements
         if bars.isEmpty {
-            bars = [.bottomBar, .navigationBar, .tabBar]
+            bars = [.automatic]
         }
         if bars.contains(ToolbarPlacement.tabBar) {
             view = view.preference(key: TabBarPreferenceKey.self, value: ToolbarBarPreferences(visibility: visibility))


### PR DESCRIPTION
Fixes #308

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

