### PR TITLE
Declare PaddingValues and Dp types to squelch warnings

### DIFF
--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -819,6 +819,9 @@ struct PresentationDetentPreferences: Equatable {
 }
 #endif
 
+
+// It is unfortunate that we have to NOWARN this entire extension just to prevent "This extension will be moved into its extended type definition when translated to Kotlin. It will not be able to access this file's private types or fileprivate members"; ideally, we would be able to squelch that specific warning, but leave on the possibility of warning about other potential issues with the code inside the extension (https://github.com/skiptools/skipstone/issues/198)
+// SKIP NOWARN
 extension View {
     public func alert(_ titleKey: LocalizedStringKey, isPresented: Binding<Bool>, @ViewBuilder actions: () -> any View) -> any View {
         return alert(Text(titleKey), isPresented: isPresented, actions: actions)


### PR DESCRIPTION
Fixes warnings introduced in https://github.com/skiptools/skip-ui/pull/336:

```
skip-ui/Sources/SkipUI/SkipUI/Layout/Presentation.swift:84:34 Skip is unable to determine the type of this expression. Consider declaring the variable type explicitly, i.e. 'var v: <Type> = ...'
skip-ui/Sources/SkipUI/SkipUI/Layout/Presentation.swift:85:32 Skip is unable to determine the type of this expression. Consider declaring the variable type explicitly, i.e. 'var v: <Type> = ...'
skip-ui/Sources/SkipUI/SkipUI/Layout/Presentation.swift:86:33 Skip is unable to determine the type of this expression. Consider declaring the variable type explicitly, i.e. 'var v: <Type> = ...'
skip-ui/Sources/SkipUI/SkipUI/Layout/Presentation.swift:87:32 Skip is unable to determine the type of this expression. Consider declaring the variable type explicitly, i.e. 'var v: <Type> = ...'
skip-ui/Sources/SkipUI/SkipUI/Layout/Presentation.swift:88:40 Skip is unable to determine the type of this expression. Consider declaring the variable type explicitly, i.e. 'var v: <Type> = ...'
skip-ui/Sources/SkipUI/SkipUI/Layout/Presentation.swift:89:42 Skip is unable to determine the type of this expression. Consider declaring the variable type explicitly, i.e. 'var v: <Type> = ...'
skip-ui/Sources/SkipUI/SkipUI/Layout/Presentation.swift:90:39 Skip is unable to determine the type of this expression. Consider declaring the variable type explicitly, i.e. 'var v: <Type> = ...'
skip-ui/Sources/SkipUI/SkipUI/Layout/Presentation.swift:91:39 Skip is unable to determine the type of this expression. Consider declaring the variable type explicitly, i.e. 'var v: <Type> = ...'
skip-ui/Sources/SkipUI/SkipUI/Layout/Presentation.swift:822:1 This extension will be moved into its extended type definition when translated to Kotlin. It will not be able to access this file's private types or fileprivate members
```
