### PR TITLE
Added support for Date Picker Ranges in Skip Lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,8 +721,8 @@ Support levels:
               <summary><code>DatePicker</code> (<a href="https://skip.dev/docs/components/datepicker/">example</a>)</summary>
               <ul>
                   <li><code>init(selection: Binding&lt;Date>, displayedComponents: DatePickerComponents = [.hourAndMinute, .date], @ViewBuilder label: () -> any View)</code></li>
+                  <li><code>init(selection: Binding&lt;Date>, in: ClosedRange&lt;Date>, displayedComponents: DatePickerComponents = [.hourAndMinute, .date], @ViewBuilder label: () -> any View)</code></li>
                   <li><code>init(_ title: String, selection: Binding&lt;Date>, displayedComponents: DatePickerComponents = [.hourAndMinute, .date])</code></li>
-                  <li>Date range constraints (<code>in: ClosedRange&lt;Date></code>) are supported via Skip Fuse bridging</li>
               </ul>
           </details>      
        </td>

--- a/Sources/SkipUI/SkipUI/Controls/DatePicker.swift
+++ b/Sources/SkipUI/SkipUI/Controls/DatePicker.swift
@@ -117,6 +117,18 @@ public struct DatePicker : View, Renderable {
         self.init(selection: selection, displayedComponents: displayedComponents, label: { Text(verbatim: title) })
     }
 
+    public init(_ titleKey: LocalizedStringKey, in range: ClosedRange<Date>, selection: Binding<Date>, displayedComponents: DatePickerComponents = [.hourAndMinute, .date]) {
+        self.init(selection: selection, in: range, displayedComponents: displayedComponents, label: { Text(titleKey) })
+    }
+
+    public init(_ titleResource: LocalizedStringResource, in range: ClosedRange<Date>, selection: Binding<Date>, displayedComponents: DatePickerComponents = [.hourAndMinute, .date]) {
+        self.init(selection: selection, in: range, displayedComponents: displayedComponents, label: { Text(titleResource) })
+    }
+
+    public init(_ title: String, selection: Binding<Date>, in range: ClosedRange<Date>, displayedComponents: DatePickerComponents = [.hourAndMinute, .date]) {
+        self.init(selection: selection, in: range, displayedComponents: displayedComponents, label: { Text(verbatim: title) })
+    }
+
     #if SKIP
     @Composable override func Render(context: ComposeContext) {
         let contentContext = context.content()

--- a/Sources/SkipUI/SkipUI/Controls/DatePicker.swift
+++ b/Sources/SkipUI/SkipUI/Controls/DatePicker.swift
@@ -46,8 +46,38 @@ public struct DatePicker : View, Renderable {
     public init(selection: Binding<Date>, displayedComponents: DatePickerComponents = [.hourAndMinute, .date], @ViewBuilder label: () -> any View) {
         self.selection = selection
         self.label = ComposeBuilder.from(label)
+
         self.minDate = nil
         self.maxDate = nil
+
+        if displayedComponents.contains(.date) {
+            dateFormatter = DateFormatter()
+            dateFormatter?.dateStyle = .medium
+            dateFormatter?.timeStyle = .none
+        } else {
+            dateFormatter = nil
+        }
+        if displayedComponents.contains(.hourAndMinute) {
+            timeFormatter = DateFormatter()
+            timeFormatter?.dateStyle = .none
+            timeFormatter?.timeStyle = .short
+        } else {
+            timeFormatter = nil
+        }
+    }
+
+    public init(selection: Binding<Date>, in range: ClosedRange<Date>, displayedComponents: DatePickerComponents = [.hourAndMinute, .date], @ViewBuilder label: () -> any View) {
+        self.selection = selection
+        self.label = ComposeBuilder.from(label)
+
+        #if SKIP
+        self.minDate = range.start
+        self.maxDate = range.endInclusive
+        #else
+        self.minDate = range.lowerBound
+        self.maxDate = range.upperBound
+        #endif
+
         if displayedComponents.contains(.date) {
             dateFormatter = DateFormatter()
             dateFormatter?.dateStyle = .medium
@@ -71,25 +101,8 @@ public struct DatePicker : View, Renderable {
 
     // SKIP @bridge
     public init(getSelection: @escaping () -> Date, setSelection: @escaping (Date) -> Void, bridgedMinDate: Date, bridgedMaxDate: Date, bridgedDisplayedComponents: Int, bridgedLabel: any View) {
-        self.selection = Binding(get: getSelection, set: setSelection)
-        self.label = ComposeBuilder.from({ bridgedLabel })
-        self.minDate = bridgedMinDate
-        self.maxDate = bridgedMaxDate
-        let displayedComponents = DatePickerComponents(rawValue: bridgedDisplayedComponents)
-        if displayedComponents.contains(.date) {
-            dateFormatter = DateFormatter()
-            dateFormatter?.dateStyle = .medium
-            dateFormatter?.timeStyle = .none
-        } else {
-            dateFormatter = nil
-        }
-        if displayedComponents.contains(.hourAndMinute) {
-            timeFormatter = DateFormatter()
-            timeFormatter?.dateStyle = .none
-            timeFormatter?.timeStyle = .short
-        } else {
-            timeFormatter = nil
-        }
+        self.init(selection: Binding(get: getSelection, set: setSelection), in: bridgedMinDate...bridgedMaxDate, displayedComponents: DatePickerComponents(rawValue: bridgedDisplayedComponents), label: { bridgedLabel }
+        )
     }
 
     public init(_ titleKey: LocalizedStringKey, selection: Binding<Date>, displayedComponents: DatePickerComponents = [.hourAndMinute, .date]) {


### PR DESCRIPTION
This PR adds support for Date Picker Ranges for Skip Lite apps.

To try it out, you can check out the `DatePickerPlayground` in [Skip Showcase](https://github.com/skiptools/skipapp-showcase/pull/72).

**Related PRs:**
- https://github.com/skiptools/skipapp-showcase/pull/72

---

Thank you for contributing to the Skip project! Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device
- [X] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [X] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

