### PR TITLE
Add View.overlay() modifier that accepts non-closure View

### DIFF
--- a/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
+++ b/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
@@ -1009,15 +1009,18 @@ extension View {
         #endif
     }
 
-    public func overlay(alignment: Alignment = .center, @ViewBuilder content: () -> any View) -> any View {
+    public func overlay(_ overlay: any View, alignment: Alignment = .center) -> any View {
         #if SKIP
-        let overlay = content()
         return ModifiedContent(content: self, modifier: RenderModifier { renderable, context in
             OverlayLayout(content: renderable, context: context, overlay: overlay, alignment: alignment)
         })
         #else
         return self
         #endif
+    }
+
+    public func overlay(alignment: Alignment = .center, @ViewBuilder content: () -> any View) -> any View {
+        return overlay(content(), alignment: alignment)
     }
 
     // SKIP @bridge


### PR DESCRIPTION
While `.background` accepts both a direct View parameter as well as a closure argument like so:

```swift
view.background { Circle() }
view.background(Circle())
```

the `.overlay` modifier only accepted the closure-based parameter. This fix updates it to be able to accept both, like so:

```swift
view.overlay { Circle() }
view.overlay(Circle())
```