### PR TITLE
Display multiple elements in section headers

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/LazyHGrid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyHGrid.swift
@@ -61,7 +61,12 @@ public struct LazyHGrid: View, Renderable {
         let scrollAxes: Axis.Set = isScrollEnabled ? Axis.Set.horizontal : []
         let scrollTargetBehavior = EnvironmentValues.shared._scrollTargetBehavior
 
-        let renderables = content.EvaluateLazyItems(level: 0, context: context)
+        let renderables = EnvironmentValues.shared.setValuesWithReturn({
+            $0.set_lazySectionStackAxis(Axis.horizontal)
+            return ComposeResult.ok
+        }, in: {
+            content.EvaluateLazyItems(level: 0, context: context)
+        })
         let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
         ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true) { modifier in

--- a/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
@@ -53,7 +53,12 @@ public struct LazyHStack : View, Renderable {
         let scrollAxes: Axis.Set = isScrollEnabled ? Axis.Set.horizontal : []
         let scrollTargetBehavior = EnvironmentValues.shared._scrollTargetBehavior
 
-        let renderables = content.EvaluateLazyItems(level: 0, context: context)
+        let renderables = EnvironmentValues.shared.setValuesWithReturn({
+            $0.set_lazySectionStackAxis(Axis.horizontal)
+            return ComposeResult.ok
+        }, in: {
+            content.EvaluateLazyItems(level: 0, context: context)
+        })
         let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
         ComposeContainer(axis: .horizontal, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true) { modifier in

--- a/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
@@ -68,7 +68,12 @@ public struct LazyVGrid: View, Renderable {
         let searchableState = EnvironmentValues.shared._searchableState
         let isSearchable = searchableState?.isOnNavigationStack == false
 
-        let renderables = content.EvaluateLazyItems(level: 0, context: context)
+        let renderables = EnvironmentValues.shared.setValuesWithReturn({
+            $0.set_lazySectionStackAxis(Axis.vertical)
+            return ComposeResult.ok
+        }, in: {
+            content.EvaluateLazyItems(level: 0, context: context)
+        })
         let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
         ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true) { modifier in

--- a/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
@@ -61,7 +61,12 @@ public struct LazyVStack : View, Renderable {
         let searchableState = EnvironmentValues.shared._searchableState
         let isSearchable = searchableState?.isOnNavigationStack == false
 
-        let renderables = content.EvaluateLazyItems(level: 0, context: context)
+        let renderables = EnvironmentValues.shared.setValuesWithReturn({
+            $0.set_lazySectionStackAxis(Axis.vertical)
+            return ComposeResult.ok
+        }, in: {
+            content.EvaluateLazyItems(level: 0, context: context)
+        })
         let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
         ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true) { modifier in

--- a/Sources/SkipUI/SkipUI/Containers/List.swift
+++ b/Sources/SkipUI/SkipUI/Containers/List.swift
@@ -157,14 +157,18 @@ public final class List : View, Renderable {
     }
 
     @Composable private func RenderList(context: ComposeContext, styling: ListStyling, arguments: ListArguments) {
-        let renderables: kotlin.collections.List<Renderable>
-        if let forEach {
-            renderables = forEach.EvaluateLazyItems(level: 0, context: context)
-        } else if let fixedContent {
-            renderables = fixedContent.EvaluateLazyItems(level: 0, context: context)
-        } else {
-            renderables = listOf()
-        }
+        let renderables = EnvironmentValues.shared.setValuesWithReturn({
+            $0.set_lazySectionStackAxis(Axis.vertical)
+            return ComposeResult.ok
+        }, in: {
+            if let forEach {
+                return forEach.EvaluateLazyItems(level: 0, context: context)
+            } else if let fixedContent {
+                return fixedContent.EvaluateLazyItems(level: 0, context: context)
+            } else {
+                return listOf()
+            }
+        })
 
         var modifier = context.modifier
         if styling.style != .plain {

--- a/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
+++ b/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
@@ -728,6 +728,13 @@ extension EnvironmentValues {
         set { setBuiltinValue(key: "_listStyle", value: newValue, defaultValue: { nil }) }
     }
 
+    /// Axis for stacking multiple views in a Section header/footer when in a lazy container.
+    /// LazyVGrid/LazyVStack/List use .vertical (VStack); LazyHGrid/LazyHStack use .horizontal (HStack).
+    var _lazySectionStackAxis: Axis? {
+        get { builtinValue(key: "_lazySectionStackAxis", defaultValue: { nil }) as! Axis? }
+        set { setBuiltinValue(key: "_lazySectionStackAxis", value: newValue, defaultValue: { nil }) }
+    }
+
     var _material3BottomAppBar: (@Composable (Material3BottomAppBarOptions) -> Material3BottomAppBarOptions)? {
         get { builtinValue(key: "_material3BottomAppBar", defaultValue: { nil }) as! (@Composable (Material3BottomAppBarOptions) -> Material3BottomAppBarOptions)? }
         set { setBuiltinValue(key: "_material3BottomAppBar", value: newValue, defaultValue: { nil }) }


### PR DESCRIPTION
We're adding a new environment variable so the grid/stack/list can convey an axis to the `Section`, so it knows whether to make a VStack or an HStack. 

(Should I be using a SkipUI VStack/HStack for this…? Is there a better way?)

Fixes #311

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

