### PR TITLE
Use Material Design colors for destructive buttons (fixes dark mode)

### DIFF
--- a/Sources/SkipUI/SkipUI/Controls/Button.swift
+++ b/Sources/SkipUI/SkipUI/Controls/Button.swift
@@ -13,6 +13,7 @@ import androidx.compose.material.ContentAlpha
 import androidx.compose.material.ripple.RippleAlpha
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ButtonElevation
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.LocalRippleConfiguration
@@ -133,7 +134,7 @@ public struct Button : View, Renderable {
         ComposeContainer(modifier: context.modifier) { modifier in
             switch buttonStyle {
             case .bordered:
-                let tint = role == .destructive ? Color.red : EnvironmentValues.shared._tint
+                let tint = role == .destructive ? Color(colorImpl: { MaterialTheme.colorScheme.error }) : EnvironmentValues.shared._tint
                 let colors: ButtonColors
                 if let tint {
                     let tintColor = tint.colorImpl()
@@ -161,11 +162,21 @@ public struct Button : View, Renderable {
                     }
                 }
             case .borderedProminent:
-                let tint = role == .destructive ? Color.red : EnvironmentValues.shared._tint
+                let tint = role == .destructive ? Color(colorImpl: { MaterialTheme.colorScheme.error }) : EnvironmentValues.shared._tint
                 let colors: ButtonColors
                 if let tint {
                     let tintColor = tint.colorImpl()
-                    colors = ButtonDefaults.buttonColors(containerColor: tintColor, disabledContainerColor: tintColor.copy(alpha: ContentAlpha.disabled))
+                    if role == .destructive {
+                        colors = ButtonDefaults
+                            .buttonColors(
+                                containerColor: MaterialTheme.colorScheme.error,
+                                contentColor: MaterialTheme.colorScheme.onError,
+                                disabledContainerColor: MaterialTheme.colorScheme.error.copy(alpha: ContentAlpha.disabled),
+                                disabledContentColor: MaterialTheme.colorScheme.onError.copy(alpha: ContentAlpha.disabled)
+                            )
+                    } else {
+                        colors = ButtonDefaults.buttonColors(containerColor: tintColor, disabledContainerColor: tintColor.copy(alpha: ContentAlpha.disabled))
+                    }
                 } else {
                     colors = ButtonDefaults.buttonColors()
                 }
@@ -198,7 +209,7 @@ public struct Button : View, Renderable {
     @Composable static func RenderTextButton(label: View, context: ComposeContext, role: ButtonRole? = nil, isPlain: Bool = false, isEnabled: Bool = EnvironmentValues.shared.isEnabled, action: (() -> Void)? = nil) {
         var foregroundStyle: ShapeStyle
         if role == .destructive {
-            foregroundStyle = Color.red
+            foregroundStyle = Color(colorImpl: { MaterialTheme.colorScheme.error })
         } else {
             foregroundStyle = EnvironmentValues.shared._foregroundStyle ?? (isPlain ? Color.primary : (EnvironmentValues.shared._tint ?? Color.accentColor))
         }


### PR DESCRIPTION
Fixes #349

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
    It does not require Fuse changes
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used Cursor to fill out the parameters of `ButtonDefaults.buttonColors`, and I tested it in the Showcase app.

-----



<img width="180" height="400" alt="Screenshot_20260304_160852" src="https://github.com/user-attachments/assets/a14341c9-47e7-4af0-a455-d40af9e344d2" />
<img width="180" height="400" alt="Screenshot_20260304_160839" src="https://github.com/user-attachments/assets/69c1c5c1-47e9-4ba8-be19-af717e443dd8" />
