### PR TITLE
Enable contextMenu for Button and other elements that handle touches

### DIFF
--- a/Sources/SkipUI/SkipUI/Commands/ContextMenu.swift
+++ b/Sources/SkipUI/SkipUI/Commands/ContextMenu.swift
@@ -66,7 +66,17 @@ class ContextMenuModifier: RenderModifier {
                             }
                         }
                     } == nil
-                    if longPressed { isMenuExpanded.value = true }
+                    if longPressed {
+                        isMenuExpanded.value = true
+                        // Consume remaining pointer events so the child's tap handler
+                        // does not fire when the finger lifts
+                        var pressed = true
+                        while pressed {
+                            let event = awaitPointerEvent(pass: PointerEventPass.Initial)
+                            event.changes.forEach { $0.consume() }
+                            pressed = event.changes.any({ $0.pressed })
+                        }
+                    }
                 }
             }
         }) {


### PR DESCRIPTION
Context menus were not working on Buttons (and, presumably, other elements that handle touches). This PR modifies the the handling to not use `combinedClickable` and instead manually handles the touch interpretation with `pointerInput`.