### PR TITLE
Navigation layout hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -3019,6 +3019,34 @@ SkipUI supports all of these models. When using `.navigationDestination(isPresen
 
 Compose imposes an additional restriction as well: we must be able to stringify `.navigationDestination` data key types. See [Restrictions on Identifiers](#restrictions-on-identifiers) below.
 
+#### Prevent layout shifting with hints
+
+Android Compose's `TopAppBar` APIs ask the client to choose a size and pass it a `title` parameter before the navigation bar composes. In SwiftUI, you specify the display mode and title using modifiers on your rendered content,  `navigationBarTitleDisplayMode` and the `navigationTitle`. Under the hood, these modifiers set SwiftUI [preferences](https://developer.apple.com/documentation/swiftui/preferences) that modify the behavior of the `NavigationStack`.
+
+If your content composes slowly, this can cause a "layout shift," where the `NavigationStack` tries to guess the height of your navigation bar, then later discovers the actual height, shifting your content up/down as the user views it.
+
+To prevent layout shifting, you can use the `navigationStackLayoutHints` modifier, like this:
+
+```swift
+struct MyView: View {
+    var body: some View {
+        NavigationStack{
+            Text("My Content")
+                .navigationTitle("My Title")
+                .navigationBarTitleDisplayMode(.inline)
+        }
+        #if os(Android)
+        .navigationStackLayoutHints(
+            expectedTitle: Text("My Title"),
+            expectedTitleDisplayMode: .inline
+        )
+        #endif
+    }
+}
+```
+
+These hints tell `NavigationStack` to render the correct navigation bar content on the first try, eliminating layout shifts.
+
 #### Modals
 
 Skip supports standard modal presentations. Android apps typically allow users to dismiss modals with the Android back button. Skip allows you to selectively disable this behavior with the Android-only `backDismissDisabled(_ isDisabled: Bool = true)` SwiftUI modifier. If you use this modifier, you **must** put it on the top-level view embedded in your `.sheet` or `.fullScreenCover`, as in the following example:

--- a/README.md
+++ b/README.md
@@ -3047,6 +3047,41 @@ struct MyView: View {
 
 These hints tell `NavigationStack` to render the correct navigation bar content on the first try, eliminating layout shifts.
 
+If your navigation destinations have different expectations, you can set them with `navigationDestinationLayoutHints`, like this:
+
+```swift
+struct CityPickerView: View {
+    var body: some View {
+        NavigationStack {
+            List(City.allCases) { city in
+                NavigationLink(value: city) {
+                    rowView(city: city)
+                }
+            }
+            .navigationTitle("Cities")
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationDestination(for: City.self) { city in
+                CityView(city: city)
+                    .navigationTitle(city.rawValue)
+                    .navigationBarTitleDisplayMode(.large)
+            }
+            #if os(Android)
+            .navigationDestinationLayoutHints(
+                for: City.self,
+                expectedTitleDisplayMode: .large
+            )
+            #endif
+        }
+        #if os(Android)
+        .navigationStackLayoutHints(
+            expectedTitle: Text("Cities"),
+            expectedTitleDisplayMode: .inline
+        )
+        #endif
+    }
+}
+```
+
 #### Modals
 
 Skip supports standard modal presentations. Android apps typically allow users to dismiss modals with the Android back button. Skip allows you to selectively disable this behavior with the Android-only `backDismissDisabled(_ isDisabled: Bool = true)` SwiftUI modifier. If you use this modifier, you **must** put it on the top-level view embedded in your `.sheet` or `.fullScreenCover`, as in the following example:

--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -223,11 +223,25 @@ public struct NavigationStack : View, Renderable {
         let state = arguments.state
         let context = context.content(stateSaver: state.stateSaver)
 
+        let hasTitleFromPreferences = arguments.title != NavigationTitlePreferenceKey.defaultValue
+        let hasTitle: Bool
+        let title: Text
+        let titleDisplayPreference: ToolbarTitleDisplayMode?
+        if let layoutHints = EnvironmentValues.shared._navigationStackLayoutHints {
+            let hasTitleFromHints = layoutHints.expectedTitle != NavigationTitlePreferenceKey.defaultValue
+            hasTitle = hasTitleFromPreferences || hasTitleFromHints
+            title = hasTitleFromPreferences ? arguments.title : (hasTitleFromHints ? layoutHints.expectedTitle : arguments.title)
+            titleDisplayPreference = arguments.toolbarPreferences.titleDisplayMode ?? layoutHints.expectedTitleDisplayMode
+        } else {
+            hasTitle = hasTitleFromPreferences
+            title = arguments.title
+            titleDisplayPreference = arguments.toolbarPreferences.titleDisplayMode
+        }
+
         let topBarPreferences = arguments.toolbarPreferences.navigationBar
         let topBarHidden = remember { mutableStateOf(false) }
         let bottomBarPreferences = arguments.toolbarPreferences.bottomBar
-        let hasTitle = arguments.title != NavigationTitlePreferenceKey.defaultValue
-        let effectiveTitleDisplayMode = navigator.value.titleDisplayMode(for: state, hasTitle: hasTitle, preference: arguments.toolbarPreferences.titleDisplayMode)
+        let effectiveTitleDisplayMode = navigator.value.titleDisplayMode(for: state, hasTitle: hasTitle, preference: titleDisplayPreference)
         let isInlineTitleDisplayMode = useInlineTitleDisplayMode(for: effectiveTitleDisplayMode, safeArea: arguments.safeArea)
 
         // We would like to only process toolbar content in our topBar/bottomBar Composables, but composing
@@ -368,12 +382,12 @@ public struct NavigationStack : View, Renderable {
                             })
                             let arrangement = Arrangement.spacedBy(2.dp, alignment: androidx.compose.ui.Alignment.CenterHorizontally)
                             Row(modifier: menuModifier, horizontalArrangement: arrangement, verticalAlignment: androidx.compose.ui.Alignment.CenterVertically) {
-                                androidx.compose.material3.Text(arguments.title.localizedTextString(), maxLines: 1, overflow: TextOverflow.Ellipsis)
+                                androidx.compose.material3.Text(title.localizedTextString(), maxLines: 1, overflow: TextOverflow.Ellipsis)
                                 Image(systemName: "chevron.down").accessibilityHidden(true).Compose(context: context)
                             }
                             titleMenu.Render(context: context)
                         } else {
-                            androidx.compose.material3.Text(arguments.title.localizedTextString(), maxLines: 1, overflow: TextOverflow.Ellipsis)
+                            androidx.compose.material3.Text(title.localizedTextString(), maxLines: 1, overflow: TextOverflow.Ellipsis)
                         }
                     }
                     let topBarNavigationIcon: @Composable () -> Void = {
@@ -1315,7 +1329,40 @@ extension View {
     public func material3BottomAppBar(_ options: @Composable (Material3BottomAppBarOptions) -> Material3BottomAppBarOptions) -> View {
         return environment(\._material3BottomAppBar, options, affectsEvaluate: false)
     }
+
+    public func navigationStackLayoutHints(expectedTitle: Text = NavigationTitlePreferenceKey.defaultValue, expectedTitleDisplayMode: ToolbarTitleDisplayMode? = nil) -> View {
+        return environment(
+            \._navigationStackLayoutHints,
+             NavigationStackLayoutHints(
+                expectedTitle: expectedTitle,
+                expectedTitleDisplayMode: expectedTitleDisplayMode),
+             affectsEvaluate: false
+        )
+    }
     #endif
+
+    // SKIP @bridge
+    public func navigationStackLayoutHints(expectedTitle: Text, bridgedExpectedTitleDisplayMode: Int?) -> any View {
+        #if SKIP
+        let expectedTitleDisplayMode: ToolbarTitleDisplayMode? = bridgedExpectedTitleDisplayMode.flatMap { raw in
+            switch NavigationBarItem.TitleDisplayMode(rawValue: raw) ?? .automatic {
+            case .automatic: return ToolbarTitleDisplayMode.automatic
+            case .inline: return ToolbarTitleDisplayMode.inline
+            case .large: return ToolbarTitleDisplayMode.large
+            }
+        }
+        return environment(
+            \._navigationStackLayoutHints,
+            NavigationStackLayoutHints(
+                expectedTitle: expectedTitle,
+                expectedTitleDisplayMode: expectedTitleDisplayMode),
+            affectsEvaluate: false
+        )
+        #else
+        return self
+        #endif
+    }
+
 }
 
 #if SKIP
@@ -1375,6 +1422,17 @@ struct NavigationTitlePreferenceKey: PreferenceKey {
 
     static func reduce(value: inout Text, nextValue: () -> Text) {
         value = nextValue()
+    }
+}
+
+/// Values supplied before `navigationTitle` / `navigationBarTitleDisplayMode` preferences propagate, so the first frames use the correct top bar eligibility, scroll behavior, and title text, preventing layout shift.
+public struct NavigationStackLayoutHints {
+    public let expectedTitle: Text
+    public let expectedTitleDisplayMode: ToolbarTitleDisplayMode?
+
+    public init(expectedTitle: Text = NavigationTitlePreferenceKey.defaultValue, expectedTitleDisplayMode: ToolbarTitleDisplayMode? = nil) {
+        self.expectedTitle = expectedTitle
+        self.expectedTitleDisplayMode = expectedTitleDisplayMode
     }
 }
 #endif

--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -136,10 +136,15 @@ public struct NavigationStack : View, Renderable {
         }
         // Make this collector non-erasable so that destinations defined at e.g. the root nav stack layer don't disappear when you push
         let destinationsCollector = PreferenceCollector<NavigationDestinations>(key: NavigationDestinationsPreferenceKey.self, state: destinations, isErasable: false)
+        let destinationLayoutHints = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<NavigationDestinationLayoutHintsMap>, Any>) { mutableStateOf(Preference<NavigationDestinationLayoutHintsMap>(key: NavigationDestinationLayoutHintsPreferenceKey.self))
+        }
+        let destinationLayoutHintsCollector = PreferenceCollector<NavigationDestinationLayoutHintsMap>(key: NavigationDestinationLayoutHintsPreferenceKey.self, state: destinationLayoutHints, isErasable: false)
         let reducedDestinations = destinations.value.reduced
+        let reducedDestinationLayoutHints = destinationLayoutHints.value.reduced
+        let mergedDestinations = mergeNavigationDestinationsWithLayoutHints(reducedDestinations, layoutHints: reducedDestinationLayoutHints)
         let navBackStack = rememberNavBackStack(SkipNavigationStackRootKey.root)
-        let navigator = rememberSaveable(stateSaver: context.stateSaver as! Saver<Navigator, Any>) { mutableStateOf(Navigator(navBackStack: navBackStack, destinations: reducedDestinations, destinationKeyTransformer: destinationKeyTransformer)) }
-        navigator.value.didCompose(navBackStack: navBackStack, destinations: reducedDestinations, path: path, navigationPath: navigationPath, keyboardController: LocalSoftwareKeyboardController.current)
+        let navigator = rememberSaveable(stateSaver: context.stateSaver as! Saver<Navigator, Any>) { mutableStateOf(Navigator(navBackStack: navBackStack, destinations: mergedDestinations, destinationKeyTransformer: destinationKeyTransformer)) }
+        navigator.value.didCompose(navBackStack: navBackStack, destinations: mergedDestinations, path: path, navigationPath: navigationPath, keyboardController: LocalSoftwareKeyboardController.current)
 
         // SKIP INSERT: val providedNavigator = LocalNavigator provides navigator.value
         CompositionLocalProvider(providedNavigator) {
@@ -165,7 +170,7 @@ public struct NavigationStack : View, Renderable {
                             let toolbarContentPreferences = rememberSaveable(stateSaver: state.stateSaver as! Saver<Preference<ToolbarContentPreferences>, Any>) { mutableStateOf(Preference<ToolbarContentPreferences>(key: ToolbarContentPreferenceKey.self)) }
                             let toolbarContentPreferencesCollector = PreferenceCollector<ToolbarContentPreferences>(key: ToolbarContentPreferenceKey.self, state: toolbarContentPreferences)
                             let arguments = NavigationEntryArguments(isRoot: true, state: state, safeArea: safeArea, ignoresSafeAreaEdges: ignoresSafeAreaEdges, title: title.value.reduced, toolbarPreferences: toolbarPreferences.value.reduced)
-                            PreferenceValues.shared.collectPreferences([titleCollector, toolbarPreferencesCollector, toolbarContentPreferencesCollector, destinationsCollector]) {
+                            PreferenceValues.shared.collectPreferences([titleCollector, toolbarPreferencesCollector, toolbarContentPreferencesCollector, destinationsCollector, destinationLayoutHintsCollector]) {
                                 RenderEntry(navigator: navigator, toolbarContent: toolbarContentPreferences, arguments: arguments, context: context) { context in
                                     root.Compose(context: context)
                                 }
@@ -188,7 +193,7 @@ public struct NavigationStack : View, Renderable {
                                 return ComposeResult.ok
                             } in: {
                                 let arguments = NavigationEntryArguments(isRoot: false, state: state, safeArea: safeArea, ignoresSafeAreaEdges: ignoresSafeAreaEdges, title: title.value.reduced, toolbarPreferences: toolbarPreferences.value.reduced)
-                                PreferenceValues.shared.collectPreferences([titleCollector, toolbarPreferencesCollector, toolbarContentPreferencesCollector, destinationsCollector]) {
+                                PreferenceValues.shared.collectPreferences([titleCollector, toolbarPreferencesCollector, toolbarContentPreferencesCollector, destinationsCollector, destinationLayoutHintsCollector]) {
                                     RenderEntry(navigator: navigator, toolbarContent: toolbarContentPreferences, arguments: arguments, context: context) { context in
                                         let destinationArguments = NavigationDestinationArguments(targetValue: targetValue)
                                         RenderDestination(state.destination, arguments: destinationArguments, context: context)
@@ -223,11 +228,12 @@ public struct NavigationStack : View, Renderable {
         let state = arguments.state
         let context = context.content(stateSaver: state.stateSaver)
 
+        let entryLayoutHints = state.layoutHints ?? (arguments.isRoot ? EnvironmentValues.shared._navigationStackLayoutHints : nil)
         let hasTitleFromPreferences = arguments.title != NavigationTitlePreferenceKey.defaultValue
         let hasTitle: Bool
         let title: Text
         let titleDisplayPreference: ToolbarTitleDisplayMode?
-        if let layoutHints = EnvironmentValues.shared._navigationStackLayoutHints {
+        if let layoutHints = entryLayoutHints {
             let hasTitleFromHints = layoutHints.expectedTitle != NavigationTitlePreferenceKey.defaultValue
             hasTitle = hasTitleFromPreferences || hasTitleFromHints
             title = hasTitleFromPreferences ? arguments.title : (hasTitleFromHints ? layoutHints.expectedTitle : arguments.title)
@@ -711,12 +717,34 @@ public struct SkipNavigationStackPushKey : NavKey {
 }
 
 typealias NavigationDestinations = Dictionary<AnyHashable, NavigationDestination>
+typealias NavigationDestinationLayoutHintsMap = Dictionary<AnyHashable, NavigationStackLayoutHints>
+
 struct NavigationDestination {
     let destination: (Any) -> any View
+    let layoutHints: NavigationStackLayoutHints?
+
+    init(destination: @escaping (Any) -> any View, layoutHints: NavigationStackLayoutHints? = nil) {
+        self.destination = destination
+        self.layoutHints = layoutHints
+    }
+
     // No way to compare closures. Assume equal so we don't think our destinations are constantly updating
     public override func equals(other: Any?) -> Bool {
         return true
     }
+}
+
+private func mergeNavigationDestinationsWithLayoutHints(_ destinations: NavigationDestinations, layoutHints: NavigationDestinationLayoutHintsMap) -> NavigationDestinations {
+    if layoutHints.isEmpty {
+        return destinations
+    }
+    var merged = destinations
+    for (key, hint) in layoutHints {
+        if let existing = merged[key] {
+            merged[key] = NavigationDestination(destination: existing.destination, layoutHints: hint)
+        }
+    }
+    return merged
 }
 
 @Stable final class Navigator {
@@ -755,15 +783,17 @@ struct NavigationDestination {
         let route: String
         let destination: ((Any) -> any View)?
         let targetValue: Any?
+        let layoutHints: NavigationStackLayoutHints?
         let stateSaver: ComposeStateSaver
         var titleDisplayMode: ToolbarTitleDisplayMode?
         var binding: Binding<Bool>?
 
-        init(id: String, route: String, destination: ((Any) -> any View)? = nil, targetValue: Any? = nil, stateSaver: ComposeStateSaver = ComposeStateSaver()) {
+        init(id: String, route: String, destination: ((Any) -> any View)? = nil, targetValue: Any? = nil, layoutHints: NavigationStackLayoutHints? = nil, stateSaver: ComposeStateSaver = ComposeStateSaver()) {
             self.id = id
             self.route = route
             self.destination = destination
             self.targetValue = targetValue
+            self.layoutHints = layoutHints
             self.stateSaver = stateSaver
         }
     }
@@ -822,7 +852,7 @@ struct NavigationDestination {
         viewDestinationValue += 1
 
         let route = Self.route(for: viewDestinationIndex, valueString: String(describing: targetValue))
-        return navigate(route: route, destination: { _ in view }, targetValue: targetValue, binding: binding)
+        return navigate(route: route, destination: { _ in view }, layoutHints: nil, targetValue: targetValue, binding: binding)
     }
 
     /// Pop the back stack.
@@ -1009,11 +1039,11 @@ struct NavigationDestination {
         }
 
         let route = route(for: key, value: targetValue)
-        navigate(route: route, destination: destination.destination, targetValue: targetValue)
+        navigate(route: route, destination: destination.destination, layoutHints: destination.layoutHints, targetValue: targetValue)
         return true
     }
 
-    private func navigate(route: String, destination: ((Any) -> any View)?, targetValue: Any, binding: Binding<Bool>? = nil) -> String? {
+    private func navigate(route: String, destination: ((Any) -> any View)?, layoutHints: NavigationStackLayoutHints?, targetValue: Any, binding: Binding<Bool>? = nil) -> String? {
         let slash = route.indexOf("/")
         guard slash >= 0 else {
             return nil
@@ -1024,17 +1054,17 @@ struct NavigationDestination {
             return nil
         }
         let pushKey = SkipNavigationStackPushKey(destinationIndex: destIndex, identifier: identifier)
-        return navigate(pushKey: pushKey, route: route, destination: destination, targetValue: targetValue, binding: binding)
+        return navigate(pushKey: pushKey, route: route, destination: destination, layoutHints: layoutHints, targetValue: targetValue, binding: binding)
     }
 
-    private func navigate(pushKey: SkipNavigationStackPushKey, route: String, destination: ((Any) -> any View)?, targetValue: Any, binding: Binding<Bool>? = nil) -> String? {
+    private func navigate(pushKey: SkipNavigationStackPushKey, route: String, destination: ((Any) -> any View)?, layoutHints: NavigationStackLayoutHints?, targetValue: Any, binding: Binding<Bool>? = nil) -> String? {
         // We see a top app bar glitch when the keyboard animates away after push, so manually dismiss it first
         keyboardController?.hide()
         navBackStack.add(pushKey)
         let entryId = stableEntryId(forKey: pushKey)
         var state = backStackState[entryId]
         if state == nil {
-            state = BackStackState(id: entryId, route: route, destination: destination, targetValue: targetValue)
+            state = BackStackState(id: entryId, route: route, destination: destination, targetValue: targetValue, layoutHints: layoutHints)
             backStackState[entryId] = state
         }
         if let binding {
@@ -1339,6 +1369,21 @@ extension View {
              affectsEvaluate: false
         )
     }
+    public func navigationDestinationLayoutHints(for data: Any.Type, expectedTitle: Text = NavigationTitlePreferenceKey.defaultValue, expectedTitleDisplayMode: ToolbarTitleDisplayMode? = nil) -> any View {
+        let hints = NavigationStackLayoutHints(
+            expectedTitle: expectedTitle,
+            expectedTitleDisplayMode: expectedTitleDisplayMode
+        )
+        return preference(key: NavigationDestinationLayoutHintsPreferenceKey.self, value: [data as! AnyHashable: hints])
+    }
+
+    public func navigationDestinationLayoutHints(destinationKey: String, expectedTitle: Text = NavigationTitlePreferenceKey.defaultValue, expectedTitleDisplayMode: ToolbarTitleDisplayMode? = nil) -> any View {
+        let hints = NavigationStackLayoutHints(
+            expectedTitle: expectedTitle,
+            expectedTitleDisplayMode: expectedTitleDisplayMode
+        )
+        return preference(key: NavigationDestinationLayoutHintsPreferenceKey.self, value: [destinationKey: hints])
+    }
     #endif
 
     // SKIP @bridge
@@ -1363,6 +1408,25 @@ extension View {
         #endif
     }
 
+    // SKIP @bridge
+    public func navigationDestinationLayoutHints(destinationKey: String, expectedTitle: Text, bridgedExpectedTitleDisplayMode: Int?) -> any View {
+        #if SKIP
+        let expectedTitleDisplayMode: ToolbarTitleDisplayMode? = bridgedExpectedTitleDisplayMode.flatMap { raw in
+            switch NavigationBarItem.TitleDisplayMode(rawValue: raw) ?? .automatic {
+            case .automatic: return ToolbarTitleDisplayMode.automatic
+            case .inline: return ToolbarTitleDisplayMode.inline
+            case .large: return ToolbarTitleDisplayMode.large
+            }
+        }
+        let hints = NavigationStackLayoutHints(
+            expectedTitle: expectedTitle,
+            expectedTitleDisplayMode: expectedTitleDisplayMode
+        )
+        return preference(key: NavigationDestinationLayoutHintsPreferenceKey.self, value: [destinationKey: hints])
+        #else
+        return self
+        #endif
+    }
 }
 
 #if SKIP
@@ -1422,6 +1486,16 @@ struct NavigationTitlePreferenceKey: PreferenceKey {
 
     static func reduce(value: inout Text, nextValue: () -> Text) {
         value = nextValue()
+    }
+}
+
+struct NavigationDestinationLayoutHintsPreferenceKey: PreferenceKey {
+    static let defaultValue: NavigationDestinationLayoutHintsMap = [:]
+
+    static func reduce(value: inout NavigationDestinationLayoutHintsMap, nextValue: () -> NavigationDestinationLayoutHintsMap) {
+        for (key, hints) in nextValue() {
+            value[key] = hints
+        }
     }
 }
 

--- a/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
+++ b/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
@@ -779,6 +779,12 @@ extension EnvironmentValues {
         set { setBuiltinValue(key: "_material3TopAppBar", value: newValue, defaultValue: { nil }) }
     }
 
+    /// Bootstrap hints so `NavigationStack` can reserve top bar space and defer body visibility until the bar is positioned (Android). See `View.navigationStackLayoutHints(_:)`.
+    var _navigationStackLayoutHints: NavigationStackLayoutHints? {
+        get { builtinValue(key: "_navigationStackLayoutHints", defaultValue: { nil }) as! NavigationStackLayoutHints? }
+        set { setBuiltinValue(key: "_navigationStackLayoutHints", value: newValue, defaultValue: { nil }) }
+    }
+
     /// Nested scroll connection for the active `NavigationStack` entry's top app bar
     public var _nestedScrollConnection: NestedScrollConnection? {
         get { builtinValue(key: "_nestedScrollConnection", defaultValue: { nil }) as! NestedScrollConnection? }


### PR DESCRIPTION
**I recommend reviewing this PR one commit at a time!**

Android Compose's `TopAppBar` API asks the client to choose a size and pass it a `title` parameter before the navigation bar composes. In SwiftUI, you specify the display mode and title using modifiers on your rendered content,  `navigationBarTitleDisplayMode` and the `navigationTitle`. Under the hood, these modifiers set SwiftUI [preferences](https://developer.apple.com/documentation/swiftui/preferences) that modify the behavior of the `NavigationStack`.

If your content composes slowly, this can cause a "layout shift," where the `NavigationStack` tries to guess the initial height of your navigation bar, then later discovers the actual height, shifting your content up/down as the user views it.

This PR provides "layout hints" to `NavigationStack`. These hints tell `NavigationStack` to render the correct navigation bar content on the first try, eliminating layout shifts and reducing recompositions.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor wrote the initial implementation of the first commit, the stack-level hints, but then I went back in and rewrote it from scratch to clean it up; I wrote the documentation by hand. (I did let Cursor generate the bridging code.)

Then Cursor write a draft of the second commit, which worked out of the box.

I tested both commits using my own private app. (Since this is a performance tweak, I'm not confident that we need to add it to the Showcase, but you could persuade me if you'd prefer that.)