### PR TITLE
Bugfix: Maintain content and scroll offset of the tab view when switching tabs

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -56,6 +56,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.zIndex
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavBackStack
@@ -378,7 +379,6 @@ public struct TabView : View, Renderable {
                 // Don't use a Scaffold: it clips content beyond its bounds and prevents .ignoresSafeArea modifiers from working
                 Column(modifier: modifier.background(Color.background.colorImpl())) {
                     let entryContext = context.content()
-                    let activeStack = tabBackStacks[selectedTabIndex.value]
                     let tabDecorators = listOf(rememberSaveableStateHolderNavEntryDecorator<NavKey>())
                     let tabEntryProvider: (NavKey) -> NavEntry<NavKey> = { key in
                         let tabKey = key as! SkipTabViewRouteKey
@@ -409,17 +409,30 @@ public struct TabView : View, Renderable {
                             }
                         })
                     }
-                    NavDisplay(
-                        backStack: activeStack,
-                        modifier: Modifier.fillMaxWidth().weight(Float(1.0)),
-                        onBack: {
-                            if activeStack.size > 1 {
-                                activeStack.removeLastOrNull()
+                    Box(modifier: Modifier.fillMaxWidth().weight(Float(1.0))) {
+                        for tabIndex in 0..<tabRenderables.size {
+                            let isSelected = selectedTabIndex.value == tabIndex
+                            let tabStack = tabBackStacks[tabIndex]
+                            Box(
+                                modifier: Modifier
+                                    .fillMaxSize()
+                                    .zIndex(isSelected ? Float(1.0) : Float(0.0))
+                                    .alpha(isSelected ? Float(1.0) : Float(0.0))
+                            ) {
+                                NavDisplay(
+                                    backStack: tabStack,
+                                    modifier: Modifier.fillMaxSize(),
+                                    onBack: {
+                                        if tabStack.size > 1 {
+                                            tabStack.removeLastOrNull()
+                                        }
+                                    },
+                                    entryDecorators: tabDecorators,
+                                    entryProvider: tabEntryProvider
+                                )
                             }
-                        },
-                        entryDecorators: tabDecorators,
-                        entryProvider: tabEntryProvider
-                    )
+                        }
+                    }
                     bottomBar()
                 }
             }


### PR DESCRIPTION
This PR resolves an issue in which switching tabs caused the view and scroll positions of the content to reset.

Previously, the tab view worked as expected. However, after updating to the latest version of Skip UI (which migrated to Navigation3), the views began to re-initialize with every tab switch, resulting in the loss of all temporary state and scroll offsets.

This PR ensures that tab views only load once and are then merely toggled. This restores the previous behavior, maintaining the user's position and data when navigating between tabs.

**Before:**
![before](https://github.com/user-attachments/assets/b4e5a181-62c5-4d1a-b0cc-d43bf0f3d237)

**After:**
![after](https://github.com/user-attachments/assets/2c6fbf74-3c81-47c9-9e38-84caf5578084)

---

Thank you for contributing to the Skip project! Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device
- [X] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
=> No Changes Required
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

