### PR TITLE
Add support for `@ScaledMetric`

### DIFF
--- a/Sources/SkipUI/SkipUI/Properties/ScaledMetric.swift
+++ b/Sources/SkipUI/SkipUI/Properties/ScaledMetric.swift
@@ -1,0 +1,56 @@
+// Copyright 2023–2026 Skip
+// SPDX-License-Identifier: MPL-2.0
+#if !SKIP_BRIDGE
+#if SKIP
+import SkipModel
+
+import android.content.res.Resources
+import androidx.compose.ui.unit.fontscaling.FontScaleConverterFactory
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+
+// SwiftUI ScaledMetric accetps a `BinaryFloatingPoint`, implemented by Double, Float, and Float80.
+// We're only supporting Double for now.
+public final class ScaledMetric<Value: Double>: StateTracker {
+    private var _wrappedValue: Value
+    private var wrappedValueState: MutableState<Value>?
+
+    public init(wrappedValue: Value) {
+        _wrappedValue = wrappedValue
+        StateTracking.register(self)
+    }
+
+    public init(wrappedValue: Value, relativeTo textStyle: Font.TextStyle) {
+        _wrappedValue = wrappedValue
+        // Compose doesn't scale differently based on text style, so we ignore it.
+        _ = textStyle
+        StateTracking.register(self)
+    }
+
+    public var wrappedValue: Value {
+        let value = wrappedValueState?.value ?? _wrappedValue
+        return ScaledMetricBridge.scaledValue(for: value) as! Value
+    }
+
+    public func trackState() {
+        wrappedValueState = mutableStateOf(_wrappedValue)
+    }
+}
+
+// SKIP @bridgeMembers
+public enum ScaledMetricBridge {
+
+    public static func scaledValue(for value: Double) -> Double {
+        let scale: Float = Resources.getSystem().configuration.fontScale
+        let scaled: Double
+        if FontScaleConverterFactory.isNonLinearFontScalingActive(fontScale: scale),
+            let converter = FontScaleConverterFactory.forScale(fontScale: scale) {
+            scaled = Double(converter.convertSpToDp(sp: Float(value)))
+        } else {
+            scaled = value * scale
+        }
+        return scaled
+    }
+}
+#endif
+#endif

--- a/Sources/SkipUI/SkipUI/Text/Font.swift
+++ b/Sources/SkipUI/SkipUI/Text/Font.swift
@@ -490,15 +490,4 @@ public enum LegibilityWeight : Hashable {
     case bold
 }
 
-#if !SKIP
-
-// Unneeded stubs:
-
-//@propertyWrapper public struct ScaledMetric<Value> : DynamicProperty where Value : BinaryFloatingPoint {
-//    public init(wrappedValue: Value, relativeTo textStyle: Font.TextStyle) { fatalError() }
-//    public init(wrappedValue: Value) { fatalError() }
-//    public var wrappedValue: Value { get { fatalError() } }
-//}
-
-#endif
 #endif


### PR DESCRIPTION
* Depends on https://github.com/skiptools/skipstone/pull/230

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
    PR incoming
- [x] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app
    PRs incoming

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor did a first draft, and then I rewrote it by hand. I tested it in the Lite showcase and the Fuse showcase apps.

## Screenshots

<img width="201" height="437" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-14 at 11 37 59" src="https://github.com/user-attachments/assets/72995faf-be7d-4b19-8a28-ad13a64cfed7" /> <img width="201" height="437" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-14 at 11 38 12" src="https://github.com/user-attachments/assets/b6518cc4-84df-4ae5-bde4-20b30ecc2427" />

<img width="180" height="400" alt="Screenshot_20260414_125118" src="https://github.com/user-attachments/assets/e6bdb08d-d598-4b68-9148-5ce0c3b34b6c" /> <img width="180" height="400" alt="Screenshot_20260414_125125" src="https://github.com/user-attachments/assets/bed5a477-f196-41d0-b7e0-feea75c364f2" />

