### PR TITLE
Fix `.firstTextBaseline` and `.lastTextBaseline`

### DIFF
--- a/Sources/SkipUI/Skip/StackLayouts.kt
+++ b/Sources/SkipUI/Skip/StackLayouts.kt
@@ -33,9 +33,27 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.util.fastCoerceAtLeast
 import androidx.compose.ui.util.fastRoundToInt
+import androidx.compose.ui.layout.LastBaseline
 import kotlin.collections.List
 import kotlin.math.max
 import kotlin.math.min
+
+/**
+ * Compose `Row` / [HStackRow] baseline alignment for `Text`: SwiftUI `HStack(alignment: .firstTextBaseline)`
+ * requires [androidx.compose.foundation.layout.alignByBaseline] on children; this applies the same
+ * [WithAlignmentLineElement] used by [HStackRowScope.alignByBaseline].
+ */
+@Stable
+fun Modifier.applyHStackTextBaselineAlignment(alignmentKey: String?): Modifier {
+    if (alignmentKey == null) {
+        return this
+    }
+    return when (alignmentKey) {
+        "firstTextBaseline" -> this.then(WithAlignmentLineElement(FirstBaseline))
+        "lastTextBaseline" -> this.then(WithAlignmentLineElement(LastBaseline))
+        else -> this
+    }
+}
 
 /**
  * This file contains heavily modified versions of Compose's `Row` and `Column` layouts to provide

--- a/Sources/SkipUI/SkipUI/Compose/ComposeContainer.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeContainer.swift
@@ -119,6 +119,7 @@ private func composeFlexibleMergedMax(_ current: Float?, _ proposed: Float?) -> 
         // the correct layout before rendering in the content block below, so that its own children can distribute available space
         $0.set_flexibleWidthModifier(nil)
         $0.set_flexibleHeightModifier(nil)
+        $0.set_horizontalStackVerticalAlignmentKey(nil)
 
         // Set the 'flexibleWidth' and 'flexibleHeight' blocks to trigger a side effect to update our container's expansion state, which
         // can cause it to recompose and recalculate its own modifier. We must use `SideEffect` or the recomposition never happens

--- a/Sources/SkipUI/SkipUI/Containers/HStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/HStack.swift
@@ -102,6 +102,7 @@ public struct HStack : View, Renderable {
                         }
                         EnvironmentValues.shared.setValues {
                             $0.set_flexibleWidthModifier(flexibleWidthModifier)
+                            $0.set_horizontalStackVerticalAlignmentKey(alignment.key)
                             return ComposeResult.ok
                         } in: {
                             var lastWasSpacer: Bool? = nil
@@ -117,6 +118,7 @@ public struct HStack : View, Renderable {
                         }
                         EnvironmentValues.shared.setValues {
                             $0.set_flexibleWidthModifier(flexibleWidthModifier)
+                            $0.set_horizontalStackVerticalAlignmentKey(alignment.key)
                             return ComposeResult.ok
                         } in: {
                             var lastWasSpacer: Bool? = nil
@@ -168,6 +170,7 @@ public struct HStack : View, Renderable {
                     }
                     EnvironmentValues.shared.setValues {
                         $0.set_flexibleWidthModifier(flexibleWidthModifier)
+                        $0.set_horizontalStackVerticalAlignmentKey(alignment.key)
                         return ComposeResult.ok
                     } in: {
                         var lastWasSpacer: Bool? = nil
@@ -193,6 +196,7 @@ public struct HStack : View, Renderable {
                     }
                     EnvironmentValues.shared.setValues {
                         $0.set_flexibleWidthModifier(flexibleWidthModifier)
+                        $0.set_horizontalStackVerticalAlignmentKey(alignment.key)
                         return ComposeResult.ok
                     } in: {
                         var lastWasSpacer: Bool? = nil

--- a/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyHStack.swift
@@ -108,6 +108,7 @@ public struct LazyHStack : View, Renderable {
                 }
                 EnvironmentValues.shared.setValues {
                     $0.set_contentPadding(EdgeInsets())
+                    $0.set_horizontalStackVerticalAlignmentKey(alignment.key)
                     return ComposeResult.ok
                 } in: {
                 LazyRow(state: listState, modifier: modifier, horizontalArrangement: rowArrangement, verticalAlignment: rowAlignment, contentPadding: contentPadding, userScrollEnabled: isScrollEnabled, flingBehavior: flingBehavior) {

--- a/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
+++ b/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
@@ -694,6 +694,12 @@ extension EnvironmentValues {
         set { setBuiltinValue(key: "_layoutAxis", value: newValue, defaultValue: { nil }) }
     }
 
+    /// When non-nil, direct children of an ``HStack`` / ``LazyHStack`` should use Compose baseline alignment (see ``Text``).
+    var _horizontalStackVerticalAlignmentKey: String? {
+        get { builtinValue(key: "_horizontalStackVerticalAlignmentKey", defaultValue: { nil }) as! String? }
+        set { setBuiltinValue(key: "_horizontalStackVerticalAlignmentKey", value: newValue, defaultValue: { nil }) }
+    }
+
     /// The axes that are unbound due to scrolling.
     ///
     /// This is different than `_scrollAxes`, because using a fixed size container or applying a different layout axis

--- a/Sources/SkipUI/SkipUI/Text/Text.swift
+++ b/Sources/SkipUI/SkipUI/Text/Text.swift
@@ -400,6 +400,9 @@ struct _Text: View, Renderable, Equatable {
         let styleInfo = Text.styleInfo(textEnvironment: textEnvironment, redaction: redaction, context: context)
         let animatable = styleInfo.style.asAnimatable(context: context)
         var modifier = Modifier.flexibleWidth(max: Float.flexibleUnknownNonExpanding).then(context.modifier)
+        if EnvironmentValues.shared._layoutAxis == .horizontal {
+            modifier = modifier.applyHStackTextBaselineAlignment(EnvironmentValues.shared._horizontalStackVerticalAlignmentKey)
+        }
         var options: Material3TextOptions
         if let locnode {
             let layoutResult = remember { mutableStateOf<TextLayoutResult?>(nil) }


### PR DESCRIPTION
## iOS
<img width="358" height="416" alt="image" src="https://github.com/user-attachments/assets/025fb276-bf22-44c0-8f08-96be92d5d02a" />

## Before: center-aligned vertically 

<img width="360" height="359" alt="image" src="https://github.com/user-attachments/assets/b4cd0ef2-eb13-4de4-8c2a-452cc90f7469" />

## After
<img width="360" height="365" alt="image" src="https://github.com/user-attachments/assets/ffa42f69-4c63-4a50-93ba-bf17d368bd84" />

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
   (Not required)
- [x] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app
    https://github.com/skiptools/skipapp-showcase/pull/93

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor did this one. I tested it manually in both Showcases.