### PR TITLE
Document how to workaround the only-child limitation on lazy grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -2635,7 +2635,22 @@ SwiftUI automatically applies a mask to shapes and paths so that touches outside
 SkipUI renders SwiftUI grid views using native Compose grids. This provides maximum performance and a native feel on Android. The different capabilities of SwiftUI and Compose grids, however, imposes restrictions on SwiftUI grid support in Android:
 
 - Pinned headers and footers are not supported.
-- When you place a `LazyHGrid` or `LazyVGrid` in a `ScrollView`, it must be the only child of that view.
+- When you place a `LazyHGrid` or `LazyVGrid` in a `ScrollView`, it must be the only child of that view. (This is because Compose grids implement their own internal scroll containers.) To simulate having other non-grid items in your `ScrollView`, put your non-grid content in the `header`s of empty `Section` containers inside the grid.
+    ```swift
+    ScrollView {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 80))]) {
+            Section {} header: {
+                Text("Insert non-grid content here")
+            }
+            ForEach(0..<50) { index in
+                Text("Grid Cell \(index)")
+            }
+            Section {} header: {
+                Text("More non-grid content here")
+            }
+        }
+    }
+    ```
 - When you define your grid with an array of `GridItem` specs, your Android grid is **based on the first `GridItem`**. Compose does not support different specs for different rows or columns, so SkipUI applies the first spec to all of them.
 - Maximum `GridItem` sizes are ignored.
 - Also see the `ForEach` [topic](#foreach).


### PR DESCRIPTION
Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app


