### PR TITLE
`scrollPosition(id: Binding<(any Hashable)?>)` for lazy containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2079,7 +2079,22 @@ Support levels:
               <ul>
                 <li>See <a href="#scrolling">Scrolling</a></li>
               </ul>
-          </details>      
+          </details>
+       </td>
+    </tr>
+    <tr>
+      <td>🟠</td>
+      <td>
+          <details>
+              <summary><code>.scrollPosition</code></summary>
+              <ul>
+                <li>Only <code>scrollPosition(id: Binding&lt;(some Hashable)?>)</code> is supported</li>
+                <li>Only works with lazy containers: <code>LazyHStack</code>, <code>LazyVStack</code>, <code>LazyHGrid</code>, <code>LazyVGrid</code>, and <code>List</code></li>
+                <li>The <code>anchor</code> parameter is not supported</li>
+                <li><code>scrollPosition(_ position: Binding&lt;ScrollPosition>, anchor: UnitPoint? = nil)</code> is not supported</li>
+                <li>See <a href="#scrolling">Scrolling</a></li>
+              </ul>
+          </details>
        </td>
     </tr>
     <tr>
@@ -3058,6 +3073,8 @@ With these updates in place, your app should extend below the system bars. If yo
 
 - The `UnitRect` parameter to `ScrollView` and `ScrollViewProxy` is ignored.
 - `ScrollViewProxy` works only for `List` and lazy containers: `LazyHStack`, `LazyVStack`, `LazyHGrid`, and `LazyVGrid`.
+- `.scrollPosition(id:)` works only for lazy containers (`List`, `LazyHStack`, `LazyVStack`, `LazyHGrid`, `LazyVGrid`). The `anchor` parameter is not supported.
+- `.scrollPosition(_ position: Binding<ScrollPosition>, anchor: UnitPoint? = nil)` is not supported.
 - If you place a lazy container in a `ScrollView`, it must be the **only** content of that `ScrollView`.
 - The content of any `ScrollView` with the `.scrollTargetBehavior` modifier applied must be a single lazy container with the `.scrollTargetLayout` modifier applied, as in the following example:
 

--- a/Sources/SkipUI/SkipUI/Containers/LazyHGrid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyHGrid.swift
@@ -12,10 +12,15 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 #elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
@@ -80,6 +85,21 @@ public struct LazyHGrid: View, Renderable {
                 }
             }
             PreferenceValues.shared.contribute(context: context, key: ScrollToIDPreferenceKey.self, value: scrollToID)
+
+            // Observe scroll position changes and contribute them via preferences
+            let scrollPositionState = remember { mutableStateOf<ScrollPositionState?>(nil) }
+            let currentItemCollector = rememberUpdatedState(itemCollector.value)
+            LaunchedEffect(gridState) {
+                snapshotFlow { gridState.firstVisibleItemIndex }
+                .distinctUntilChanged()
+                .collect { index in
+                    let id = currentItemCollector.value.id(for: index)
+                    scrollPositionState.value = ScrollPositionState(id: id)
+                }
+            }
+            if let scrollPosition = scrollPositionState.value {
+                PreferenceValues.shared.contribute(context: context, key: ScrollPositionPreferenceKey.self, value: scrollPosition)
+            }
 
             EnvironmentValues.shared.setValues {
                 $0.set_scrollTargetBehavior(nil)

--- a/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
@@ -10,10 +10,15 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 #elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
@@ -76,6 +81,21 @@ public struct LazyHStack : View, Renderable {
                 }
             }
             PreferenceValues.shared.contribute(context: context, key: ScrollToIDPreferenceKey.self, value: scrollToID)
