### PR TITLE
TabView: Keep a stable SaveableStateHolder for each tab's backStack

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -64,6 +64,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.rememberDecoratedNavEntries
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
@@ -383,7 +384,6 @@ public struct TabView : View, Renderable {
                 Column(modifier: modifier.background(Color.background.colorImpl())) {
                     let entryContext = context.content()
                     let activeStack = tabBackStacks[selectedTabIndex.value]
-                    let tabDecorators = listOf(rememberSaveableStateHolderNavEntryDecorator<NavKey>())
                     let tabEntryProvider: (NavKey) -> NavEntry<NavKey> = { key in
                         let tabKey = key as! SkipTabViewRouteKey
                         return NavEntry(tabKey, content: { key in
@@ -413,16 +413,30 @@ public struct TabView : View, Renderable {
                             }
                         })
                     }
+                    // Keep a stable SaveableStateHolder for each tab's backStack
+                    let decoratedEntrySlots = remember { arrayOfNulls<kotlin.collections.List<NavEntry<NavKey>>?>(100) }
+                    var tabIndex = 0
+                    while tabIndex < 100 {
+                        let ti = tabIndex
+                        key(ti) {
+                            let tabDecorators = listOf(rememberSaveableStateHolderNavEntryDecorator<NavKey>())
+                            decoratedEntrySlots[ti] = rememberDecoratedNavEntries(
+                                backStack: tabBackStacks[ti],
+                                entryDecorators: tabDecorators,
+                                entryProvider: tabEntryProvider
+                            )
+                        }
+                        tabIndex += 1
+                    }
+                    let activeEntries = decoratedEntrySlots[selectedTabIndex.value]!
                     NavDisplay(
-                        backStack: activeStack,
+                        entries: activeEntries,
                         modifier: Modifier.fillMaxWidth().weight(Float(1.0)),
                         onBack: {
                             if activeStack.size > 1 {
                                 activeStack.removeLastOrNull()
                             }
                         },
-                        entryDecorators: tabDecorators,
-                        entryProvider: tabEntryProvider
                     )
                     bottomBar()
                 }


### PR DESCRIPTION
Fixes #397

This is underdocumented in https://developer.android.com/guide/navigation/navigation-3/naventrydecorators but there's a bit more documentation in https://developer.android.com/reference/kotlin/androidx/navigation3/ui/NavDisplay.composable and a sample in https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/multiplestacks

Nav 3 has a `NavDisplay` composable that accepts a `backStack`, and a `NavDisplay` composible that accepts a `List<NavEntry>`. The `backStack` API is a convenience API that calls the `entries` API, like this:

```kotlin
val entries =
    rememberDecoratedNavEntries(
        backStack = backStack,
        entryDecorators = entryDecorators,
        entryProvider = entryProvider,
    )

NavDisplay(
    entries = entries,
    // ...
)
```

Each `NavEntry` gets its own `backStack` with its own decorators, the most important of which is the builtin decorator that provides a `SaveableStateHolder`, which ensures that `remember`ed state gets restored. In Nav 3, you call `rememberDecoratedNavEntries` to associate a `backStack` with its decorators.

We were remembering just one `SaveableStateHolder` decorator for the active `backStack`, but we needed to remember N `SaveableStateHolder` decorators for N tabs.

Here, we're calling `rememberDecoratedNavEntries` 100 times for 100 slots, each with its own `backStack`, its own decorators (just the one `SaveableStateHolder` decorator for each), all sharing the same `tabEntryProvider`.

We pass `NavDisplay` the current `entries` (a list of just one entry) for the currently selected tab. When we switch tabs, we pass `NavDisplay` a different list of one entry, with its own `backStack` and `SaveableStateHolder`; when returning to a previous tab, we provide the remembered entry list, which provides its remembered `SaveableStateHolder`, so the tab can restore its state from that.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
  (no change required)
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

