### PR TITLE
Navigation 3, predictive back

### DIFF
--- a/Sources/SkipUI/Skip/skip.yml
+++ b/Sources/SkipUI/Skip/skip.yml
@@ -13,7 +13,8 @@ settings:
             - block: 'create("libs")'
               contents:
                 - 'version("coil", "3.4.0")'
-                - 'version("androidx-navigation", "2.9.7")'
+                - 'version("androidx-nav3", "1.0.1")'
+                - 'version("kotlinx-serialization-json", "1.8.1")'
                 - 'version("androidx-appcompat", "1.7.1")'
                 - 'version("androidx-activity", "1.13.0")'
                 - 'version("androidx-lifecycle-process", "2.10.0")'
@@ -32,7 +33,10 @@ settings:
                 - 'library("androidx-appcompat", "androidx.appcompat", "appcompat").versionRef("androidx-appcompat")'
                 - 'library("androidx-appcompat-resources", "androidx.appcompat", "appcompat-resources").versionRef("androidx-appcompat")'
 
-                - 'library("androidx-navigation-compose", "androidx.navigation", "navigation-compose").versionRef("androidx-navigation")'
+                - 'library("androidx-navigation3-runtime", "androidx.navigation3", "navigation3-runtime").versionRef("androidx-nav3")'
+                - 'library("androidx-navigation3-ui", "androidx.navigation3", "navigation3-ui").versionRef("androidx-nav3")'
+                - 'library("kotlinx-serialization-json", "org.jetbrains.kotlinx", "kotlinx-serialization-json").versionRef("kotlinx-serialization-json")'
+                - 'plugin("kotlin-serialization", "org.jetbrains.kotlin.plugin.serialization").versionRef("kotlin")'
                 - 'library("androidx-activity-compose", "androidx.activity", "activity-compose").versionRef("androidx-activity")'
                 - 'library("androidx-lifecycle-process", "androidx.lifecycle", "lifecycle-process").versionRef("androidx-lifecycle-process")'
                 - 'library("androidx-compose-material3-adaptive", "androidx.compose.material3.adaptive", "adaptive").versionRef("androidx-material3-adaptive")'
@@ -54,6 +58,7 @@ build:
     - block: 'plugins'
       contents:
         - 'alias(libs.plugins.kotlin.compose)'
+        - 'alias(libs.plugins.kotlin.serialization)'
 
     - block: 'android'
       contents:
@@ -73,7 +78,9 @@ build:
         - 'api(libs.androidx.compose.material3)'
         - 'api(libs.androidx.compose.material3.adaptive)'
         - 'api(libs.androidx.compose.foundation)'
-        - 'api(libs.androidx.navigation.compose)'
+        - 'api(libs.androidx.navigation3.runtime)'
+        - 'api(libs.androidx.navigation3.ui)'
+        - 'api(libs.kotlinx.serialization.json)'
         - 'api(libs.androidx.appcompat)'
         - 'api(libs.androidx.appcompat.resources)'
         - 'api(libs.androidx.activity.compose)'

--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -8,6 +8,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -54,7 +55,6 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -77,14 +77,15 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
-import androidx.navigation.NavBackStackEntry
-import androidx.navigation.NavHostController
-import androidx.navigation.NavType
-import androidx.navigation.navArgument
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
 import kotlin.reflect.full.superclasses
+import kotlinx.serialization.Serializable
+import androidx.compose.runtime.key
 import kotlinx.coroutines.delay
 #endif
 
