### PR TITLE
`tabViewStyle(.sidebarAdaptable)`

### DIFF
--- a/Sources/SkipUI/Skip/skip.yml
+++ b/Sources/SkipUI/Skip/skip.yml
@@ -40,6 +40,7 @@ settings:
                 - 'library("androidx-activity-compose", "androidx.activity", "activity-compose").versionRef("androidx-activity")'
                 - 'library("androidx-lifecycle-process", "androidx.lifecycle", "lifecycle-process").versionRef("androidx-lifecycle-process")'
                 - 'library("androidx-compose-material3-adaptive", "androidx.compose.material3.adaptive", "adaptive").versionRef("androidx-material3-adaptive")'
+                - 'library("androidx-compose-material3-adaptive-navigation-suite", "androidx.compose.material3", "material3-adaptive-navigation-suite").versionRef("androidx-material3-adaptive")'
 
                 - 'library("androidx-work-runtime", "androidx.work", "work-runtime-ktx").versionRef("androidx-work")'
 
@@ -77,6 +78,7 @@ build:
         - 'api(libs.androidx.compose.material.icons.extended)'
         - 'api(libs.androidx.compose.material3)'
         - 'api(libs.androidx.compose.material3.adaptive)'
+        - 'api(libs.androidx.compose.material3.adaptive.navigation.suite)'
         - 'api(libs.androidx.compose.foundation)'
         - 'api(libs.androidx.navigation3.runtime)'
         - 'api(libs.androidx.navigation3.ui)'

--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -11,15 +11,17 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -34,7 +36,15 @@ import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationBarItemColors
 import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
+import androidx.compose.material3.NavigationRailItemDefaults
 import androidx.compose.material3.contentColorFor
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldLayout
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
+import androidx.compose.material3.adaptive.navigationsuite.rememberNavigationSuiteScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.SideEffect
@@ -250,130 +260,11 @@ public struct TabView : View, Renderable {
             }
         }
         let bottomBarHeightPx = remember { mutableStateOf(with(density) { defaultBottomBarHeight.toPx() }) }
+        let tabNavLeadingEndPx = remember { mutableStateOf(Float(0.0)) }
 
         // Reduce the tab bar preferences outside the bar composable. Otherwise the reduced value may change
         // when the bottom bar recomposes
         let reducedTabBarPreferences = tabBarPreferences.value.reduced
