### PR TITLE
Wrap `TabView` icon in a `Box` to restore padding

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -27,6 +27,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarDefaults
@@ -738,28 +739,43 @@ public struct Tab : TabContent, Renderable {
     }
 
     @Composable func RenderImage(context: ComposeContext) {
-        let scaledContext = context.content(modifier: context.modifier.graphicsLayer(scaleX: Float(1.5), scaleY: Float(1.5)))
-        let renderable = label.Evaluate(context: scaledContext, options: 0).firstOrNull() ?? EmptyView()
+        let renderable = label.Evaluate(context: context, options: 0).firstOrNull() ?? EmptyView()
         let stripped = renderable.strip()
-        // Default to a lighter symbol weight so tab icons approximate SwiftUI sizing
+        // compute size of outer box (for padding)
+        let textStyle = EnvironmentValues.shared.font?.fontImpl() ?? LocalTextStyle.current
+        let outerModifier: Modifier
+        if textStyle.fontSize.isSp {
+            let textSizeDp = with(LocalDensity.current) {
+                textStyle.fontSize.toDp()
+            }
+            let slotDp = textSizeDp * Float(1.5)
+            outerModifier = context.modifier.then(Modifier.size(slotDp))
+        } else {
+            outerModifier = context.modifier
+        }
         let renderImage: (@Composable () -> ()) = {
             if let label = stripped as? Label {
-                label.RenderImage(context: scaledContext)
+                label.RenderImage(context: context)
             } else if stripped is Image {
-                renderable.Render(context: scaledContext)
+                renderable.Render(context: context)
             }
         }
-        if EnvironmentValues.shared._textEnvironment.fontWeight == nil {
-            EnvironmentValues.shared.setValues {
-                var textEnvironment = $0._textEnvironment
-                textEnvironment.fontWeight = Font.Weight.light
-                $0.set_textEnvironment(textEnvironment)
-                return ComposeResult.ok
-            } in: {
-                renderImage()
+        Box(modifier: outerModifier, contentAlignment: androidx.compose.ui.Alignment.Center) {
+            Box(modifier: Modifier.graphicsLayer(scaleX: Float(1.5), scaleY: Float(1.5)), contentAlignment: androidx.compose.ui.Alignment.Center) {
+                // Default to a lighter symbol weight so tab icons approximate SwiftUI sizing
+                if EnvironmentValues.shared._textEnvironment.fontWeight == nil {
+                    EnvironmentValues.shared.setValues {
+                        var textEnvironment = $0._textEnvironment
+                        textEnvironment.fontWeight = Font.Weight.light
+                        $0.set_textEnvironment(textEnvironment)
+                        return ComposeResult.ok
+                    } in: {
+                        renderImage()
+                    }
+                } else {
+                    renderImage()
+                }
             }
-        } else {
-            renderImage()
         }
     }
     #else


### PR DESCRIPTION
In #358 we adopted a `graphicsLayer` modifier with 1.5x scale, but `graphicsLayer` doesn't affect layout, so the padding around TabView icons seemed to shrink.

Here, we're putting the image in a `Box` with `graphicsLayer` scaling, and wrapping that in an outer `Box` with `size` scaling.

Fixes #367

Three screenshots:
Before #358, After #358, After this PR
<img width="180" height="400" alt="Screenshot_20260325_195428" src="https://github.com/user-attachments/assets/69fa57b0-bf60-4d0b-ab9d-e33e065566e8" /> <img width="180" height="400" alt="Screenshot_20260325_195537" src="https://github.com/user-attachments/assets/3dd42736-2246-4351-a461-633749db20a5" /> <img width="180" height="400" alt="Screenshot_20260325_211749" src="https://github.com/user-attachments/assets/20dafc31-312b-4871-b5d9-31aabb8d5fa9" />


Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor generated this PR; I cleaned it up slightly, and manually compared it to prior screenshots.