+
+            // Observe scroll position changes and contribute them via preferences
+            let scrollPositionState = remember { mutableStateOf<ScrollPositionState?>(nil) }
+            let currentItemCollector = rememberUpdatedState(itemCollector.value)
+            LaunchedEffect(listState) {
+                snapshotFlow { listState.firstVisibleItemIndex }
+                .distinctUntilChanged()
+                .collect { index in
+                    let id = currentItemCollector.value.id(for: index)
+                    scrollPositionState.value = ScrollPositionState(id: id)
+                }
+            }
+            if let scrollPosition = scrollPositionState.value {
+                PreferenceValues.shared.contribute(context: context, key: ScrollPositionPreferenceKey.self, value: scrollPosition)
+            }
 
             EnvironmentValues.shared.setValues {
                 $0.set_scrollTargetBehavior(nil)

--- a/Sources/SkipUI/SkipUI/Containers/LazySupport.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazySupport.swift
@@ -246,6 +246,49 @@ public final class LazyItemCollector {
         return nil
     }
 
+    /// Return the item ID for the given list index, or nil.
+    func id(for index: Int) -> AnyHashable? {
+        var currentIndex = startItemIndex
+        for content in self.content {
+            switch content {
+            case .items(let start, let count, let idMap, _):
+                if index >= currentIndex && index < currentIndex + count {
+                    let i = start + (index - currentIndex)
+                    if let idMap {
+                        return idMap(i)
+                    } else {
+                        return i
+                    }
+                }
+                currentIndex += count
+            case .objectItems(let objects, let idMap, _):
+                if index >= currentIndex && index < currentIndex + objects.count {
+                    let object = objects[index - currentIndex]
+                    return idMap(object)
+                }
+                currentIndex += objects.count
+            case .objectBindingItems(let binding, let idMap, _):
+                let count = binding.wrappedValue.count
+                if index >= currentIndex && index < currentIndex + count {
+                    let object = binding.wrappedValue[index - currentIndex]
+                    return idMap(object)
+                }
+                currentIndex += count
+            case .sectionHeader(let count):
+                if index >= currentIndex && index < currentIndex + count {
+                    return nil
+                }
+                currentIndex += count
+            case .sectionFooter(let count):
+                if index >= currentIndex && index < currentIndex + count {
+                    return nil
+                }
+                currentIndex += count
+            }
+        }
+        return nil
+    }
+
     private var moving: (fromIndex: Int, toIndex: Int)?
     private var moveTrigger = 0
 

--- a/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
@@ -15,11 +15,16 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 #elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
@@ -96,6 +101,21 @@ public struct LazyVGrid: View, Renderable {
                 if safeAreaEdges.contains(Edge.Set.bottom) {
                     PreferenceValues.shared.contribute(context: context, key: ToolbarPreferenceKey.self, value: ToolbarPreferences(scrollableState: gridState, for: [ToolbarPlacement.bottomBar]))
                     PreferenceValues.shared.contribute(context: context, key: TabBarPreferenceKey.self, value: ToolbarBarPreferences(scrollableState: gridState))
+                }
+
+                // Observe scroll position changes and contribute them via preferences
+                let scrollPositionState = remember { mutableStateOf<ScrollPositionState?>(nil) }
+                let currentItemCollector = rememberUpdatedState(itemCollector.value)
+                LaunchedEffect(gridState) {
+                    snapshotFlow { gridState.firstVisibleItemIndex }
+                    .distinctUntilChanged()
+                    .collect { index in
+                        let id = currentItemCollector.value.id(for: index)
+                        scrollPositionState.value = ScrollPositionState(id: id)
+                    }
+                }
+                if let scrollPosition = scrollPositionState.value {
+                    PreferenceValues.shared.contribute(context: context, key: ScrollPositionPreferenceKey.self, value: scrollPosition)
                 }
 
                 EnvironmentValues.shared.setValues {

--- a/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
@@ -14,11 +14,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 #elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
@@ -89,6 +94,21 @@ public struct LazyVStack : View, Renderable {
                 if safeAreaEdges.contains(Edge.Set.bottom) {
                     PreferenceValues.shared.contribute(context: context, key: ToolbarPreferenceKey.self, value: ToolbarPreferences(scrollableState: listState, for: [ToolbarPlacement.bottomBar]))
                     PreferenceValues.shared.contribute(context: context, key: TabBarPreferenceKey.self, value: ToolbarBarPreferences(scrollableState: listState))
+                }
+
+                // Observe scroll position changes and contribute them via preferences
+                let scrollPositionState = remember { mutableStateOf<ScrollPositionState?>(nil) }
+                let currentItemCollector = rememberUpdatedState(itemCollector.value)
+                LaunchedEffect(listState) {
+                    snapshotFlow { listState.firstVisibleItemIndex }
+                    .distinctUntilChanged()
+                    .collect { index in
+                        let id = currentItemCollector.value.id(for: index)
+                        scrollPositionState.value = ScrollPositionState(id: id)
+                    }
+                }
+                if let scrollPosition = scrollPositionState.value {
+                    PreferenceValues.shared.contribute(context: context, key: ScrollPositionPreferenceKey.self, value: scrollPosition)
                 }
 
                 EnvironmentValues.shared.setValues {

--- a/Sources/SkipUI/SkipUI/Containers/ScrollView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/ScrollView.swift
@@ -240,7 +240,25 @@ struct BuiltinScrollAxisSetPreferenceKey: PreferenceKey {
         value.formUnion(nextValue())
     }
 }
+
+/// Holds the current scroll position ID for visible items in a scroll view.
+struct ScrollPositionState {
+    let id: AnyHashable?
+}
+
+struct ScrollPositionPreferenceKey: PreferenceKey {
+    static let defaultValue = ScrollPositionState(id: nil)
+
+    static func reduce(value: inout ScrollPositionState, nextValue: () -> ScrollPositionState) {
+        value = nextValue()
+    }
+}
 #endif
+
+public struct ScrollPosition {
+    @available(*, unavailable)
+    public init() {}
+}
 
 public enum ScrollBounceBehavior {
     case automatic
@@ -391,14 +409,28 @@ extension View {
         return self
     }
 
-    @available(*, unavailable)
-    public func scrollPosition(id: Binding<(any Hashable)?>) -> some View {
+    public func scrollPosition(id: Binding<(some Hashable)?>, anchor: UnitPoint? = nil) -> some View {
+        #if SKIP
+        guard anchor == nil else {
+            fatalError("scrollPosition(id:anchor:) is only supported on Android with nil anchor")
+        }
+        return onPreferenceChange(ScrollPositionPreferenceKey.self) { newValue in
+            id.wrappedValue = newValue.id
+        }
+        #else
         return self
+        #endif
     }
 
-    @available(*, unavailable)
-    public func scrollPosition(initialAnchor: UnitPoint?) -> some View {
+    // SKIP @bridge
+    public func scrollPosition(getId: @escaping () -> AnyHashable?, setId: @escaping (AnyHashable?) -> Void) -> any View {
+        #if SKIP
+        return onPreferenceChange(ScrollPositionPreferenceKey.self) { newValue in
+            setId(newValue.id)
+        }
+        #else
         return self
+        #endif
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
`scrollPosition` is a pretty complicated feature. You can bind it to the ID of the selected iterable with `scrollPosition(id: Binding<(any Hashable)?>)`, or you can bind it to a [ScrollPosition](https://developer.apple.com/documentation/swiftui/view/scrollposition%28_%3Aanchor%3A%29) with a bunch of features. In addition, you can pass it a [UnitPoint](https://developer.apple.com/documentation/swiftui/unitpoint) `anchor:`, allowing you to select which _part_ of the selected item has to be in view.

It would be quite complicated to implement it for all types of containers, but there's a relatively straightforward implementation possible in lazy containers, which have a `firstVisibleItemIndex` that we can use to convert into a ScrollPositionPreferenceKey.

This implementation doesn't support `anchor:`, and it doesn't support `ScrollPosition`; it just tells you the ID of the item scrolled into view. This all that I needed it for, to implement little dots as scroll indicators on a carousel.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [x] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app
    https://github.com/skiptools/skipapp-showcase/pull/67

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used Cursor Kimi 2.5 to generate most of this, testing it with the showcase app.

-----

