### PR TITLE
Reimplement Alert matching native compose

### DIFF
--- a/Sources/SkipUI/Skip/SkipAlertDialog.kt
+++ b/Sources/SkipUI/Skip/SkipAlertDialog.kt
@@ -27,10 +27,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -81,8 +79,7 @@ fun SkipAlertDialog(
         Box(
             modifier = modifier
                 .sizeIn(minWidth = DialogMinWidth, maxWidth = DialogMaxWidth)
-                .then(Modifier.semantics { paneTitle = "Dialog" })
-                .then(Modifier.logLayoutModifier(tag = "SkipAlertDialog")),
+                .then(Modifier.semantics { paneTitle = "Dialog" }),
             propagateMinConstraints = true,
         ) {
             SkipAlertDialogContent(
@@ -128,7 +125,6 @@ private fun SkipAlertDialogContent(
     titleContentColor: Color,
     textContentColor: Color,
 ) {
-    SideEffect { Log.d("SkipAlertDialog", "containerColor=$containerColor") }
     Surface(
         modifier = modifier,
         shape = shape,
@@ -159,9 +155,8 @@ private fun SkipAlertDialogContent(
                     }
                 }
             }
-            text?.let {
-                SideEffect { Log.d("SkipAlertMessageColor", "textContentColor=$textContentColor") }
-                val scrollState = rememberScrollState()
+                    text?.let {
+                        val scrollState = rememberScrollState()
                 ProvideContentColorTextStyle(
                     contentColor = textContentColor,
                     textStyle = MaterialTheme.typography.bodyMedium,
@@ -188,9 +183,7 @@ private fun SkipAlertDialogContent(
                 }
             }
             Box(
-                modifier = Modifier
-                    .align(Alignment.End)
-                    .then(Modifier.logLayoutModifier(tag = "SkipAlertDialogButtonBox")),
+                modifier = Modifier.align(Alignment.End),
                 contentAlignment = Alignment.CenterEnd,
             ) {
                 ProvideContentColorTextStyle(
@@ -227,7 +220,7 @@ private fun SkipAlertDialogFlowRow(
     val density = LocalDensity.current
     val layoutDirection = LocalLayoutDirection.current
     Layout(
-        modifier = Modifier.logLayoutModifier(tag = "SkipAlertDialogFlowRow"),
+        modifier = Modifier,
         content = content,
     ) { measurables, constraints ->
         val sequences = mutableListOf<kotlin.collections.List<Placeable>>()

--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -522,7 +522,7 @@ final class DisableScrollToDismissConnection : NestedScrollConnection {
                 let button = s as? Button ?? (s as? Link)?.content
                 let label = button?.label ?? (s as? NavigationLink)?.label
                 let bt = label?.Evaluate(context: contentContext, options: 0).mapNotNull { $0.strip() as? Text }.firstOrNull()
-                androidx.compose.material3.Text(modifier: Modifier.logLayoutModifier(tag: "SkipAlertNeutralText"), color: tint, text: bt?.localizedTextString() ?? "", style: MaterialTheme.typography.labelLarge)
+                androidx.compose.material3.Text(color: tint, text: bt?.localizedTextString() ?? "", style: MaterialTheme.typography.labelLarge)
             }
         }
     }
@@ -537,11 +537,11 @@ final class DisableScrollToDismissConnection : NestedScrollConnection {
                     let label = button?.label ?? (stripped as? NavigationLink)?.label
                     let bt = label?.Evaluate(context: contentContext, options: 0).mapNotNull { $0.strip() as? Text }.firstOrNull()
                     let color = button?.role == .destructive ? MaterialTheme.colorScheme.error : tint
-                    androidx.compose.material3.Text(modifier: Modifier.logLayoutModifier(tag: "SkipAlertConfirmText"), color: color, text: bt?.localizedTextString() ?? "", style: MaterialTheme.typography.labelLarge)
+                    androidx.compose.material3.Text(color: color, text: bt?.localizedTextString() ?? "", style: MaterialTheme.typography.labelLarge)
                 }
             } else {
                 androidx.compose.material3.TextButton(onClick: { isPresented.set(false) }) {
-                    androidx.compose.material3.Text(modifier: Modifier.logLayoutModifier(tag: "SkipAlertOKText"), color: tint, text: stringResource(android.R.string.ok), style: MaterialTheme.typography.labelLarge)
+                    androidx.compose.material3.Text(color: tint, text: stringResource(android.R.string.ok), style: MaterialTheme.typography.labelLarge)
                 }
             }
         },
@@ -552,7 +552,7 @@ final class DisableScrollToDismissConnection : NestedScrollConnection {
                     let button = stripped as? Button
                     let label = button?.label
                     let bt = label?.Evaluate(context: contentContext, options: 0).mapNotNull { $0.strip() as? Text }.firstOrNull()
-                    androidx.compose.material3.Text(modifier: Modifier.logLayoutModifier(tag: "SkipAlertCancelText"), color: tint, text: bt?.localizedTextString() ?? "", style: MaterialTheme.typography.labelLarge)
+                    androidx.compose.material3.Text(color: tint, text: bt?.localizedTextString() ?? "", style: MaterialTheme.typography.labelLarge)
                 }
             }
         } : nil,
@@ -562,7 +562,7 @@ final class DisableScrollToDismissConnection : NestedScrollConnection {
             androidx.compose.material3.Text(color: Color.primary.colorImpl(), text: stringResource(titleResource!), style: MaterialTheme.typography.headlineSmall)
         } : nil),
         text: messageText != nil ? {
-            androidx.compose.material3.Text(modifier: Modifier.logLayoutModifier(tag: "SkipAlertMessageText"), text: messageText!.localizedTextString(), style: MaterialTheme.typography.bodyMedium)
+            androidx.compose.material3.Text(text: messageText!.localizedTextString(), style: MaterialTheme.typography.bodyMedium)
         } : nil,
         textFields: textFields.size > 0 ? {
             for textField in textFields {


### PR DESCRIPTION
Fixes #135

This is a pretty extensive PR. As @joshuakcockrell pointed out, Skip alerts didn't look very much like a "stock" Compose alert. Compose offers two APIs for alerts, a high-level `AlertDialog` which gives you an opinionated container with an expected look and feel, and a low-level `BasicAlertDialog` where you do everything yourself.

Skip's implementation used `BasicAlertDialog`, but it didn't adhere to the Material Design that `AlertDialog` provided; as a result, it felt very iOS-y and not very native to the platform.

Ideally, we'd just pass everything we need to `AlertDialog`, but we can't do that, because `AlertDialog` supports only two buttons (confirm + dismiss), and doesn't support embedding text fields.

Soooo I _forked_ `AlertDialog` from the original Compose sources, and checked it in as `SkipAlertDialog.kt` with some minor changes. I then added native `AlertDialog` playgrounds to the showcase, and verified that `SkipAlertDialog`'s implementation was a pixel-perfect match for `AlertDialog`.

With that done, I added support for any number of neutral buttons to `AlertDialog`, added support for text fields, and added a scrolling container, allowing users to scroll to read very long messages.

I took screenshots of each of the dialogs comparing them to the standard. The only difference now is that `SkipAlertDialog` puts the destructive button _above_ the cancel button in the long button titles case, but that feels right to me, so I left that difference in.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [x] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

https://github.com/skiptools/skipapp-showcase/pull/63

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used Cursor to copy the code from Compose. I carefully reviewed every line, and manually tested thoroughly in the showcase.

-----

