### PR TITLE
UIImage Additions

### DIFF
--- a/Sources/SkipUI/SkipUI/UIKit/UIImage.swift
+++ b/Sources/SkipUI/SkipUI/UIKit/UIImage.swift
@@ -8,6 +8,8 @@ import android.graphics.ImageDecoder
 import android.net.Uri
 import java.nio.ByteBuffer
 import android.graphics.Bitmap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 #endif
 
 // SKIP @bridge
@@ -80,13 +82,39 @@ public class UIImage {
     public func prepareForDisplay(completionHandler: @escaping (UIImage?) -> Void) {
         fatalError()
     }
-    @available(*, unavailable)
+    
     public func preparingThumbnail(of size: CGSize) -> UIImage? {
-        fatalError()
+        #if SKIP
+        if let bitmap {
+            let newBitmap = Bitmap.createScaledBitmap(bitmap, Int(size.width), Int(size.height), true)
+            return UIImage(bitmap: newBitmap, scale: 1.0)
+        }
+        #endif
+        return nil
     }
+    
+    // SKIP @bridge
+    public func preparingThumbnail(width: CGFloat, height: CGFloat) -> UIImage? {
+        return preparingThumbnail(of: .init(width: width, height: height))
+    }
+    
     @available(*, unavailable)
     public func prepareThumbnail(of size: CGSize, completionHandler: @escaping (UIImage?) -> Void) {
         fatalError()
+    }
+
+    public func byPreparingThumbnail(ofSize size: CGSize) async -> UIImage? {
+        #if SKIP
+        return await withContext(Dispatchers.Default) {
+            preparingThumbnail(of: size)
+        }
+        #endif
+        return nil
+    }
+    
+    // SKIP @bridge
+    public func byPreparingThumbnail(width: CGFloat, height: CGFloat) async -> UIImage? {
+        return await byPreparingThumbnail(ofSize: .init(width: width, height: height))
     }
 
     public init?(contentsOfFile path: String) {
@@ -101,6 +129,7 @@ public class UIImage {
             }
             
             self.bitmap = bitmap
+            self.size = .init(width: Double(bitmap.getWidth()), height: Double(bitmap.getHeight()))
         } catch {
             android.util.Log.w("SkipUI", "Error initializing UIImage from contentsOfFile", error as? Throwable)
             return nil
@@ -125,7 +154,7 @@ public class UIImage {
             }
             
             self.bitmap = bitmap
-            
+            self.size = .init(width: Double(bitmap.getWidth()), height: Double(bitmap.getHeight()))
         } catch {
             android.util.Log.w("SkipUI", "Error initializing UIImage from data", error as? Throwable)
             return nil
@@ -138,6 +167,14 @@ public class UIImage {
     public static func bridgedInit(data: Data, scale: CGFloat) -> UIImage? {
         return UIImage(data: data, scale: scale)
     }
+    
+    #if SKIP
+    private init(bitmap: Bitmap, scale: CGFloat) {
+        self.bitmap = bitmap
+        self.size = .init(width: Double(bitmap.getWidth()), height: Double(bitmap.getHeight()))
+        self.scale = scale
+    }
+    #endif
 
     @available(*, unavailable)
     public struct UIImageReader {
@@ -213,11 +250,18 @@ public class UIImage {
 
     // SKIP @bridge
     public let scale: CGFloat
-
-    @available(*, unavailable)
-    public var size: CGSize {
-        fatalError()
+    
+    public private(set) var size: CGSize = .zero
+    
+    // SKIP @bridge
+    public var bridgedWidth: CGFloat {
+        return size.width
     }
+    // SKIP @bridge
+    public var bridgedHeight: CGFloat {
+        return size.height
+    }
+    
     @available(*, unavailable)
     public var imageOrientation: Any {
         fatalError()


### PR DESCRIPTION
I use UIImage's quite heavily in my app and there were a couple of API surfaces missing that I've added here.

1. Image `.size`
2. Thumbnail creation with `.byPreparingThumbnail(ofSize: _)`

One thing to note is that unfortunately CGSize, wasn't bridgable. So for skip fuse access, I've added separate functions/accessors that take individual CGFloats for width and height. 

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
  - https://github.com/skiptools/skip-fuse-ui/pull/100
- [x] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app
  - https://github.com/skiptools/skipapp-showcase/pull/89
  - https://github.com/skiptools/skipapp-showcase-fuse/pull/60

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

