### PR TITLE
Fix default scaling of images in tab view tabs

### DIFF
--- a/Sources/SkipUI/SkipUI/Components/Image.swift
+++ b/Sources/SkipUI/SkipUI/Components/Image.swift
@@ -395,8 +395,7 @@ public struct Image : View, Renderable, Equatable {
                 let textSizeDp = with(LocalDensity.current) {
                     textStyle.fontSize.toDp()
                 }
-                // Apply a multiplier to more closely match SwiftUI's relative text and system image sizes
-                modifier = Modifier.size(textSizeDp * Float(1.5))
+                modifier = Modifier.size(textSizeDp)
             } else {
                 modifier = Modifier
             }

--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -50,6 +50,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.platform.LocalDensity
@@ -737,12 +738,28 @@ public struct Tab : TabContent, Renderable {
     }
 
     @Composable func RenderImage(context: ComposeContext) {
-        let renderable = label.Evaluate(context: context, options: 0).firstOrNull() ?? EmptyView()
+        let scaledContext = context.content(modifier: context.modifier.graphicsLayer(scaleX: Float(1.5), scaleY: Float(1.5)))
+        let renderable = label.Evaluate(context: scaledContext, options: 0).firstOrNull() ?? EmptyView()
         let stripped = renderable.strip()
-        if let label = stripped as? Label {
-            label.RenderImage(context: context)
-        } else if stripped is Image {
-            renderable.Render(context: context)
+        // Default to a lighter symbol weight so tab icons approximate SwiftUI sizing
+        let renderImage: (@Composable () -> ()) = {
+            if let label = stripped as? Label {
+                label.RenderImage(context: scaledContext)
+            } else if stripped is Image {
+                renderable.Render(context: scaledContext)
+            }
+        }
+        if EnvironmentValues.shared._textEnvironment.fontWeight == nil {
+            EnvironmentValues.shared.setValues {
+                var textEnvironment = $0._textEnvironment
+                textEnvironment.fontWeight = Font.Weight.light
+                $0.set_textEnvironment(textEnvironment)
+                return ComposeResult.ok
+            } in: {
+                renderImage()
+            }
+        } else {
+            renderImage()
         }
     }
     #else


### PR DESCRIPTION
Previously, symbol/vector images would be rendered with a default scaling of 1.5 in order to accommodate a (common) case of using symbol images in tab views. This would get the image sized about right, but would make it look "heavier" than its iOS equivalent, as can be seen in the previous Showcase center tabs (which is the only one that uses a custom symbol image):

<img height="500" alt="Screenshot_1773719375 copy" src="https://github.com/user-attachments/assets/3a497429-dc6e-482c-b2af-a3bd3693f3e1" />
<img height="500" alt="Simulator Screenshot - iPhone 17 - 2026-03-17 at 18 22 59" src="https://github.com/user-attachments/assets/18488578-9a19-40ea-b1ee-dec74496e84f" />

With this changes, the image itself will not be scaled by by default, but when an image is being rendered in a tab it will apply the font scaling of 1.5, as well as defaulting to a light font weight in order to replicate the default iOS tab bar behavior.

The resulting tab icons are much closer:

<img height="500" alt="Screenshot_1773786183" src="https://github.com/user-attachments/assets/192c9439-4d9e-4fbb-b1e7-ee7028079c55" />
<img height="500" alt="Simulator Screenshot - iPhone 17 - 2026-03-17 at 18 22 59" src="https://github.com/user-attachments/assets/18488578-9a19-40ea-b1ee-dec74496e84f" />
