### PR TITLE
Add support for `statusBarHidden(:)`

### DIFF
--- a/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
+++ b/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
@@ -49,6 +49,9 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsControllerCompat
 #elseif canImport(CoreGraphics)
 import struct CoreGraphics.CGAffineTransform
 import struct CoreGraphics.CGFloat
@@ -1279,9 +1282,51 @@ extension View {
         #endif
     }
 
-    @available(*, unavailable)
-    public func statusBarHidden(_ hidden: Bool = true) -> some View {
+    // SKIP @bridge
+    public func statusBarHidden(_ hidden: Bool = true) -> any View {
+        #if SKIP
+        return ModifiedContent(content: self, modifier: SideEffectModifier { _ in
+            DisposableEffect(hidden) {
+                let statusBars: Int = androidx.core.view.WindowInsetsCompat.Type.statusBars()
+                // This flag makes status bar show/hide animation smooth
+                // It also fixes the status bar state when resuming the app from background
+                let showTransientBarsBySwipe: Int = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                var effectDecorView: android.view.View? = nil
+                if let activity = UIApplication.shared.androidActivity {
+                    let decorView = activity.window.decorView
+                    effectDecorView = decorView
+                    ViewCompat.setOnApplyWindowInsetsListener(decorView) { view, windowInsets in
+                        if hidden, windowInsets.isVisible(statusBars) {
+                            let insetsController = WindowCompat.getInsetsController(activity.window, decorView)
+                            insetsController.systemBarsBehavior = showTransientBarsBySwipe
+                            insetsController.hide(statusBars)
+                        }
+                        return ViewCompat.onApplyWindowInsets(view, windowInsets)
+                    }
+                    let insetsController = WindowCompat.getInsetsController(activity.window, decorView)
+                    insetsController.systemBarsBehavior = showTransientBarsBySwipe
+                    if hidden {
+                        insetsController.hide(statusBars)
+                    } else {
+                        insetsController.show(statusBars)
+                    }
+                }
+                onDispose {
+                    if let effectDecorView {
+                        ViewCompat.setOnApplyWindowInsetsListener(effectDecorView, nil)
+                    }
+                    if hidden, let activity = UIApplication.shared.androidActivity {
+                        let insetsController = WindowCompat.getInsetsController(activity.window, activity.window.decorView)
+                        insetsController.systemBarsBehavior = showTransientBarsBySwipe
+                        insetsController.show(statusBars)
+                    }
+                }
+            }
+            return ComposeResult.ok
+        })
+        #else
         return self
+        #endif
     }
 
     @available(*, unavailable)


### PR DESCRIPTION

[Screen_recording_20260429_122620.webm](https://github.com/user-attachments/assets/4d4c13d3-f391-4ba2-bb8b-0b8287d5fdc3)

This PR replaces PR #386. I jumped through a _ton_ of hoops trying to get that to work, but it turned out that all I needed was a magic flag, [`WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE`](https://developer.android.com/reference/androidx/core/view/WindowInsetsControllerCompat#BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE()).

> Option for [setSystemBarsBehavior](https://developer.android.com/reference/androidx/core/view/WindowInsetsControllerCompat#setSystemBarsBehavior(int)): Window would like to remain interactive when hiding navigation bars by calling [hide](https://developer.android.com/reference/androidx/core/view/WindowInsetsControllerCompat#hide(int)) or [setInsetsAndAlpha](https://developer.android.com/reference/androidx/core/view/WindowInsetsAnimationControllerCompat#setInsetsAndAlpha(androidx.core.graphics.Insets,float,float)).
> 
> When system bars are hidden in this mode, they can be revealed temporarily with system gestures, such as swiping from the edge of the screen where the bar is hidden from. These transient system bars will overlay app’s content, may have some degree of transparency, and will automatically hide after a short timeout.

Without this flag, the status bar takes a full second to fade away, and then the window insets change suddenly, creating a jarring layout shift. With this flag, the status bar animates away in 0.5s, and the inset animates with it. The flag also creates this effect where if you swipe down from the top of the screen, the status bar reappears. That seems fine to me.

They also offer a callback to use when it's time to re-hide the status bar, which we're using.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
    https://github.com/skiptools/skip-fuse-ui/pull/97
- [x] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app
    https://github.com/skiptools/skipapp-showcase/pull/86
    https://github.com/skiptools/skipapp-showcase-fuse/pull/56
-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor did a first draft, which I cleaned up. I manually tested in the Showcase Lite app.