@@ -136,25 +137,23 @@ public struct NavigationStack : View, Renderable {
         // Make this collector non-erasable so that destinations defined at e.g. the root nav stack layer don't disappear when you push
         let destinationsCollector = PreferenceCollector<NavigationDestinations>(key: NavigationDestinationsPreferenceKey.self, state: destinations, isErasable: false)
         let reducedDestinations = destinations.value.reduced
-        let navController = rememberNavController()
-        let navigator = rememberSaveable(stateSaver: context.stateSaver as! Saver<Navigator, Any>) { mutableStateOf(Navigator(navController: navController, destinations: reducedDestinations, destinationKeyTransformer: destinationKeyTransformer)) }
-        navigator.value.didCompose(navController: navController, destinations: reducedDestinations, path: path, navigationPath: navigationPath, keyboardController: LocalSoftwareKeyboardController.current)
+        let navBackStack = rememberNavBackStack(SkipNavigationStackRootKey.root)
+        let navigator = rememberSaveable(stateSaver: context.stateSaver as! Saver<Navigator, Any>) { mutableStateOf(Navigator(navBackStack: navBackStack, destinations: reducedDestinations, destinationKeyTransformer: destinationKeyTransformer)) }
+        navigator.value.didCompose(navBackStack: navBackStack, destinations: reducedDestinations, path: path, navigationPath: navigationPath, keyboardController: LocalSoftwareKeyboardController.current)
 
         // SKIP INSERT: val providedNavigator = LocalNavigator provides navigator.value
         CompositionLocalProvider(providedNavigator) {
             let safeArea = EnvironmentValues.shared._safeArea
-            // We have to ignore the safe area around the entire NavHost to prevent push/pop animation issues with the system bars.
+            // We have to ignore the safe area around the entire NavDisplay to prevent push/pop animation issues with the system bars.
             // When we layout, only extend into safe areas that are due to system bars, not into any app chrome
             var ignoresSafeAreaEdges: Edge.Set = [.top, .bottom]
             ignoresSafeAreaEdges.formIntersection(safeArea?.absoluteSystemBarEdges ?? [])
             IgnoresSafeAreaLayout(expandInto: ignoresSafeAreaEdges) { _, _ in
                 ComposeContainer(modifier: context.modifier, fillWidth: true, fillHeight: true) { modifier in
-                    let isRTL = EnvironmentValues.shared.layoutDirection == LayoutDirection.rightToLeft
-                    NavHost(navController: navController, startDestination: Navigator.rootRoute, modifier: modifier) {
-                        composable(route: Navigator.rootRoute,
-                                   exitTransition: { fadeOut(animationSpec: tween(durationMillis: 200)) + slideOutHorizontally(targetOffsetX: { $0 * (isRTL ? 1 : -1) / 3 }) },
-                                   popEnterTransition: { fadeIn() + slideInHorizontally(initialOffsetX: { $0 * (isRTL ? 1 : -1) / 3 }) }) { entry in
-                            guard let state = navigator.value.state(for: entry) else {
+                    let decoratorList = listOf(rememberSaveableStateHolderNavEntryDecorator<NavKey>())
+                    let entryProvider = entryProvider {
+                        entry<SkipNavigationStackRootKey> { _ in
+                            guard let state = navigator.value.stateForRoot() else {
                                 return
                             }
                             // These preferences are per-entry, but if we put them in RenderEntry then their initial values don't show
@@ -172,39 +171,48 @@ public struct NavigationStack : View, Renderable {
                                 }
                             }
                         }
-                        for destinationIndex in 0..<Navigator.destinationCount {
-                            composable(route: Navigator.route(for: destinationIndex, valueString: "{identifier}"),
-                                       arguments: listOf(navArgument("identifier") { type = NavType.StringType }),
-                                       enterTransition: { fadeIn() + slideInHorizontally(initialOffsetX: { $0 * (isRTL ? -1 : 1) / 3 }) },
-                                       exitTransition: { fadeOut(animationSpec: tween(durationMillis: 200)) + slideOutHorizontally(targetOffsetX: { $0 * (isRTL ? 1 : -1) / 3 }) },
-                                       popEnterTransition: { fadeIn() + slideInHorizontally(initialOffsetX: { $0 * (isRTL ? 1 : -1) / 3 }) },
-                                       popExitTransition: { fadeOut(animationSpec: tween(durationMillis: 200)) + slideOutHorizontally(targetOffsetX: { $0 * (isRTL ? -1 : 1) / 3 }) }) { entry in
-                                guard let state = navigator.value.state(for: entry), let targetValue = state.targetValue else {
-                                    return
-                                }
-                                // These preferences are per-entry, but if we put them in RenderEntry then their initial values don't show
-                                // during the navigation animation. We have to collect them here
-                                let title = rememberSaveable(stateSaver: state.stateSaver as! Saver<Preference<Text>, Any>) { mutableStateOf(Preference<Text>(key: NavigationTitlePreferenceKey.self)) }
-                                let titleCollector = PreferenceCollector<Text>(key: NavigationTitlePreferenceKey.self, state: title)
-                                let toolbarPreferences = rememberSaveable(stateSaver: state.stateSaver as! Saver<Preference<ToolbarPreferences>, Any>) { mutableStateOf(Preference<ToolbarPreferences>(key: ToolbarPreferenceKey.self)) }
-                                let toolbarPreferencesCollector = PreferenceCollector<ToolbarPreferences>(key: ToolbarPreferenceKey.self, state: toolbarPreferences)
-                                let toolbarContentPreferences = rememberSaveable(stateSaver: state.stateSaver as! Saver<Preference<ToolbarContentPreferences>, Any>) { mutableStateOf(Preference<ToolbarContentPreferences>(key: ToolbarContentPreferenceKey.self)) }
-                                let toolbarContentPreferencesCollector = PreferenceCollector<ToolbarContentPreferences>(key: ToolbarContentPreferenceKey.self, state: toolbarContentPreferences)
-                                EnvironmentValues.shared.setValues {
-                                    $0.setdismiss(DismissAction(action: { navigator.value.navigateBack() }))
-                                    return ComposeResult.ok
-                                } in: {
-                                    let arguments = NavigationEntryArguments(isRoot: false, state: state, safeArea: safeArea, ignoresSafeAreaEdges: ignoresSafeAreaEdges, title: title.value.reduced, toolbarPreferences: toolbarPreferences.value.reduced)
-                                    PreferenceValues.shared.collectPreferences([titleCollector, toolbarPreferencesCollector, toolbarContentPreferencesCollector, destinationsCollector]) {
-                                        RenderEntry(navigator: navigator, toolbarContent: toolbarContentPreferences, arguments: arguments, context: context) { context in
-                                            let destinationArguments = NavigationDestinationArguments(targetValue: targetValue)
-                                            RenderDestination(state.destination, arguments: destinationArguments, context: context)
-                                        }
+                        entry<SkipNavigationStackPushKey> { navKey in
+                            guard let state = navigator.value.state(forPushKey: navKey), let targetValue = state.targetValue else {
+                                return
+                            }
+                            // These preferences are per-entry, but if we put them in RenderEntry then their initial values don't show
+                            // during the navigation animation. We have to collect them here
+                            let title = rememberSaveable(stateSaver: state.stateSaver as! Saver<Preference<Text>, Any>) { mutableStateOf(Preference<Text>(key: NavigationTitlePreferenceKey.self)) }
+                            let titleCollector = PreferenceCollector<Text>(key: NavigationTitlePreferenceKey.self, state: title)
+                            let toolbarPreferences = rememberSaveable(stateSaver: state.stateSaver as! Saver<Preference<ToolbarPreferences>, Any>) { mutableStateOf(Preference<ToolbarPreferences>(key: ToolbarPreferenceKey.self)) }
+                            let toolbarPreferencesCollector = PreferenceCollector<ToolbarPreferences>(key: ToolbarPreferenceKey.self, state: toolbarPreferences)
+                            let toolbarContentPreferences = rememberSaveable(stateSaver: state.stateSaver as! Saver<Preference<ToolbarContentPreferences>, Any>) { mutableStateOf(Preference<ToolbarContentPreferences>(key: ToolbarContentPreferenceKey.self)) }
+                            let toolbarContentPreferencesCollector = PreferenceCollector<ToolbarContentPreferences>(key: ToolbarContentPreferenceKey.self, state: toolbarContentPreferences)
+                            EnvironmentValues.shared.setValues {
+                                $0.setdismiss(DismissAction(action: { navigator.value.navigateBack() }))
+                                return ComposeResult.ok
+                            } in: {
+                                let arguments = NavigationEntryArguments(isRoot: false, state: state, safeArea: safeArea, ignoresSafeAreaEdges: ignoresSafeAreaEdges, title: title.value.reduced, toolbarPreferences: toolbarPreferences.value.reduced)
+                                PreferenceValues.shared.collectPreferences([titleCollector, toolbarPreferencesCollector, toolbarContentPreferencesCollector, destinationsCollector]) {
+                                    RenderEntry(navigator: navigator, toolbarContent: toolbarContentPreferences, arguments: arguments, context: context) { context in
+                                        let destinationArguments = NavigationDestinationArguments(targetValue: targetValue)
+                                        RenderDestination(state.destination, arguments: destinationArguments, context: context)
                                     }
                                 }
                             }
                         }
                     }
+                    NavDisplay(
+                        backStack: navBackStack,
+                        modifier: modifier,
+                        onBack: { navigator.value.navigateBack() },
+                        transitionSpec: {
+                            // SKIP INSERT: slideInHorizontally { it } + fadeIn() togetherWith slideOutHorizontally { -it } + fadeOut()
+                        },
+                        popTransitionSpec: {
+                            // SKIP INSERT: slideInHorizontally { -it } + fadeIn() togetherWith slideOutHorizontally { it } + fadeOut()
+                        },
+                        predictivePopTransitionSpec: { _ in
+                            // SKIP INSERT: slideInHorizontally { -it } + fadeIn() togetherWith slideOutHorizontally { it } + fadeOut()
+                        },
+                        entryDecorators: decoratorList,
+                        entryProvider: entryProvider
+                    )
                 }
             }
         }
@@ -257,13 +265,6 @@ public struct NavigationStack : View, Renderable {
             modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
         }
         modifier = modifier.then(context.modifier)
-
-        // Intercept system back button to keep our state in sync
-        BackHandler(enabled: !arguments.isRoot) {
-            if arguments.toolbarPreferences.backButtonHidden != true {
-                navigator.value.navigateBack()
-            }
-        }
 
         let defaultTopBarHeight = 112.dp
         let topBarBottomPx = remember {
@@ -670,6 +671,18 @@ public struct NavigationStack : View, Renderable {
 }
 
 #if SKIP
+
+// SKIP INSERT: @Serializable
+public enum SkipNavigationStackRootKey : NavKey {
+    case root
+}
+
+// SKIP INSERT: @Serializable
+public struct SkipNavigationStackPushKey : NavKey {
+    public let destinationIndex: Int
+    public let identifier: String
+}
+
 @Stable struct NavigationEntryArguments: Equatable {
     let isRoot: Bool
     let state: Navigator.BackStackState
@@ -708,7 +721,7 @@ struct NavigationDestination {
         return String(describing: destinationIndex) + "/" + valueString
     }
 
-    private var navController: NavHostController
+    private var navBackStack: NavBackStack<NavKey>
     private var keyboardController: SoftwareKeyboardController?
     private var destinations: NavigationDestinations
     private var destinationIndexes: [AnyHashable: Int] = [:]
@@ -741,16 +754,16 @@ struct NavigationDestination {
         }
     }
 
-    init(navController: NavHostController, destinations: NavigationDestinations, destinationKeyTransformer: ((Any) -> String)?) {
-        self.navController = navController
+    init(navBackStack: NavBackStack<NavKey>, destinations: NavigationDestinations, destinationKeyTransformer: ((Any) -> String)?) {
+        self.navBackStack = navBackStack
         self.destinations = destinations
         self.destinationKeyTransformer = destinationKeyTransformer
         updateDestinationIndexes()
     }
 
     /// Call with updated state on recompose.
-    @Composable func didCompose(navController: NavHostController, destinations: NavigationDestinations, path: Binding<[Any]>?, navigationPath: Binding<NavigationPath>?, keyboardController: SoftwareKeyboardController?) {
-        self.navController = navController
+    @Composable func didCompose(navBackStack: NavBackStack<NavKey>, destinations: NavigationDestinations, path: Binding<[Any]>?, navigationPath: Binding<NavigationPath>?, keyboardController: SoftwareKeyboardController?) {
+        self.navBackStack = navBackStack
         self.destinations = destinations
         self.path = path
         self.navigationPath = navigationPath
@@ -762,7 +775,7 @@ struct NavigationDestination {
 
     /// Whether we're at the root of the navigation stack.
     var isRoot: Bool {
-        return navController.currentBackStack.value.size <= 2 // graph entry, root entry
+        return navBackStack.size <= 1
     }
 
     /// Navigate to a target value specified in a `NavigationLink`.
@@ -802,42 +815,51 @@ struct NavigationDestination {
     func navigateBack() {
         // Check for a view destination before we pop our path bindings, because the user could push arbitrary views
         // that are not represented in the bound path
-        let viewDestinationPrefix = Self.route(for: viewDestinationIndex, valueString: "")
-        if navController.currentBackStackEntry?.destination.route?.hasPrefix(viewDestinationPrefix) == true {
-            navController.popBackStack()
+        if let lastKey = navBackStack.lastOrNull() as? SkipNavigationStackPushKey, lastKey.destinationIndex == viewDestinationIndex {
+            navBackStack.removeLastOrNull()
         } else if let path {
             path.wrappedValue.popLast()
         } else if let navigationPath {
             navigationPath.wrappedValue.removeLast()
         } else if !isRoot {
-            navController.popBackStack()
+            navBackStack.removeLastOrNull()
         }
     }
 
     /// Whether the given view entry ID is presented.
     func isViewPresented(id: String, asTop: Bool = false) -> Bool {
-        let stack = navController.currentBackStack.value
-        guard !stack.isEmpty() else {
+        guard !navBackStack.isEmpty() else {
             return false
         }
         guard !asTop else {
-            return stack.last().id == id
+            return stableEntryId(forKey: navBackStack[navBackStack.size - 1]) == id
         }
-        return stack.any { $0.id == id }
+        for key in navBackStack {
+            if stableEntryId(forKey: key) == id {
+                return true
+            }
+        }
+        return false
     }
 
-    /// The entry being navigated to.
-    func state(for entry: NavBackStackEntry) -> BackStackState? {
-        if let state = backStackState[entry.id] {
+    func stateForRoot() -> BackStackState? {
+        let rootId = stableEntryId(forKey: SkipNavigationStackRootKey.root)
+        if let state = backStackState[rootId] {
             return state
         }
         // Need to establish the root state?
-        guard navController.currentBackStack.value.count() > 1 && entry.id == navController.currentBackStack.value[1].id else {
+        guard navBackStack.size >= 1, navBackStack.firstOrNull() is SkipNavigationStackRootKey else {
             return nil
         }
-        let rootState = BackStackState(id: entry.id, route: Self.rootRoute)
-        backStackState[entry.id] = rootState
+        let rootState = BackStackState(id: rootId, route: Self.rootRoute)
+        backStackState[rootId] = rootState
         return rootState
+    }
+
+    /// The entry being navigated to.
+    func state(forPushKey pushKey: SkipNavigationStackPushKey) -> BackStackState? {
+        let id = stableEntryId(forKey: pushKey)
+        return backStackState[id]
     }
 
     /// The effective title display mode for the given preference value.
@@ -854,24 +876,34 @@ struct NavigationDestination {
 
         // Base the display mode on the back stack
         var titleDisplayMode: ToolbarTitleDisplayMode? = nil
-        for entry in navController.currentBackStack.value {
-            if entry.id == state.id {
+        for key in navBackStack {
+            let entryId = stableEntryId(forKey: key)
+            if entryId == state.id {
                 break
-            } else if let entryTitleDisplayMode = backStackState[entry.id]?.titleDisplayMode {
+            } else if let entryTitleDisplayMode = backStackState[entryId]?.titleDisplayMode {
                 titleDisplayMode = entryTitleDisplayMode
             }
         }
         return titleDisplayMode ?? ToolbarTitleDisplayMode.automatic
     }
 
-    /// Sync our back stack state with the nav controller.
-    @Composable private func syncState() {
-        // Collect as state to ensure we get re-called on change
-        let entryList = navController.currentBackStack.collectAsState()
+    private func stableEntryId(forKey key: NavKey) -> String {
+        if key is SkipNavigationStackRootKey {
+            return Self.rootRoute
+        } else if let pushKey = key as? SkipNavigationStackPushKey {
+            return Self.route(for: pushKey.destinationIndex, valueString: pushKey.identifier)
+        } else {
+            return String(describing: key)
+        }
+    }
 
-        // Toggle any presented bindings for popped states back to false. Do this immediately so that we don't
+    /// Sync our back stack state with the navigation back stack.
+    @Composable private func syncState() {
+        let stackKeys = navBackStack.toList()
         // re-present views that were removed from the stack
-        let entryIDs = Set(entryList.value.map { $0.id })
+        let entryIDs = Set(stackKeys.map { stableEntryId(forKey: $0) })
+        // Toggle any presented bindings for popped states back to false. Do this immediately so that we don't
+        // continue to present popped values while waiting for our delayed state sync below.
         for (id, state) in backStackState {
             if !entryIDs.contains(id) {
                 state.binding?.wrappedValue = false
@@ -880,12 +912,14 @@ struct NavigationDestination {
 
         // Sync the back stack with remaining states. We delay this to allow views that receive compose calls while
         // animating away to find their state
-        LaunchedEffect(entryList.value) {
+        let stackEffectKey = stackKeys.map { stableEntryId(forKey: $0) }.joinToString(separator: "|")
+        LaunchedEffect(stackEffectKey) {
             delay(1000) // 1 second
             var syncedBackStackState: [String: BackStackState] = [:]
-            for entry in entryList.value {
-                if let state = backStackState[entry.id] {
-                    syncedBackStackState[entry.id] = state
+            for key in stackKeys {
+                let entryId = stableEntryId(forKey: key)
+                if let state = backStackState[entryId] {
+                    syncedBackStackState[entryId] = state
                 }
             }
             backStackState = syncedBackStackState
@@ -896,19 +930,20 @@ struct NavigationDestination {
         guard let path = (self.path?.wrappedValue ?? navigationPath?.wrappedValue.path) else {
             return
         }
-        let backStack = navController.currentBackStack.value
-        guard !backStack.isEmpty() else {
+        let keys = navBackStack.toList()
+        guard !keys.isEmpty() else {
             return
         }
 
         // Figure out where the path and back stack first differ
         var pathIndex = 0
-        var backStackIndex = 2 // graph, root
+        var backStackIndex = 1 // root key at 0
         while pathIndex < path.count {
-            if backStackIndex >= backStack.count() {
+            if backStackIndex >= keys.size {
                 break
             }
-            let state = backStackState[backStack[backStackIndex].id]
+            let kid = stableEntryId(forKey: keys[backStackIndex])
+            let state = backStackState[kid]
             if state?.targetValue != path[pathIndex] {
                 break
             }
@@ -922,8 +957,9 @@ struct NavigationDestination {
         if pathIndex == path.count {
             hasOnlyTrailingViews = true
             let viewDestinationPrefix = Self.route(for: viewDestinationIndex, valueString: "")
-            for i in 0..<(backStack.count() - backStackIndex) {
-                if backStack[backStackIndex + i].destination.route?.hasPrefix(viewDestinationPrefix) != true {
+            for i in 0..<(keys.size - backStackIndex) {
+                let kid = stableEntryId(forKey: keys[backStackIndex + i])
+                if !kid.hasPrefix(viewDestinationPrefix) {
                     hasOnlyTrailingViews = false
                     break
                 }
@@ -934,8 +970,8 @@ struct NavigationDestination {
         }
 
         // Pop back to last common value
-        for _ in 0..<(backStack.count() - backStackIndex) {
-            navController.popBackStack()
+        for _ in 0..<(keys.size - backStackIndex) {
+            navBackStack.removeLastOrNull()
         }
         // Navigate to any new path values
         for i in pathIndex..<path.count {
@@ -964,21 +1000,33 @@ struct NavigationDestination {
     }
 
     private func navigate(route: String, destination: ((Any) -> any View)?, targetValue: Any, binding: Binding<Bool>? = nil) -> String? {
-        // We see a top app bar glitch when the keyboard animates away after push, so manually dismiss it first
-        keyboardController?.hide()
-        navController.navigate(route)
-        guard let entry = navController.currentBackStackEntry else {
+        let slash = route.indexOf("/")
+        guard slash >= 0 else {
             return nil
         }
-        var state = backStackState[entry.id]
+        let indexStr = route.substring(0, slash)
+        let identifier = route.substring(slash + 1)
+        guard let destIndex = Int(string: indexStr) else {
+            return nil
+        }
+        let pushKey = SkipNavigationStackPushKey(destinationIndex: destIndex, identifier: identifier)
+        return navigate(pushKey: pushKey, route: route, destination: destination, targetValue: targetValue, binding: binding)
+    }
+
+    private func navigate(pushKey: SkipNavigationStackPushKey, route: String, destination: ((Any) -> any View)?, targetValue: Any, binding: Binding<Bool>? = nil) -> String? {
+        // We see a top app bar glitch when the keyboard animates away after push, so manually dismiss it first
+        keyboardController?.hide()
+        navBackStack.add(pushKey)
+        let entryId = stableEntryId(forKey: pushKey)
+        var state = backStackState[entryId]
         if state == nil {
-            state = BackStackState(id: entry.id, route: route, destination: destination, targetValue: targetValue)
-            backStackState[entry.id] = state
+            state = BackStackState(id: entryId, route: route, destination: destination, targetValue: targetValue)
+            backStackState[entryId] = state
         }
         if let binding {
             state?.binding = binding
         }
-        return entry.id
+        return entryId
     }
 
     private func route(for key: AnyHashable, value: Any) -> String {

--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -41,6 +41,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -57,13 +58,15 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
 #endif
 
 // SKIP @bridge
@@ -220,9 +223,10 @@ public struct TabView : View, Renderable {
             }
         }
 
-        let navController = rememberNavController()
+        let tabBackStacks = rememberSkipTabViewBackStacks()
+        let selectedTabIndex = rememberSaveable(stateSaver: context.stateSaver as! Saver<Int, Any>) { mutableStateOf(0) }
         // Isolate access to current route within child Composable so route nav does not force us to recompose
-        navigateToCurrentRoute(controller: navController, tabRenderables: tabRenderables)
+        navigateToCurrentRoute(tabBackStacks: tabBackStacks, selectedTabIndex: selectedTabIndex, tabRenderables: tabRenderables)
 
         let tabBarPreferences = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<ToolbarBarPreferences>, Any>) { mutableStateOf(Preference<ToolbarBarPreferences>(key: TabBarPreferenceKey.self)) }
         let tabBarPreferencesCollector = PreferenceCollector<ToolbarBarPreferences>(key: TabBarPreferenceKey.self, state: tabBarPreferences)
@@ -310,7 +314,7 @@ public struct TabView : View, Renderable {
                     }
                 }
 
-                let currentRoute = currentRoute(for: navController) // Note: forces recompose of this context on tab navigation
+                let currentRoute = String(describing: selectedTabIndex.value) // Note: forces recompose of this context on tab navigation
                 // Pull the tab bar below the keyboard
                 let bottomPadding = with(density) { min(bottomBarHeightPx.value, Float(WindowInsets.ime.getBottom(density))).toDp() }
                 PaddingLayout(padding: EdgeInsets(top: 0.0, leading: 0.0, bottom: Double(-bottomPadding.value), trailing: 0.0), context: context.content()) { context in
@@ -321,7 +325,7 @@ public struct TabView : View, Renderable {
                         if let selection, let tagValue = tagValue(route: route, in: tabRenderables) {
                             selection.wrappedValue = tagValue
                         } else {
-                            navigate(controller: navController, route: route)
+                            selectedTabIndex.value = tabIndex
                         }
                     }
                     let itemIcon: @Composable (Int) -> Void = { tabIndex in
@@ -373,41 +377,49 @@ public struct TabView : View, Renderable {
             ComposeContainer(modifier: context.modifier, fillWidth: true, fillHeight: true) { modifier in
                 // Don't use a Scaffold: it clips content beyond its bounds and prevents .ignoresSafeArea modifiers from working
                 Column(modifier: modifier.background(Color.background.colorImpl())) {
-                    NavHost(navController,
-                            modifier: Modifier.fillMaxWidth().weight(Float(1.0)),
-                            startDestination: "0",
-                            enterTransition: { fadeIn() },
-                            exitTransition: { fadeOut() }) {
-                        // Use a constant number of routes. Changing routes causes a NavHost to reset its state
-                        let entryContext = context.content()
-                        for tabIndex in 0..<100 {
-                            composable(String(describing: tabIndex)) { _ in
-                                // Inset manually where our container ignored the safe area, but we aren't showing a bar
-                                let topPadding = ignoresSafeAreaEdges.contains(.top) ? WindowInsets.safeDrawing.asPaddingValues().calculateTopPadding() : 0.dp
-                                var bottomPadding = 0.dp
-                                if bottomBarTopPx.value <= Float(0.0) && ignoresSafeAreaEdges.contains(.bottom) {
-                                    bottomPadding = max(0.dp, WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() - WindowInsets.ime.asPaddingValues().calculateBottomPadding())
-                                }
-                                let contentModifier = Modifier.fillMaxSize().padding(top: topPadding, bottom: bottomPadding)
-                                let contentSafeArea = safeArea?.insetting(.bottom, to: bottomBarTopPx.value)
+                    let entryContext = context.content()
+                    let activeStack = tabBackStacks[selectedTabIndex.value]
+                    let tabDecorators = listOf(rememberSaveableStateHolderNavEntryDecorator<NavKey>())
+                    let tabEntryProvider: (NavKey) -> NavEntry<NavKey> = { key in
+                        let tabKey = key as! SkipTabViewRouteKey
+                        return NavEntry(tabKey, content: { key in
+                            let tabIndex = (key as! SkipTabViewRouteKey).index
+                            // Inset manually where our container ignored the safe area, but we aren't showing a bar
+                            let topPadding = ignoresSafeAreaEdges.contains(.top) ? WindowInsets.safeDrawing.asPaddingValues().calculateTopPadding() : 0.dp
+                            var bottomPadding = 0.dp
+                            if bottomBarTopPx.value <= Float(0.0) && ignoresSafeAreaEdges.contains(.bottom) {
+                                bottomPadding = max(0.dp, WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() - WindowInsets.ime.asPaddingValues().calculateBottomPadding())
+                            }
+                            let contentModifier = Modifier.fillMaxSize().padding(top: topPadding, bottom: bottomPadding)
+                            let contentSafeArea = safeArea?.insetting(.bottom, to: bottomBarTopPx.value)
 
-                                // Special-case the first composition to avoid seeing the layout adjust. This is a common
-                                // issue with nav stacks in particular, and they're common enough that we need to cater to them.
-                                // Use an extra container to avoid causing the content itself to recompose
-                                let hasComposed = remember { mutableStateOf(false) }
-                                SideEffect { hasComposed.value = true }
-                                let alpha = hasComposed.value ? Float(1.0) : Float(0.0)
-                                Box(modifier: Modifier.alpha(alpha), contentAlignment: androidx.compose.ui.Alignment.Center) {
-                                    // This block is called multiple times on tab switch. Use stable arguments that will prevent our entry from
-                                    // recomposing when called with the same values
-                                    let arguments = TabEntryArguments(tabIndex: tabIndex, modifier: contentModifier, safeArea: contentSafeArea)
-                                    PreferenceValues.shared.collectPreferences([tabBarPreferencesCollector]) {
-                                        RenderEntry(with: arguments, context: entryContext)
-                                    }
+                            // Special-case the first composition to avoid seeing the layout adjust. This is a common
+                            // issue with nav stacks in particular, and they're common enough that we need to cater to them.
+                            // Use an extra container to avoid causing the content itself to recompose
+                            let hasComposed = remember { mutableStateOf(false) }
+                            SideEffect { hasComposed.value = true }
+                            let alpha = hasComposed.value ? Float(1.0) : Float(0.0)
+                            Box(modifier: Modifier.alpha(alpha), contentAlignment: androidx.compose.ui.Alignment.Center) {
+                                // This block is called multiple times on tab switch. Use stable arguments that will prevent our entry from
+                                // recomposing when called with the same values
+                                let arguments = TabEntryArguments(tabIndex: tabIndex, modifier: contentModifier, safeArea: contentSafeArea)
+                                PreferenceValues.shared.collectPreferences([tabBarPreferencesCollector]) {
+                                    RenderEntry(with: arguments, context: entryContext)
                                 }
                             }
-                        }
+                        })
                     }
+                    NavDisplay(
+                        backStack: activeStack,
+                        modifier: Modifier.fillMaxWidth().weight(Float(1.0)),
+                        onBack: {
+                            if activeStack.size > 1 {
+                                activeStack.removeLastOrNull()
+                            }
+                        },
+                        entryDecorators: tabDecorators,
+                        entryProvider: tabEntryProvider
+                    )
                     bottomBar()
                 }
             }
@@ -474,33 +486,13 @@ public struct TabView : View, Renderable {
         }
     }
 
-    private func navigate(controller navController: NavHostController, route: String) {
-        navController.navigate(route) {
-            // Clear back stack so that tabs don't participate in Android system back button
-            let destinationID = navController.currentBackStackEntry?.destination?.id ?? navController.graph.startDestinationId
-            popUpTo(destinationID) {
-                inclusive = true
-                saveState = true
-            }
-            // Avoid multiple copies of the same destination when reselecting the same item
-            launchSingleTop = true
-            // Restore state when reselecting a previously selected item
-            restoreState = true
-        }
-    }
-
-    @Composable private func navigateToCurrentRoute(controller navController: NavHostController, tabRenderables: kotlin.collections.List<Renderable>) {
-        let currentRoute = currentRoute(for: navController)
-        if let selection, let currentRoute, selection.wrappedValue != tagValue(route: currentRoute, in: tabRenderables) {
-            if let route = route(tagValue: selection.wrappedValue, in: tabRenderables) {
-                navigate(controller: navController, route: route)
+    @Composable private func navigateToCurrentRoute(tabBackStacks: kotlin.collections.List<NavBackStack<NavKey>>, selectedTabIndex: MutableState<Int>, tabRenderables: kotlin.collections.List<Renderable>) {
+        let currentRoute = String(describing: selectedTabIndex.value)
+        if let selection, selection.wrappedValue != tagValue(route: currentRoute, in: tabRenderables) {
+            if let route = route(tagValue: selection.wrappedValue, in: tabRenderables), let idx = Int(string: route) {
+                selectedTabIndex.value = idx
             }
         }
-    }
-
-    @Composable private func currentRoute(for navController: NavHostController) -> String? {
-        // In your BottomNavigation composable, get the current NavBackStackEntry using the currentBackStackEntryAsState() function. This entry gives you access to the current NavDestination. The selected state of each BottomNavigationItem can then be determined by comparing the item's route with the route of the current destination and its parent destinations (to handle cases when you are using nested navigation) via the NavDestination hierarchy.
-        navController.currentBackStackEntryAsState().value?.destination?.route
     }
     #else
     public var body: some View {
@@ -510,6 +502,27 @@ public struct TabView : View, Renderable {
 }
 
 #if SKIP
+// SKIP INSERT: @Serializable
+public struct SkipTabViewRouteKey : NavKey {
+    public let index: Int
+}
+
+/// Fixed 100 persistent back stacks for tab bar content (matches legacy `0..<100` routes).
+@Composable public func rememberSkipTabViewBackStacks() -> kotlin.collections.List<NavBackStack<NavKey>> {
+    // Use a constant number of routes. Changing routes causes a NavHost to reset its state
+    // TODO is this necessary with NavDisplay?
+    let slots = remember { arrayOfNulls<NavBackStack<NavKey>?>(100) }
+    var tabIndex = 0
+    while tabIndex < 100 {
+        let ti = tabIndex
+        key(ti) {
+            slots[ti] = rememberNavBackStack(SkipTabViewRouteKey(index: ti))
+        }
+        tabIndex += 1
+    }
+    return slots.filterNotNull()
+}
+
 @Stable struct TabEntryArguments: Equatable {
     let tabIndex: Int
     let modifier: Modifier


### PR DESCRIPTION
Fixes #292 and #370

Relevant Google docs:

* Navigation 2 (I had to brush up on Nav2 to do this PR. Maybe you need a refresher?)
  * https://developer.android.com/guide/navigation
  * https://developer.android.com/develop/ui/compose/navigation
* https://developer.android.com/guide/navigation/navigation-3
  * ^^ the whole thing, but especially https://developer.android.com/guide/navigation/navigation-3/migration-guide
* Predictive back
  * https://developer.android.com/develop/ui/compose/system/predictive-back
  * https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture
  * https://developer.android.com/design/ui/mobile/guides/patterns/predictive-back

My goal was to keep this PR as lightweight as possible, to make it as straightforward as possible to review it. (I recommend viewing it in a whitespace-ignoring diff tool, even just `git diff -w`.)

I think a deeper refactoring is possible here, to integrate more deeply with Navigation 3, but I figure we'd land this, shake out bugs, and then refactor in a subsequent PR (if desired).

# `Navigation.swift`

The migration guide calls for these steps:
> 1. Add the Navigation 3 dependencies.
> 2. Update your navigation routes to implement the `NavKey` interface.
> 3. Create classes to hold and modify your navigation state.
> 4. Replace `NavController` with these classes.
> 5. Move your destinations from `NavHost`'s `NavGraph` into an `entryProvider`.
> 6. Replace `NavHost` with `NavDisplay`.
> 7. Remove Navigation 2 dependencies.

I'm going to explain these steps slightly out of order.

* I have nothing interesting to say about Step 1 or Step 7; I updated `skip.yml`.
* Steps 2, 3, and 5 are about the new Navigation 3 data model, which I'll summarize below.
* With the new data model in place, all that remained were steps 4 and 6, which were mindless replacements.

## `NavKey`s instead of routes (Step 2, Step 3, Step 5)

In Nav2 terms, `Navigation.swift`'s `Navigator` routes were strings, either `Navigator.rootRoute` `"navigationroot"` or a route defined by the static `route(for:valueString:)` function.

```swift
/// Route for the given destination index and value string.
static func route(for destinationIndex: Int, valueString: String) -> String {
    return String(describing: destinationIndex) + "/" + valueString
}
```

In the `NavigationStack` `@Composable Render(context:)`, we defined the navigation graph in code, passing the root composable, followed by a list of composables (each with its own destination route) to the `NavHost` constructor.

In this PR, I defined two `NavKey` objects:

```swift
// SKIP INSERT: @Serializable
public enum SkipNavigationStackRootKey : NavKey {
    case root
}

// SKIP INSERT: @Serializable
public struct SkipNavigationStackPushKey : NavKey {
    public let destinationIndex: Int
    public let identifier: String
}
```

`@Composable Render(context:)` now builds an "entry provider" using these two types; no need for a for loop over destinations here. We still use `route(for:valueString:)` to construct a stable entry ID for each entry in the navigation stack:

```swift
private func stableEntryId(forKey key: NavKey) -> String {
    if key is SkipNavigationStackRootKey {
        return Self.rootRoute
    } else if let pushKey = key as? SkipNavigationStackPushKey {
        return Self.route(for: pushKey.destinationIndex, valueString: pushKey.identifier)
    } else {
        return String(describing: key)
    }
}
```

`Navigator` kept a `private var backStackState: [String: BackStackState] = [:]` … we're still using it, with the `stableEntryId` as the key.

```swift
func state(forPushKey pushKey: SkipNavigationStackPushKey) -> BackStackState? {
    let id = stableEntryId(forKey: pushKey)
    return backStackState[id]
}
```

## Replacing `NavController` with `NavBackStack<NavKey>` and replacing `NavHost` with `NavDisplay` (Steps 4 and 6)

Instead of a `NavController`, Navigation 3 uses a "back stack", which can be a simple array, but they recommend using `rememberNavBackStack` which creates a `NavBackStack<NavKey>`. Everything you would do with a `navController`, you now do by mutating the `navBackStack`, so there's a lot of find-and-replace of `navController` with `navBackStack` throughout.

In Navigation 2, we included a `BackHandler` which called `navigator.value.navigateBack()`; this broke predictive back. In Navigation 3, `NavDisplay` replaces `NavHost`, and includes an `onBack` callback where we can call `navigator.value.navigateBack()`. We therefore no longer require a `BackHandler`. By simply deleting it, we get predictive-back animations for free.

In fact, we get _all_ stack transition animations for free, so I just deleted the existing animation definitions, too, preferring to use Android's recommended defaults. (Perhaps in a subsequent PR, we'll implement the [`navigationTransition(_:)`](https://developer.apple.com/documentation/swiftui/view/navigationtransition%28_%3A%29) modifier, allowing users to customize the transition animation for individual stack entries. Luckily for me, we don't support that yet, so I don't have to worry about it right now.)

# `TabView.swift`

The `TabView` `NavHost` did a thing that strikes me as quite strange: it defined a navigation graph of 100 tabs, identified by ID number. There's a comment explaining: "Use a constant number of routes. Changing routes causes a NavHost to reset its state"

I didn't want to mess with this, and I wasn't at all sure how to do regression testing against ripping that out, so I made a little function to return a list of 100 `NavBackStack`s, leaving in a little "TODO" comment:

```swift
/// Fixed 100 persistent back stacks for tab bar content (matches legacy `0..<100` routes).
@Composable public func rememberSkipTabViewBackStacks() -> kotlin.collections.List<NavBackStack<NavKey>> {
    // Use a constant number of routes. Changing routes causes a NavHost to reset its state
    // TODO is this necessary with NavDisplay?
    let slots = remember { arrayOfNulls<NavBackStack<NavKey>?>(100) }
    var tabIndex = 0
    while tabIndex < 100 {
        let ti = tabIndex
        key(ti) {
            slots[ti] = rememberNavBackStack(SkipTabViewRouteKey(index: ti))
        }
        tabIndex += 1
    }
    return slots.filterNotNull()
}
``` 

And we also created a new `NavKey` route for `TabView`, tracking the tab index.

```swift
// SKIP INSERT: @Serializable
public struct SkipTabViewRouteKey : NavKey {
    public let index: Int
}
```

`TabView`s `NavDisplay` then has a generic handler for any `SkipTabViewRouteKey`.

`TabView` now tracks its own `selectedTabIndex` state instead of asking `navController` to navigate to a numbered route. Functions that accepted a `navController` now accept `selectedTabIndex: MutableState<Int>` and the `tabBackStacks`.

What `TabView` called a `route` is now just a stringified `tabIndex`. (It probably doesn't need to be stringified, but it kept this huge PR from being even huger, because we already had a function that converts string routes into tab tag values.)

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

The migration guide recommended prompting an AI to do the transition, "Migrate from Navigation 2 to Navigation 3 using the official migration guide." I started with that, and cleaned up and thoroughly reviewed the result.

To verify the changes, I wrote automated tests! ✨ https://github.com/skiptools/skipapp-showcase/pull/83

…and I also just clicked around the NavigationStackPlayground and the TabView playground in the showcase.

## Manually testing predictive back

I especially enjoyed testing predictive back. It's a little thorny to set it up in the emulator. I created an API 36 (Android 16) medium phone with the Google Play Store. I searched settings for "Gesture Navigation" and turned on "Gesture navigation." With that on, if you drag on the emulator from the left 5% of the screen or the right 5% of the screen toward the center, you'll see a predictive back animation.

Prior to this PR, the Showcase already supported the built in "back-to-home" predictive back animation, but when navigating back from a playground to the list, nothing animated until you released your finger. But now…

[Screen_recording_20260331_154710.webm](https://github.com/user-attachments/assets/3ae27fdb-7876-41a1-b032-3e5cf6d4dcdb)

