### PR TITLE
Add support for LazyItemScope scoped modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,29 @@ TextField("Enter username:", text: $username)
     #endif
 ```
 
+You can also apply [scoped modifiers](https://developer.android.com/develop/ui/compose/modifiers#scope-safety). e.g. in a `LazyHStack` you can use modifiers scoped to [`LazyItemScope`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/lazy/LazyItemScope), like `animateItem()`.
+
+```swift
+#if SKIP
+import androidx.compose.foundation.lazy.LazyItemScope
+#endif
+
+...
+
+LazyHStack {
+    ForEach(0..<count, id: \.self) { i in
+        Color.red
+            .frame(width: 20, height: 20)
+            .id(i + 1)
+            #if SKIP
+            .composeModifier(scope: LazyItemScope.self) {
+                $0.animateItem()
+            }
+            #endif
+    }
+}
+```
+
 ## Material
 
 Under the hood, SkipUI uses Android's Material 3 colors and components. While we expect you to use SwiftUI's built-in color schemes (`.preferredColorScheme`) and modifiers (`.background`, `.foregroundStyle`, `.tint`, and so on) for most UI styling, there are some Android customizations that have no SwiftUI equivalent. Skip therefore adds additional, Android-only API for manipulating Material colors and components.

--- a/Sources/SkipUI/SkipUI/Compose/ComposeContext.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeContext.swift
@@ -10,7 +10,7 @@ import androidx.compose.ui.Modifier
 ///
 /// This type is often used as an argument to internal `@Composable` functions and is not mutated by reference, so mark `@Stable`
 /// to avoid excessive recomposition.
-@Stable public struct ComposeContext: Equatable{
+@Stable public struct ComposeContext: Equatable {
     /// Modifiers to apply.
     public var modifier: Modifier = Modifier
 
@@ -19,15 +19,19 @@ import androidx.compose.ui.Modifier
 
     /// Use in conjunction with `rememberSaveable` to store view state.
     public var stateSaver: Saver<Any?, Any> = ComposeStateSaver()
+    
+    /// The scope of the current composition (so users can call scoped modifiers).
+    public var scope: AnyObject?
 
     /// The context to pass to child content of a container view.
     ///
     /// By default, modifiers and the `composer` are reset for child content.
-    public func content(modifier: Modifier = Modifier, composer: Composer? = nil, stateSaver: Saver<Any?, Any>? = nil) -> ComposeContext {
+    public func content(modifier: Modifier = Modifier, composer: Composer? = nil, stateSaver: Saver<Any?, Any>? = nil, scope: AnyObject? = nil) -> ComposeContext {
         var context = self
         context.modifier = modifier
         context.composer = composer
         context.stateSaver = stateSaver ?? self.stateSaver
+        context.scope = scope
         return context
     }
 }

--- a/Sources/SkipUI/SkipUI/Compose/ComposeView.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeView.swift
@@ -60,6 +60,15 @@ extension View {
             return modifier($0.modifier)
         })
     }
+    
+    /// Add the given scoped modifier to the underlying Compose view.
+    // SKIP DECLARE: fun <S: Any> composeModifier(scope: KClass<S>, modifier: S.(Modifier) -> Modifier): View
+    public func composeModifier<S>(scope: S.Type, _ modifier: (Modifier) -> Modifier) throws -> View {
+        return ModifiedContent(content: self, modifier: RenderModifier { context in
+            let scope = try context.scope as S
+            return scope.run { modifier(context.modifier) }
+        })
+    }
     #endif
 
     /// Apply the given `ContentModifier`.

--- a/Sources/SkipUI/SkipUI/Containers/LazyHGrid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyHGrid.swift
@@ -62,7 +62,6 @@ public struct LazyHGrid: View, Renderable {
         let scrollTargetBehavior = EnvironmentValues.shared._scrollTargetBehavior
 
         let renderables = content.EvaluateLazyItems(level: 0, context: context)
-        let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
         ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true) { modifier in
             // Integrate with our scroll-to-top and ScrollViewReader
@@ -92,7 +91,7 @@ public struct LazyHGrid: View, Renderable {
                         item: { renderable, _ in
                             item {
                                 Box(contentAlignment: boxAlignment) {
-                                    renderable.Render(context: itemContext)
+                                    renderable.Render(context: context.content(scope: self))
                                 }
                             }
                         },
@@ -101,37 +100,40 @@ public struct LazyHGrid: View, Renderable {
                             let key: ((Int) -> String)? = identifier == nil ? nil : { composeBundleString(for: identifier!($0 + range.start)) }
                             items(count: count, key: key) { index in
                                 Box(contentAlignment: boxAlignment) {
-                                    factory(index + range.start, itemContext).Render(context: itemContext)
+                                    let scopedContext = context.content(scope: self)
+                                    factory(index + range.start, scopedContext).Render(context: scopedContext)
                                 }
                             }
                         },
                         objectItems: { objects, identifier, _, _, _, _, factory in
                             let key: (Int) -> String = { composeBundleString(for: identifier(objects[$0])) }
                             items(count: objects.count, key: key) { index in
+                                let scopedContext = context.content(scope: self)
                                 Box(contentAlignment: boxAlignment) {
-                                    factory(objects[index], itemContext).Render(context: itemContext)
+                                    factory(objects[index], scopedContext).Render(context: scopedContext)
                                 }
                             }
                         },
                         objectBindingItems: { objectsBinding, identifier, _, _, _, _, _, factory in
                             let key: (Int) -> String = { composeBundleString(for: identifier(objectsBinding.wrappedValue[$0])) }
                             items(count: objectsBinding.wrappedValue.count, key: key) { index in
+                                let scopedContext = context.content(scope: self)
                                 Box(contentAlignment: boxAlignment) {
-                                    factory(objectsBinding, index, itemContext).Render(context: itemContext)
+                                    factory(objectsBinding, index, scopedContext).Render(context: scopedContext)
                                 }
                             }
                         },
                         sectionHeader: { renderable in
                             item(span: { GridItemSpan(maxLineSpan) }) {
                                 Box(contentAlignment: androidx.compose.ui.Alignment.Center) {
-                                    renderable.Render(context: itemContext)
+                                    renderable.Render(context: context.content(scope: self))
                                 }
                             }
                         },
                         sectionFooter: { renderable in
                             item(span: { GridItemSpan(maxLineSpan) }) {
                                 Box(contentAlignment: androidx.compose.ui.Alignment.Center) {
-                                    renderable.Render(context: itemContext)
+                                    renderable.Render(context: context.content(scope: self))
                                 }
                             }
                         }

--- a/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
@@ -54,7 +54,6 @@ public struct LazyHStack : View, Renderable {
         let scrollTargetBehavior = EnvironmentValues.shared._scrollTargetBehavior
 
         let renderables = content.EvaluateLazyItems(level: 0, context: context)
-        let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
         ComposeContainer(axis: .horizontal, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true) { modifier in
             // Integrate with ScrollViewReader
@@ -83,36 +82,36 @@ public struct LazyHStack : View, Renderable {
                         startItemIndex: 0,
                         item: { renderable, _ in
                             item {
-                                renderable.Render(context: itemContext)
+                                renderable.Render(context: context.content(scope: self))
                             }
                         },
                         indexedItems: { range, identifier, _, _, _, _, factory in
                             let count = range.endExclusive - range.start
                             let key: ((Int) -> String)? = identifier == nil ? nil : { composeBundleString(for: identifier!($0 + range.start)) }
                             items(count: count, key: key) { index in
-                                factory(index + range.start, itemContext).Render(context: itemContext)
+                                factory(index + range.start, context.content(scope: self)).Render(context: context.content(scope: self))
                             }
                         },
                         objectItems: { objects, identifier, _, _, _, _, factory in
                             let key: (Int) -> String = { composeBundleString(for: identifier(objects[$0])) }
                             items(count: objects.count, key: key) { index in
-                                factory(objects[index], itemContext).Render(context: itemContext)
+                                factory(objects[index], context.content(scope: self)).Render(context: context.content(scope: self))
                             }
                         },
                         objectBindingItems: { objectsBinding, identifier, _, _, _, _, _, factory in
                             let key: (Int) -> String = { composeBundleString(for: identifier(objectsBinding.wrappedValue[$0])) }
                             items(count: objectsBinding.wrappedValue.count, key: key) { index in
-                                factory(objectsBinding, index, itemContext).Render(context: itemContext)
+                                factory(objectsBinding, index, context.content(scope: self)).Render(context: context.content(scope: self))
                             }
                         },
                         sectionHeader: { renderable in
                             item {
-                                renderable.Render(context: itemContext)
+                                renderable.Render(context: context.content(scope: self))
                             }
                         },
                         sectionFooter: { renderable in
                             item {
-                                renderable.Render(context: itemContext)
+                                renderable.Render(context: context.content(scope: self))
                             }
                         }
                     )

--- a/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
@@ -69,7 +69,6 @@ public struct LazyVGrid: View, Renderable {
         let isSearchable = searchableState?.isOnNavigationStack == false
 
         let renderables = content.EvaluateLazyItems(level: 0, context: context)
-        let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
         ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true) { modifier in
             IgnoresSafeAreaLayout(expandInto: [], checkEdges: [.bottom], modifier: modifier) { _, safeAreaEdges in
@@ -109,7 +108,7 @@ public struct LazyVGrid: View, Renderable {
                             item: { renderable, _ in
                                 item {
                                     Box(contentAlignment: boxAlignment) {
-                                        renderable.Render(context: itemContext)
+                                        renderable.Render(context: context.content(scope: self))
                                     }
                                 }
                             },
@@ -118,7 +117,8 @@ public struct LazyVGrid: View, Renderable {
                                 let key: ((Int) -> String)? = identifier == nil ? nil : { composeBundleString(for: identifier!($0 + range.start)) }
                                 items(count: count, key: key) { index in
                                     Box(contentAlignment: boxAlignment) {
-                                        factory(index + range.start, itemContext).Render(context: itemContext)
+                                        let scopedContext = context.content(scope: self)
+                                        factory(index + range.start, scopedContext).Render(context: scopedContext)
                                     }
                                 }
                             },
@@ -126,7 +126,8 @@ public struct LazyVGrid: View, Renderable {
                                 let key: (Int) -> String = { composeBundleString(for: identifier(objects[$0])) }
                                 items(count: objects.count, key: key) { index in
                                     Box(contentAlignment: boxAlignment) {
-                                        factory(objects[index], itemContext).Render(context: itemContext)
+                                        let scopedContext = context.content(scope: self)
+                                        factory(objects[index], scopedContext).Render(context: scopedContext)
                                     }
                                 }
                             },
@@ -134,21 +135,22 @@ public struct LazyVGrid: View, Renderable {
                                 let key: (Int) -> String = { composeBundleString(for: identifier(objectsBinding.wrappedValue[$0])) }
                                 items(count: objectsBinding.wrappedValue.count, key: key) { index in
                                     Box(contentAlignment: boxAlignment) {
-                                        factory(objectsBinding, index, itemContext).Render(context: itemContext)
+                                        let scopedContext = context.content(scope: self)
+                                        factory(objectsBinding, index, scopedContext).Render(context: scopedContext)
                                     }
                                 }
                             },
                             sectionHeader: { renderable in
                                 item(span: { GridItemSpan(maxLineSpan) }) {
                                     Box(contentAlignment: androidx.compose.ui.Alignment.Center) {
-                                        renderable.Render(context: itemContext)
+                                        renderable.Render(context: context.content(scope: self))
                                     }
                                 }
                             },
                             sectionFooter: { renderable in
                                 item(span: { GridItemSpan(maxLineSpan) }) {
                                     Box(contentAlignment: androidx.compose.ui.Alignment.Center) {
-                                        renderable.Render(context: itemContext)
+                                        renderable.Render(context: context.content(scope: self))
                                     }
                                 }
                             }
@@ -156,7 +158,7 @@ public struct LazyVGrid: View, Renderable {
                         if isSearchable {
                             item(span: { GridItemSpan(maxLineSpan) }) {
                                 let modifier = Modifier.padding(start: 16.dp, end: 16.dp, top: 16.dp, bottom: 8.dp).fillMaxWidth()
-                                SearchField(state: searchableState!, context: context.content(modifier: modifier))
+                                SearchField(state: searchableState!, context: context.content(modifier: modifier, scope: self))
                             }
                         }
                         for renderable in renderables {

--- a/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
@@ -62,7 +62,6 @@ public struct LazyVStack : View, Renderable {
         let isSearchable = searchableState?.isOnNavigationStack == false
 
         let renderables = content.EvaluateLazyItems(level: 0, context: context)
-        let itemContext = context.content()
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
         ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true) { modifier in
             IgnoresSafeAreaLayout(expandInto: [], checkEdges: [.bottom], modifier: modifier) { _, safeAreaEdges in
@@ -101,36 +100,39 @@ public struct LazyVStack : View, Renderable {
                             startItemIndex: isSearchable ? 1 : 0,
                             item: { renderable, _ in
                                 item {
-                                    renderable.Render(context: itemContext)
+                                    renderable.Render(context: context.content(scope: self))
                                 }
                             },
                             indexedItems: { range, identifier, _, _, _, _, factory in
                                 let count = range.endExclusive - range.start
                                 let key: ((Int) -> String)? = identifier == nil ? nil : { composeBundleString(for: identifier!($0 + range.start)) }
                                 items(count: count, key: key) { index in
-                                    factory(index + range.start, itemContext).Render(context: itemContext)
+                                    let scopedContext = context.content(scope: self)
+                                    factory(index + range.start, scopedContext).Render(context: scopedContext)
                                 }
                             },
                             objectItems: { objects, identifier, _, _, _, _, factory in
                                 let key: (Int) -> String = { composeBundleString(for: identifier(objects[$0])) }
                                 items(count: objects.count, key: key) { index in
-                                    factory(objects[index], itemContext).Render(context: itemContext)
+                                    let scopedContext = context.content(scope: self)
+                                    factory(objects[index], scopedContext).Render(context: scopedContext)
                                 }
                             },
                             objectBindingItems: { objectsBinding, identifier, _, _, _, _, _, factory in
                                 let key: (Int) -> String = { composeBundleString(for: identifier(objectsBinding.wrappedValue[$0])) }
                                 items(count: objectsBinding.wrappedValue.count, key: key) { index in
-                                    factory(objectsBinding, index, itemContext).Render(context: itemContext)
+                                    let scopedContext = context.content(scope: self)
+                                    factory(objectsBinding, index, scopedContext).Render(context: scopedContext)
                                 }
                             },
                             sectionHeader: { renderable in
                                 item {
-                                    renderable.Render(context: itemContext)
+                                    renderable.Render(context: context.content(scope: self))
                                 }
                             },
                             sectionFooter: { renderable in
                                 item {
-                                    renderable.Render(context: itemContext)
+                                    renderable.Render(context: context.content(scope: self))
                                 }
                             }
                         )


### PR DESCRIPTION
Rebased version of https://github.com/skiptools/skip-ui/pull/221

The `ComposeContext` now tracks an additional variable, `scope`, which users can use in `ComposeView` or `ComposeModifierView` to access scoped modifiers. https://developer.android.com/develop/ui/compose/modifiers#scope-safety

I've also added a new variant of `.composeModifier(scope:)` that allows users to declare a class to which their `(Modifier) -> Modifier` function will be scoped, making it easy to access modifiers scoped to that class.

Finally, I've set the `scope` variable in `LazyHStack`, `LazyVStack`, `LazyHGrid`, and `LazyVGrid`. There are probably a lot more places where this could be set.


