### PR TITLE
Make `.frame(maxWidth:)` respect parent bounds

### DIFF
--- a/Sources/SkipUI/SkipUI/Compose/ComposeExtensions.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeExtensions.swift
@@ -7,8 +7,10 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.requiredWidthIn
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -79,11 +81,11 @@ extension Modifier {
     /// For internal use.
     func applyNonExpandingFlexibleWidth(ideal: Float? = nil, min: Float? = nil, max: Float? = nil) -> Modifier {
         if let min, min! > Float(0), let max, max! >= Float(0) {
-            return requiredWidthIn(min: min!.dp, max: max!.dp)
+            return widthIn(min: min!.dp, max: max!.dp)
         } else if let min, min! > Float(0) {
-            return requiredWidthIn(min: min!.dp)
+            return widthIn(min: min!.dp)
         } else if let max, max! >= Float(0) {
-            return requiredWidthIn(max: max!.dp)
+            return widthIn(max: max!.dp)
         } else {
             return self
         }
@@ -92,11 +94,11 @@ extension Modifier {
     /// For internal use.
     func applyNonExpandingFlexibleHeight(ideal: Float? = nil, min: Float? = nil, max: Float? = nil) -> Modifier {
         if let min, min! > Float(0), let max, max! >= Float(0) {
-            return requiredHeightIn(min: min!.dp, max: max!.dp)
+            return heightIn(min: min!.dp, max: max!.dp)
         } else if let min, min! > Float(0) {
-            return requiredHeightIn(min: min!.dp)
+            return heightIn(min: min!.dp)
         } else if let max, max! >= Float(0) {
-            return requiredHeightIn(max: max!.dp)
+            return heightIn(max: max!.dp)
         } else {
             return self
         }


### PR DESCRIPTION
Fixes #339

The `applyNonExpandingFlexibleWidth` and `applyNonExpandingFlexibleHeight` functions were using Jetpack Compose's `requiredWidthIn()` and `requiredHeightIn()` modifiers, which enforce their constraints as hard requirements that can exceed parent bounds.

In this PR, we're using `widthIn()` / `heightIn()`, which sets constraints that respect parent bounds (the actual max becomes `min(parentMax, specifiedMax)`)

## iOS

<img width="201" height="437" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-27 at 22 34 06" src="https://github.com/user-attachments/assets/a44010b8-11c9-489a-9f38-2403e7c8f345" />

## Android Before

<img width="180" height="400" alt="Screenshot_20260227_221605" src="https://github.com/user-attachments/assets/eb623430-0915-4404-a604-673288410952" />

## Android After

<img width="180" height="400" alt="Screenshot_20260227_222403" src="https://github.com/user-attachments/assets/6a4be2ea-ca5b-4e07-93af-2559e877f17a" />

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor found the issue immediately, fixing it in one shot.

-----

