### PR TITLE
Log a message when navigation is throttled

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -1429,6 +1429,7 @@ public struct NavigationLink : View, Renderable {
             // Hack to prevent multiple quick taps from pushing duplicate entries
             let now = CFAbsoluteTimeGetCurrent()
             guard NavigationLink.lastNavigationTime + NavigationLink.minimumNavigationInterval <= now else {
+                logger.debug("navigation throttled; diff: \(now - lastNavigationTime) minimumNavigationInterval: \(NavigationLink.minimumNavigationInterval)")
                 return
             }
             NavigationLink.lastNavigationTime = now


### PR DESCRIPTION
This bit me hard when I was trying to write automated tests against the Showcase… took me a loooong time to track down. A little bit of logging would have gone a long way to help me figure it out!

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