-        let bottomBar: @Composable () -> Void = {
-            guard tabs.any({ $0 != nil }) && reducedTabBarPreferences.visibility != Visibility.hidden else {
-                SideEffect {
-                    bottomBarTopPx.value = Float(0.0)
-                    bottomBarHeightPx.value = Float(0.0)
-                }
-                return
-            }
-            var tabBarModifier = Modifier.fillMaxWidth()
-                .onGloballyPositionedInWindow { bounds in
-                    bottomBarTopPx.value = bounds.top
-                    bottomBarHeightPx.value = bounds.bottom - bounds.top
-                }
-                .semantics { testTagsAsResourceId = true }.testTag("skip_ui_automation_tab_bar")
-            let tint = EnvironmentValues.shared._tint
-            let hasColorScheme = reducedTabBarPreferences.colorScheme != nil
-            let isSystemBackground = reducedTabBarPreferences.isSystemBackground == true
-            let showScrolledBackground = reducedTabBarPreferences.backgroundVisibility == Visibility.visible || reducedTabBarPreferences.scrollableState?.canScrollForward == true
-            let materialColorScheme: androidx.compose.material3.ColorScheme
-            if showScrolledBackground, let customColorScheme = reducedTabBarPreferences.colorScheme?.asMaterialTheme() {
-                materialColorScheme = customColorScheme
-            } else {
-                materialColorScheme = MaterialTheme.colorScheme
-            }
-            MaterialTheme(colorScheme: materialColorScheme) {
-                let indicatorColor: androidx.compose.ui.graphics.Color
-                if let tint {
-                    indicatorColor = tint.asComposeColor().copy(alpha: Float(0.35))
-                } else {
-                    indicatorColor = ColorScheme.fromMaterialTheme(colorScheme: materialColorScheme) == ColorScheme.dark ? androidx.compose.ui.graphics.Color.White.copy(alpha: Float(0.1)) : androidx.compose.ui.graphics.Color.Black.copy(alpha: Float(0.1))
-                }
-                let tabBarBackgroundColor: androidx.compose.ui.graphics.Color
-                let unscrolledTabBarBackgroundColor: androidx.compose.ui.graphics.Color
-                let tabBarBackgroundForBrush: ShapeStyle?
-                let tabBarItemColors: NavigationBarItemColors
-                if reducedTabBarPreferences.backgroundVisibility == Visibility.hidden {
-                    tabBarBackgroundColor = androidx.compose.ui.graphics.Color.Transparent
-                    unscrolledTabBarBackgroundColor = androidx.compose.ui.graphics.Color.Transparent
-                    tabBarBackgroundForBrush = nil
-                    tabBarItemColors = NavigationBarItemDefaults.colors(indicatorColor: indicatorColor)
-                } else if let background = reducedTabBarPreferences.background {
-                    if let color = background.asColor(opacity: 1.0, animationContext: nil) {
-                        tabBarBackgroundColor = color
-                        unscrolledTabBarBackgroundColor = isSystemBackground ? Color.systemBarBackground.colorImpl() : color.copy(alpha: Float(0.0))
-                        tabBarBackgroundForBrush = nil
-                    } else {
-                        unscrolledTabBarBackgroundColor = isSystemBackground ? Color.systemBarBackground.colorImpl() : androidx.compose.ui.graphics.Color.Transparent
-                        tabBarBackgroundColor = unscrolledTabBarBackgroundColor.copy(alpha: Float(0.0))
-                        tabBarBackgroundForBrush = background
-                    }
-                    tabBarItemColors = NavigationBarItemDefaults.colors(indicatorColor: indicatorColor)
-                } else {
-                    tabBarBackgroundColor = Color.systemBarBackground.colorImpl()
-                    unscrolledTabBarBackgroundColor = isSystemBackground ? tabBarBackgroundColor : tabBarBackgroundColor.copy(alpha: Float(0.0))
-                    tabBarBackgroundForBrush = nil
-                    if tint == nil {
-                        tabBarItemColors = NavigationBarItemDefaults.colors()
-                    } else {
-                        tabBarItemColors = NavigationBarItemDefaults.colors(indicatorColor: indicatorColor)
-                    }
-                }
-                if showScrolledBackground, let tabBarBackgroundForBrush {
-                    if let tabBarBackgroundBrush = tabBarBackgroundForBrush.asBrush(opacity: 1.0, animationContext: nil) {
-                        tabBarModifier = tabBarModifier.background(tabBarBackgroundBrush)
-                    }
-                }
-
-                let currentRoute = String(describing: selectedTabIndex.value) // Note: forces recompose of this context on tab navigation
-                // Pull the tab bar below the keyboard
-                let bottomPadding = with(density) { min(bottomBarHeightPx.value, Float(WindowInsets.ime.getBottom(density))).toDp() }
-                PaddingLayout(padding: EdgeInsets(top: 0.0, leading: 0.0, bottom: Double(-bottomPadding.value), trailing: 0.0), context: context.content()) { context in
-                    let tabsState = rememberUpdatedState(tabs)
-                    let containerColor = showScrolledBackground ? tabBarBackgroundColor : unscrolledTabBarBackgroundColor
-                    let onItemClick: (Int) -> Void = { tabIndex in
-                        let route = String(describing: tabIndex)
-                        if let selection, let tagValue = tagValue(route: route, in: tabRenderables) {
-                            selection.wrappedValue = tagValue
-                        } else {
-                            selectedTabIndex.value = tabIndex
-                        }
-                    }
-                    let itemIcon: @Composable (Int) -> Void = { tabIndex in
-                        let tab = tabsState.value[tabIndex]
-                        tab?.RenderImage(context: tabContext)
-                    }
-                    let itemLabel: @Composable (Int) -> Void = { tabIndex in
-                        let tab = tabsState.value[tabIndex]
-                        tab?.RenderTitle(context: tabContext)
-                    }
-                    var options = Material3NavigationBarOptions(modifier: context.modifier.then(tabBarModifier), containerColor: containerColor, contentColor: MaterialTheme.colorScheme.contentColorFor(containerColor), onItemClick: onItemClick, itemIcon: itemIcon, itemLabel: itemLabel, itemColors: tabBarItemColors)
-                    if let updateOptions = EnvironmentValues.shared._material3NavigationBar {
-                        options = updateOptions(options)
-                    }
-                    NavigationBar(modifier: options.modifier.semantics { testTagsAsResourceId = true }.testTag("skip_ui_automation_tab_bar"), containerColor: options.containerColor, contentColor: options.contentColor, tonalElevation: options.tonalElevation) {
-                        for tabIndex in 0..<tabRenderables.size {
-                            if tabs[tabIndex]?.isHidden == true {
-                                continue
-                            }
-                            let route = String(describing: tabIndex)
-                            let label: (@Composable () -> Void)?
-                            if let itemLabel = options.itemLabel {
-                                label = { itemLabel(tabIndex)  }
-                            } else {
-                                label = nil
-                            }
-                            NavigationBarItem(selected: route == currentRoute,
-                                onClick: { options.onItemClick(tabIndex) },
-                                icon: { options.itemIcon(tabIndex) },
-                                modifier: options.itemModifier(tabIndex),
-                                enabled: options.itemEnabled(tabIndex) && tabs[tabIndex]?.isDisabled != true,
-                                label: label,
-                                alwaysShowLabel: options.alwaysShowItemLabels,
-                                colors: options.itemColors,
-                                interactionSource: options.itemInteractionSource
-                            )
-                        }
-                    }
-                }
-            }
-        }
 
         // When we layout, extend into the safe area if it is due to system bars, not into any app chrome. We extend
         // into the top bar too so that tab content can also extend into the top area without getting cut off during
