### PR TITLE
Fix .onLongPressGesture not firing on Text with markdown link

### DIFF
--- a/Sources/SkipUI/SkipUI/Text/Text.swift
+++ b/Sources/SkipUI/SkipUI/Text/Text.swift
@@ -3,7 +3,7 @@
 #if !SKIP_BRIDGE
 import Foundation
 #if SKIP
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -12,11 +12,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.DrawModifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawOutline
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.ExperimentalTextApi
@@ -39,6 +41,8 @@ import androidx.compose.foundation.text.TextAutoSize
 import skip.foundation.LocalizedStringResource
 import skip.foundation.Bundle
 import skip.foundation.Locale
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.math.abs
 #elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGFloat
 #endif
@@ -418,8 +422,33 @@ struct _Text: View, Renderable, Equatable {
                 let currentHandler = rememberUpdatedState(EnvironmentValues.shared.openURL)
                 let currentIsEnabled = rememberUpdatedState(EnvironmentValues.shared.isEnabled)
                 modifier = modifier.pointerInput(true) {
-                    detectTapGestures { pos in
-                        if currentIsEnabled.value, let offset = layoutResult.value?.getOffsetForPosition(pos), let urlString = currentText.value.getUrlAnnotations(offset, offset).firstOrNull()?.item.url, let url = URL(string: urlString) {
+                    // Detect a tap on a markdown link without consuming pointer events,
+                    // so a parent .onLongPressGesture / .onTapGesture / .gesture(...)
+                    // still fires. See https://github.com/skiptools/skip-ui/issues/371.
+                    let slop = viewConfiguration.touchSlop
+                    let timeout = viewConfiguration.longPressTimeoutMillis
+                    awaitEachGesture {
+                        let downEvent = awaitPointerEvent(pass: PointerEventPass.Initial)
+                        guard let down = downEvent.changes.firstOrNull({ $0.pressed }) else { return }
+                        let start = down.position
+                        let upPosition: Offset? = withTimeoutOrNull(timeout) {
+                            while true {
+                                let event = awaitPointerEvent(pass: PointerEventPass.Initial)
+                                guard let change = event.changes.firstOrNull() else { return nil }
+                                if abs(change.position.x - start.x) > slop || abs(change.position.y - start.y) > slop {
+                                    return nil
+                                }
+                                if !change.pressed {
+                                    return change.position
+                                }
+                            }
+                            return nil
+                        }
+                        guard let upPosition else { return }
+                        if currentIsEnabled.value,
+                           let offset = layoutResult.value?.getOffsetForPosition(upPosition),
+                           let urlString = currentText.value.getUrlAnnotations(offset, offset).firstOrNull()?.item.url,
+                           let url = URL(string: urlString) {
                             currentHandler.value.invoke(url)
                         }
                     }

--- a/Tests/SkipUITests/SkipUITests.swift
+++ b/Tests/SkipUITests/SkipUITests.swift
@@ -284,6 +284,35 @@ final class SkipUITests: SkipUITestCase {
         }
     }
 
+    // Regression test for https://github.com/skiptools/skip-ui/issues/371:
+    // .onLongPressGesture must still fire on a Text whose body contains a
+    // markdown link. Before the fix, the link-tap pointerInput in Text
+    // consumed the down event so the parent gesture's long-press timer
+    // never started.
+    func testLongPressOnTextWithMarkdownLink() throws {
+        try testUI(view: {
+            LongPressLinkTestView().accessibilityIdentifier("test-view")
+        }, eval: { rule in
+            try check(rule, id: "status", hasText: "no")
+            #if SKIP
+            rule.onNodeWithTag("text").performTouchInput { longClick() }
+            #endif
+            try check(rule, id: "status", hasText: "yes")
+        })
+    }
+    struct LongPressLinkTestView: View {
+        @State var pressed = false
+        var body: some View {
+            VStack {
+                Text("Long press [me](https://skip.tools)")
+                    .accessibilityIdentifier("text")
+                    .onLongPressGesture { pressed = true }
+                Text(pressed ? "yes" : "no")
+                    .accessibilityIdentifier("status")
+            }
+        }
+    }
+
     // look up a localized string in the current bundle using the given language
     func localizedBundle(_ lang: String) throws -> Bundle {
         try XCTUnwrap(Bundle(url: XCTUnwrap(Bundle.module.url(forResource: "Localizable", withExtension: "strings", subdirectory: nil, localization: lang)).deletingLastPathComponent()))


### PR DESCRIPTION
## Summary

Fixes #371 — `.onLongPressGesture` (and any other `.gesture(...)` / `.onTapGesture` modifier) does not fire on Android when applied to a `Text` whose body contains a markdown `[Link](url)`. The same code works on iOS and on plain `Text`.

## Root cause

`_Text.Render()` installed an inner `Modifier.pointerInput(true) { detectTapGestures { pos in ... } }` to handle link taps whenever the rendered `AttributedString` had URL annotations (`Sources/SkipUI/SkipUI/Text/Text.swift`). The same node already had an outer `pointerInput(true) { detectTapGestures(onLongPress:, onTap:, ...) }` installed by `GestureModifier` (`Sources/SkipUI/SkipUI/System/Gesture.swift`) for any attached `.onLongPressGesture` / `.onTapGesture` / `.gesture(...)`.

Compose's `detectTapGestures` consumes the down event for its own state machine, so the outer detector's `awaitFirstDown(requireUnconsumed = true)` never returned and its long-press timer never started.

Plain `Text` is unaffected because `if !links.isEmpty()` is false and the inner block is never installed. iOS is unaffected because the inner block is `#if SKIP`-gated and SwiftUI's recogniser-based gesture composition isn't subject to Compose's "first consumer wins" pointer semantics.

## Fix

Replaces the inner `detectTapGestures` with a non-consuming `awaitEachGesture` loop on `PointerEventPass.Initial`, mirroring the pattern already used in `Sources/SkipUI/SkipUI/Commands/ContextMenu.swift`. The inner detector observes pointer events, identifies a clean tap within `viewConfiguration.touchSlop` and `viewConfiguration.longPressTimeoutMillis`, opens the URL on hit, and never calls `consume()` — so the outer `GestureModifier`'s `detectTapGestures` runs unobstructed.

## Test plan

- New `testLongPressOnTextWithMarkdownLink` in `Tests/SkipUITests/SkipUITests.swift` renders a `Text("Long press [me](url)")` with `.onLongPressGesture` and a status indicator, then performs `composeTestRule.onNodeWithTag("text").performTouchInput { longClick() }`. Verified to pass on Robolectric (transpiled Kotlin/Compose path) — without the fix, the status stays `"no"`; with the fix, it flips to `"yes"`.
- The full `swift test` run is green: 55 passed, 2 skipped (pre-existing), 0 failed.
- Manual reproduction with the verbatim 17-line snippet from the issue: long-press now fires the dialog on both Texts on Android. Repro project: <https://github.com/digitalby/skip-ui-issue-371-research>.

## Out of scope

- Refactoring the link-tap path to share a single `detectTapGestures` instance with `GestureModifier` (would require new internal gesture-registration plumbing). The non-consuming detector is a localised fix that resolves the user-visible bug without that surface-area change. Happy to follow up with a larger refactor if maintainers want it.
- Sweep of other `pointerInput { detectTapGestures }` call sites for the same class of collision. None obvious from the codebase, but a deliberate audit would be a separate PR.
