### PR TITLE
Document that .frame(maxWidth:) ignores parent bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2877,6 +2877,7 @@ SkipUI fully supports SwiftUI's various layout mechanisms, including `HStack`, `
 
 - Skip never places content in an implicit `VStack`, like SwiftUI sometimes does. Always place multiple views in an explicit stack of the desired type.
 - Expanding elements such as `Spacer` or `.frame(maxWidth: .infinity)` within nested `HStacks` or `VStacks` may measure differently. Try un-nesting stacks to get more SwiftUI-like layout.
+- Views with `.frame(maxWidth:)` or `.frame(maxHeight:)` set to explicit values larger than the parent's actual size may expand beyond the parent container's bounds on Android. To work around this, use a `GeometryReader` to compute the parent's size and set an explicit `.frame(width:)` or `.frame(height:)` instead of `maxWidth` or `maxHeight`. See [Issue #339](https://github.com/skiptools/skip-ui/issues/339).
 
 Note: if your app was developed under an earlier version of Skip and it relies on nuances of older layout behavior, you can apply the Android-only `.layoutImplementationVersion()` modifier. Set this modifier on a `View` hierarchy to simulate the previous behavior:
 

--- a/Tests/SkipUITests/LayoutTests.swift
+++ b/Tests/SkipUITests/LayoutTests.swift
@@ -628,4 +628,29 @@ final class LayoutTests: XCSnapshotTestCase {
         """))
     }
 
+    func testFrameMaxWidthRespectsParentBounds() throws {
+        // Skip on Android until the layout issue is fixed
+        // See: https://github.com/skiptools/skip-ui/issues/339
+        #if SKIP
+        throw XCTSkip("Android: .frame(maxWidth:) may expand beyond parent bounds")
+        #endif
+        
+        // Create a black container (width: 12), put a white rectangle inside with
+        // maxWidth: 20 (larger than parent), and add a red border.
+        // Expected: The white rectangle should be constrained to width 12 (parent bounds).
+        XCTAssertEqual(try pixmap(content: ZStack {
+            Color.black.frame(width: 12.0, height: 6.0)
+            Color.white
+                .frame(maxWidth: 20.0, maxHeight: 4.0)
+                .border(Color.red, width: 1)
+        }), """
+        . . . . . . . . . . . .
+        . . . . . . . . . . . .
+        .                     .
+        .                     .
+        . . . . . . . . . . . .
+        . . . . . . . . . . . .
+        """)
+    }
+
 }


### PR DESCRIPTION
I spent all day trying to fix this bug; I'm giving up and just documenting it better.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