@@ -383,65 +274,259 @@ public struct TabView : View, Renderable {
         IgnoresSafeAreaLayout(expandInto: ignoresSafeAreaEdges) { _, _ in
             ComposeContainer(modifier: context.modifier, fillWidth: true, fillHeight: true) { modifier in
                 // Don't use a Scaffold: it clips content beyond its bounds and prevents .ignoresSafeArea modifiers from working
-                Column(modifier: modifier.background(Color.background.colorImpl())) {
-                    let entryContext = context.content()
-                    let activeStack = tabBackStacks[selectedTabIndex.value]
-                    let tabEntryProvider: (NavKey) -> NavEntry<NavKey> = { key in
-                        let tabKey = key as! SkipTabViewRouteKey
-                        return NavEntry(tabKey, content: { key in
-                            let tabIndex = (key as! SkipTabViewRouteKey).index
-                            // Inset manually where our container ignored the safe area, but we aren't showing a bar
-                            let topPadding = ignoresSafeAreaEdges.contains(.top) ? WindowInsets.safeDrawing.asPaddingValues().calculateTopPadding() : 0.dp
-                            var bottomPadding = 0.dp
-                            if bottomBarTopPx.value <= Float(0.0) && ignoresSafeAreaEdges.contains(.bottom) {
-                                bottomPadding = max(0.dp, WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() - WindowInsets.ime.asPaddingValues().calculateBottomPadding())
+                Box(modifier: modifier.background(Color.background.colorImpl()).fillMaxSize()) {
+                    let tabViewStyle = EnvironmentValues.shared._tabViewStyle
+                    let layoutType: NavigationSuiteType
+                    if tabViewStyle is SidebarAdaptableTabViewStyle {
+                        layoutType = NavigationSuiteScaffoldDefaults.calculateFromAdaptiveInfo(currentWindowAdaptiveInfo())
+                    } else {
+                        // `.automatic` (DefaultTabViewStyle), `.tabBarOnly`, and unset style all use a bottom tab bar only.
+                        layoutType = NavigationSuiteType.NavigationBar
+                    }
+                    let layoutTypeState = rememberUpdatedState(layoutType)
+                    let navigationSuiteScaffoldState = rememberNavigationSuiteScaffoldState()
+                    NavigationSuiteScaffoldLayout(
+                        navigationSuite: {
+                            guard tabs.any({ $0 != nil }) && reducedTabBarPreferences.visibility != Visibility.hidden else {
+                                SideEffect {
+                                    bottomBarTopPx.value = Float(0.0)
+                                    bottomBarHeightPx.value = Float(0.0)
+                                    tabNavLeadingEndPx.value = Float(0.0)
+                                }
+                                return
                             }
-                            let contentModifier = Modifier.fillMaxSize().padding(top: topPadding, bottom: bottomPadding)
-                            let tabViewSafeArea = tabViewSafeAreaState.value
-                            let contentSafeArea = tabViewSafeArea?.insetting(Edge.bottom, to: bottomBarTopPx.value)
+                            var tabBarModifier = (layoutType == NavigationSuiteType.NavigationBar ? Modifier.fillMaxWidth() : Modifier.fillMaxHeight().wrapContentWidth())
+                                .onGloballyPositionedInWindow { bounds in
+                                    let lt = layoutTypeState.value
+                                    if lt == NavigationSuiteType.NavigationBar {
+                                        bottomBarTopPx.value = bounds.top
+                                        bottomBarHeightPx.value = bounds.bottom - bounds.top
+                                        tabNavLeadingEndPx.value = Float(0.0)
+                                    } else if lt == NavigationSuiteType.NavigationRail {
+                                        bottomBarTopPx.value = Float(0.0)
+                                        bottomBarHeightPx.value = Float(0.0)
+                                        tabNavLeadingEndPx.value = bounds.right
+                                    } else {
+                                        bottomBarTopPx.value = Float(0.0)
+                                        bottomBarHeightPx.value = Float(0.0)
+                                        tabNavLeadingEndPx.value = Float(0.0)
+                                    }
+                                }
+                                .semantics { testTagsAsResourceId = true }.testTag("skip_ui_automation_tab_bar")
+                            let tint = EnvironmentValues.shared._tint
+                            let isSystemBackground = reducedTabBarPreferences.isSystemBackground == true
+                            let showScrolledBackground = reducedTabBarPreferences.backgroundVisibility == Visibility.visible || reducedTabBarPreferences.scrollableState?.canScrollForward == true
+                            let materialColorScheme: androidx.compose.material3.ColorScheme
+                            if showScrolledBackground, let customColorScheme = reducedTabBarPreferences.colorScheme?.asMaterialTheme() {
+                                materialColorScheme = customColorScheme
+                            } else {
+                                materialColorScheme = MaterialTheme.colorScheme
+                            }
+                            MaterialTheme(colorScheme: materialColorScheme) {
+                                let indicatorColor: androidx.compose.ui.graphics.Color
+                                if let tint {
+                                    indicatorColor = tint.asComposeColor().copy(alpha: Float(0.35))
+                                } else {
+                                    indicatorColor = ColorScheme.fromMaterialTheme(colorScheme: materialColorScheme) == ColorScheme.dark ? androidx.compose.ui.graphics.Color.White.copy(alpha: Float(0.1)) : androidx.compose.ui.graphics.Color.Black.copy(alpha: Float(0.1))
+                                }
+                                let tabBarBackgroundColor: androidx.compose.ui.graphics.Color
+                                let unscrolledTabBarBackgroundColor: androidx.compose.ui.graphics.Color
+                                let tabBarBackgroundForBrush: ShapeStyle?
+                                let tabBarItemColors: NavigationBarItemColors
+                                if reducedTabBarPreferences.backgroundVisibility == Visibility.hidden {
+                                    tabBarBackgroundColor = androidx.compose.ui.graphics.Color.Transparent
+                                    unscrolledTabBarBackgroundColor = androidx.compose.ui.graphics.Color.Transparent
+                                    tabBarBackgroundForBrush = nil
+                                    tabBarItemColors = NavigationBarItemDefaults.colors(indicatorColor: indicatorColor)
+                                } else if let background = reducedTabBarPreferences.background {
+                                    if let color = background.asColor(opacity: 1.0, animationContext: nil) {
+                                        tabBarBackgroundColor = color
+                                        unscrolledTabBarBackgroundColor = isSystemBackground ? Color.systemBarBackground.colorImpl() : color.copy(alpha: Float(0.0))
+                                        tabBarBackgroundForBrush = nil
+                                    } else {
+                                        unscrolledTabBarBackgroundColor = isSystemBackground ? Color.systemBarBackground.colorImpl() : androidx.compose.ui.graphics.Color.Transparent
+                                        tabBarBackgroundColor = unscrolledTabBarBackgroundColor.copy(alpha: Float(0.0))
+                                        tabBarBackgroundForBrush = background
+                                    }
+                                    tabBarItemColors = NavigationBarItemDefaults.colors(indicatorColor: indicatorColor)
+                                } else {
+                                    tabBarBackgroundColor = Color.systemBarBackground.colorImpl()
+                                    unscrolledTabBarBackgroundColor = isSystemBackground ? tabBarBackgroundColor : tabBarBackgroundColor.copy(alpha: Float(0.0))
+                                    tabBarBackgroundForBrush = nil
+                                    if tint == nil {
+                                        tabBarItemColors = NavigationBarItemDefaults.colors()
+                                    } else {
+                                        tabBarItemColors = NavigationBarItemDefaults.colors(indicatorColor: indicatorColor)
+                                    }
+                                }
+                                if showScrolledBackground, let tabBarBackgroundForBrush {
+                                    if let tabBarBackgroundBrush = tabBarBackgroundForBrush.asBrush(opacity: 1.0, animationContext: nil) {
+                                        tabBarModifier = tabBarModifier.background(tabBarBackgroundBrush)
+                                    }
+                                }
 
-                            // Special-case the first composition to avoid seeing the layout adjust. This is a common
-                            // issue with nav stacks in particular, and they're common enough that we need to cater to them.
-                            // Use an extra container to avoid causing the content itself to recompose
-                            let hasComposed = remember { mutableStateOf(false) }
-                            SideEffect { hasComposed.value = true }
-                            let alpha = hasComposed.value ? Float(1.0) : Float(0.0)
-                            Box(modifier: Modifier.alpha(alpha), contentAlignment: androidx.compose.ui.Alignment.Center) {
-                                // This block is called multiple times on tab switch. Use stable arguments that will prevent our entry from
-                                // recomposing when called with the same values
-                                let arguments = TabEntryArguments(tabIndex: tabIndex, modifier: contentModifier, safeArea: contentSafeArea)
-                                PreferenceValues.shared.collectPreferences([tabBarPreferencesCollector]) {
-                                    RenderEntry(with: arguments, context: entryContext)
+                                let currentRoute = String(describing: selectedTabIndex.value) // Note: forces recompose of this context on tab navigation
+                                let bottomPadding: Dp
+                                if layoutType == NavigationSuiteType.NavigationBar {
+                                    bottomPadding = with(density) { min(bottomBarHeightPx.value, Float(WindowInsets.ime.getBottom(density))).toDp() }
+                                } else {
+                                    bottomPadding = 0.dp
+                                }
+                                PaddingLayout(padding: EdgeInsets(top: 0.0, leading: 0.0, bottom: Double(-bottomPadding.value), trailing: 0.0), context: context.content()) { context in
+                                    let tabsState = rememberUpdatedState(tabs)
+                                    let containerColor = showScrolledBackground ? tabBarBackgroundColor : unscrolledTabBarBackgroundColor
+                                    let onItemClick: (Int) -> Void = { tabIndex in
+                                        let route = String(describing: tabIndex)
+                                        if let selection, let tagValue = tagValue(route: route, in: tabRenderables) {
+                                            selection.wrappedValue = tagValue
+                                        } else {
+                                            selectedTabIndex.value = tabIndex
+                                        }
+                                    }
+                                    let itemIcon: @Composable (Int) -> Void = { tabIndex in
+                                        let tab = tabsState.value[tabIndex]
+                                        tab?.RenderImage(context: tabContext)
+                                    }
+                                    let itemLabel: @Composable (Int) -> Void = { tabIndex in
+                                        let tab = tabsState.value[tabIndex]
+                                        tab?.RenderTitle(context: tabContext)
+                                    }
+                                    var options = Material3NavigationBarOptions(modifier: context.modifier.then(tabBarModifier), containerColor: containerColor, contentColor: MaterialTheme.colorScheme.contentColorFor(containerColor), onItemClick: onItemClick, itemIcon: itemIcon, itemLabel: itemLabel, itemColors: tabBarItemColors)
+                                    if let updateOptions = EnvironmentValues.shared._material3NavigationBar {
+                                        options = updateOptions(options)
+                                    }
+                                    let railItemColors = NavigationRailItemDefaults.colors(
+                                        selectedIconColor: options.itemColors.selectedIconColor,
+                                        selectedTextColor: options.itemColors.selectedTextColor,
+                                        indicatorColor: options.itemColors.selectedIndicatorColor,
+                                        unselectedIconColor: options.itemColors.unselectedIconColor,
+                                        unselectedTextColor: options.itemColors.unselectedTextColor,
+                                        disabledIconColor: options.itemColors.disabledIconColor,
+                                        disabledTextColor: options.itemColors.disabledTextColor
+                                    )
+                                    if layoutType == NavigationSuiteType.NavigationBar {
+                                        NavigationBar(modifier: options.modifier.semantics { testTagsAsResourceId = true }.testTag("skip_ui_automation_tab_bar"), containerColor: options.containerColor, contentColor: options.contentColor, tonalElevation: options.tonalElevation) {
+                                            for tabIndex in 0..<tabRenderables.size {
+                                                if tabs[tabIndex]?.isHidden == true {
+                                                    continue
+                                                }
+                                                let route = String(describing: tabIndex)
+                                                let label: (@Composable () -> Void)?
+                                                if let itemLabel = options.itemLabel {
+                                                    label = { itemLabel(tabIndex) }
+                                                } else {
+                                                    label = nil
+                                                }
+                                                NavigationBarItem(selected: route == currentRoute,
+                                                    onClick: { options.onItemClick(tabIndex) },
+                                                    icon: { options.itemIcon(tabIndex) },
+                                                    modifier: options.itemModifier(tabIndex),
+                                                    enabled: options.itemEnabled(tabIndex) && tabs[tabIndex]?.isDisabled != true,
+                                                    label: label,
+                                                    alwaysShowLabel: options.alwaysShowItemLabels,
+                                                    colors: options.itemColors,
+                                                    interactionSource: options.itemInteractionSource
+                                                )
+                                            }
+                                        }
+                                    } else {
+                                        NavigationRail(modifier: options.modifier, containerColor: options.containerColor, contentColor: options.contentColor) {
+                                            // Center the item group vertically (Material navigation rail guidance for tablets).
+                                            Spacer(modifier: Modifier.weight(Float(1.0)))
+                                            for tabIndex in 0..<tabRenderables.size {
+                                                if tabs[tabIndex]?.isHidden == true {
+                                                    continue
+                                                }
+                                                let route = String(describing: tabIndex)
+                                                let label: (@Composable () -> Void)?
+                                                if let itemLabel = options.itemLabel {
+                                                    label = { itemLabel(tabIndex) }
+                                                } else {
+                                                    label = nil
+                                                }
+                                                NavigationRailItem(selected: route == currentRoute,
+                                                    onClick: { options.onItemClick(tabIndex) },
+                                                    icon: { options.itemIcon(tabIndex) },
+                                                    modifier: options.itemModifier(tabIndex),
+                                                    enabled: options.itemEnabled(tabIndex) && tabs[tabIndex]?.isDisabled != true,
+                                                    label: label,
+                                                    alwaysShowLabel: options.alwaysShowItemLabels,
+                                                    colors: railItemColors,
+                                                    interactionSource: options.itemInteractionSource
+                                                )
+                                            }
+                                            Spacer(modifier: Modifier.weight(Float(1.0)))
+                                        }
+                                    }
                                 }
                             }
-                        })
-                    }
-                    // Keep a stable SaveableStateHolder for each tab's backStack
-                    let decoratedEntrySlots = remember { arrayOfNulls<kotlin.collections.List<NavEntry<NavKey>>?>(100) }
-                    var tabIndex = 0
-                    while tabIndex < 100 {
-                        let ti = tabIndex
-                        key(ti) {
-                            let tabDecorators = listOf(rememberSaveableStateHolderNavEntryDecorator<NavKey>())
-                            decoratedEntrySlots[ti] = rememberDecoratedNavEntries(
-                                backStack: tabBackStacks[ti],
-                                entryDecorators: tabDecorators,
-                                entryProvider: tabEntryProvider
+                        },
+                        navigationSuiteType: layoutType,
+                        state: navigationSuiteScaffoldState,
+                        primaryActionContent: {},
+                        content: {
+                            let entryContext = context.content()
+                            let activeStack = tabBackStacks[selectedTabIndex.value]
+                            let tabEntryProvider: (NavKey) -> NavEntry<NavKey> = { key in
+                                let tabKey = key as! SkipTabViewRouteKey
+                                return NavEntry(tabKey, content: { key in
+                                    let tabIndex = (key as! SkipTabViewRouteKey).index
+                                    // Inset manually where our container ignored the safe area, but we aren't showing a bar
+                                    let topPadding = ignoresSafeAreaEdges.contains(.top) ? WindowInsets.safeDrawing.asPaddingValues().calculateTopPadding() : 0.dp
+                                    var bottomPadding = 0.dp
+                                    if bottomBarTopPx.value <= Float(0.0) && ignoresSafeAreaEdges.contains(.bottom) {
+                                        bottomPadding = max(0.dp, WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() - WindowInsets.ime.asPaddingValues().calculateBottomPadding())
+                                    }
+                                    let contentModifier = Modifier.fillMaxSize().padding(top: topPadding, bottom: bottomPadding)
+                                    let tabViewSafeArea = tabViewSafeAreaState.value
+                                    var contentSafeArea = tabViewSafeArea?.insetting(Edge.bottom, to: bottomBarTopPx.value)
+                                    if tabNavLeadingEndPx.value > Float(0.0) {
+                                        contentSafeArea = contentSafeArea?.insetting(Edge.leading, to: tabNavLeadingEndPx.value)
+                                    }
+
+                                    // Special-case the first composition to avoid seeing the layout adjust. This is a common
+                                    // issue with nav stacks in particular, and they're common enough that we need to cater to them.
+                                    // Use an extra container to avoid causing the content itself to recompose
+                                    let hasComposed = remember { mutableStateOf(false) }
+                                    SideEffect { hasComposed.value = true }
+                                    let alpha = hasComposed.value ? Float(1.0) : Float(0.0)
+                                    Box(modifier: Modifier.alpha(alpha), contentAlignment: androidx.compose.ui.Alignment.Center) {
+                                        // This block is called multiple times on tab switch. Use stable arguments that will prevent our entry from
+                                        // recomposing when called with the same values
+                                        let arguments = TabEntryArguments(tabIndex: tabIndex, modifier: contentModifier, safeArea: contentSafeArea)
+                                        PreferenceValues.shared.collectPreferences([tabBarPreferencesCollector]) {
+                                            RenderEntry(with: arguments, context: entryContext)
+                                        }
+                                    }
+                                })
+                            }
+                            // Keep a stable SaveableStateHolder for each tab's backStack
+                            let decoratedEntrySlots = remember { arrayOfNulls<kotlin.collections.List<NavEntry<NavKey>>?>(100) }
+                            var tabIndex = 0
+                            while tabIndex < 100 {
+                                let ti = tabIndex
+                                key(ti) {
+                                    let tabDecorators = listOf(rememberSaveableStateHolderNavEntryDecorator<NavKey>())
+                                    decoratedEntrySlots[ti] = rememberDecoratedNavEntries(
+                                        backStack: tabBackStacks[ti],
+                                        entryDecorators: tabDecorators,
+                                        entryProvider: tabEntryProvider
+                                    )
+                                }
+                                tabIndex += 1
+                            }
+                            let activeEntries = decoratedEntrySlots[selectedTabIndex.value]!
+                            NavDisplay(
+                                entries: activeEntries,
+                                modifier: Modifier.fillMaxSize(),
+                                onBack: {
+                                    if activeStack.size > 1 {
+                                        activeStack.removeLastOrNull()
+                                    }
+                                },
                             )
                         }
-                        tabIndex += 1
-                    }
-                    let activeEntries = decoratedEntrySlots[selectedTabIndex.value]!
-                    NavDisplay(
-                        entries: activeEntries,
-                        modifier: Modifier.fillMaxWidth().weight(Float(1.0)),
-                        onBack: {
-                            if activeStack.size > 1 {
-                                activeStack.removeLastOrNull()
-                            }
-                        },
                     )
-                    bottomBar()
                 }
             }
         }
@@ -590,6 +675,16 @@ public struct TabBarOnlyTabViewStyle: TabViewStyle {
 
 extension TabViewStyle where Self == TabBarOnlyTabViewStyle {
     public static var tabBarOnly: TabBarOnlyTabViewStyle { TabBarOnlyTabViewStyle() }
+}
+
+public struct SidebarAdaptableTabViewStyle: TabViewStyle {
+    static let identifier = 3 // For bridging
+
+    public init() {}
+}
+
+extension TabViewStyle where Self == SidebarAdaptableTabViewStyle {
+    public static var sidebarAdaptable: SidebarAdaptableTabViewStyle { SidebarAdaptableTabViewStyle() }
 }
 
 public struct PageTabViewStyle: TabViewStyle {
@@ -1097,6 +1192,8 @@ extension View {
         switch bridgedStyle {
         case TabBarOnlyTabViewStyle.identifier:
             style = TabBarOnlyTabViewStyle()
+        case SidebarAdaptableTabViewStyle.identifier:
+            style = SidebarAdaptableTabViewStyle()
         case PageTabViewStyle.identifier:
             let indexDisplayMode: PageTabViewStyle.IndexDisplayMode = (bridgedDisplayMode == nil ? nil : PageTabViewStyle.IndexDisplayMode(rawValue: bridgedDisplayMode!)) ?? .automatic
             style = PageTabViewStyle(indexDisplayMode: indexDisplayMode)


### PR DESCRIPTION
There are a lot of indentation changes in this PR. It's best viewed in a whitespace-ignoring diff tool, even just `git diff -w`.

This PR adds a dependency on `androidx.compose.material3:material3-adaptive-navigation-suite`. We're not using the top-level `NavigationSuiteScaffold`, but we are using its `NavigationSuiteScaffoldLayout`.

Before/After

<img width="320" height="200" alt="Screenshot_20260403_210724" src="https://github.com/user-attachments/assets/7e288fe1-39a0-40a2-8a5d-b268ac8fae83" />
<img width="320" height="200" alt="Screenshot_20260403_205950" src="https://github.com/user-attachments/assets/8d96c197-8476-485e-8eb1-3375ce659e79" />


## It was a judgment call to decide what Material component(s) to use for this

* https://m3.material.io/components/navigation-rail/overview
* https://m3.material.io/components/navigation-drawer/overview

Google's Material 3 guidelines on navigation are a bit confusing right now, because the documentation is about the new Material 3 Expressive upgrade, which is not part of the current stable Compose Bill of Materials. In Material 3 Expressive, "Navigation Drawer" was deprecated in favor of a new "expanded" mode for Navigation Rail.

On iOS 18 and iOS 26, `sidebarAdaptable` shows a bottom tab bar on iPhone, and, on iPad, shows UI that I think is more comparable to a Material 3 "Navigation Drawer" or a Material 3 Expressive "Wide Navigation Rail," with a button to switch between a wide sidebar and a top tab bar.

Google's default `NavigationSuiteScaffold` prefers to use a "collapsed" Navigation Rail on large screens, even in the new Material 3 Expressive version. And Google's apps tend to follow that pattern, e.g. the Google Play Store (which has been updated to adopt Material 3 Expressive components in Android 16) uses a collapsed, non-expandable Navigation Rail.

So, we're forced to decide what behavior the sidebar should have by default: collapsed Navigation Rail or expanded Navigation Rail(/Drawer)?

And we also have to decide whether to give the user a toggle, and what the toggle would do. On SwiftUI, users can toggle between a sidebar and a top tab bar. Material 3 Expressive recommends a toggle between a collapsed Navigation Rail and an expanded Navigation Rail.

I opted not to give the user any toggle at all, and to prefer a collapsed Navigation Rail by default, matching `NavigationSuiteScaffold` and the Google Play Store in Android 16 (which _has_ been upgraded to Material 3 Expressive). Perhaps we could add a setting to give the user a toggle in a future PR.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
    https://github.com/skiptools/skip-fuse-ui/pull/98
- [x] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app
    https://github.com/skiptools/skipapp-showcase/pull/87
    https://github.com/skiptools/skipapp-showcase-fuse/pull/57

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor mostly did the whole thing; I manually tested it on Android phones and tablets.