### PR TITLE
Add support for FilledIconButton as the navigation icon button

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,10 +543,17 @@ extension View {
     public func material3TopAppBar(_ options: @Composable (Material3TopAppBarOptions) -> Material3TopAppBarOptions) -> some View
 }
 
+public enum Material3TopAppBarNavigationIconButtonStyle {
+    case iconButton
+    case filledIconButton
+}
+
 public struct Material3TopAppBarOptions {
     public var title: @Composable () -> Void
     public var modifier: androidx.compose.ui.Modifier
     public var navigationIcon: @Composable () -> Void
+    public var navigationIconButtonStyle: Material3TopAppBarNavigationIconButtonStyle
+    public var navigationIconButtonColors: androidx.compose.material3.IconButtonColors?
     public var colors: androidx.compose.material3.TopAppBarColors
     public var scrollBehavior: androidx.compose.material3.TopAppBarScrollBehavior?
     public var preferCenterAlignedStyle: Bool

--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -28,7 +28,6 @@ import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowForward
@@ -37,7 +36,11 @@ import androidx.compose.material.icons.outlined.KeyboardArrowLeft
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.BottomAppBarDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -253,12 +256,18 @@ public struct NavigationStack : View, Renderable {
         // Determine the final scrollBehavior early by checking if the environment value would modify it
         // We need to do this before we create the nestedScroll modifier so we attach the correct nestedScrollConnection
         let scrollBehavior: TopAppBarScrollBehavior
+        let navigationIconButtonStyle: Material3TopAppBarNavigationIconButtonStyle
+        let navigationIconButtonColors: IconButtonColors?
         if let updateOptions = EnvironmentValues.shared._material3TopAppBar {
             let tempOptions = Material3TopAppBarOptions(title: {}, modifier: Modifier, navigationIcon: {}, colors: TopAppBarDefaults.topAppBarColors(), scrollBehavior: initialScrollBehavior)
             let updatedOptions = updateOptions(tempOptions)
             scrollBehavior = updatedOptions.scrollBehavior ?? initialScrollBehavior
+            navigationIconButtonStyle = updatedOptions.navigationIconButtonStyle
+            navigationIconButtonColors = updatedOptions.navigationIconButtonColors
         } else {
             scrollBehavior = initialScrollBehavior
+            navigationIconButtonStyle = Material3TopAppBarNavigationIconButtonStyle.iconButton
+            navigationIconButtonColors = nil
         }
         var modifier = Modifier.nestedScroll(searchFieldScrollConnection)
         if !topBarHidden.value {
@@ -382,11 +391,25 @@ public struct NavigationStack : View, Renderable {
                             let toolbarItemContext = context.content(modifier: Modifier.padding(start: 12.dp, end: 12.dp))
                             Row(verticalAlignment: androidx.compose.ui.Alignment.CenterVertically) {
                                 if hasBackButton {
-                                    IconButton(onClick: {
-                                        navigator.value.navigateBack()
-                                    }) {
-                                        let isRTL = EnvironmentValues.shared.layoutDirection == LayoutDirection.rightToLeft
-                                        Icon(imageVector: (isRTL ? Icons.Filled.ArrowForward : Icons.Filled.ArrowBack), contentDescription: "Back", tint: tint.colorImpl())
+                                    let isRTL = EnvironmentValues.shared.layoutDirection == LayoutDirection.rightToLeft
+                                    let backIcon: @Composable () -> Void = {
+                                        Icon(
+                                            imageVector: (isRTL ? Icons.Filled.ArrowForward : Icons.Filled.ArrowBack),
+                                            contentDescription: "Back",
+                                            tint: tint.colorImpl()
+                                        )
+                                    }
+                                    switch navigationIconButtonStyle {
+                                    case Material3TopAppBarNavigationIconButtonStyle.filledIconButton:
+                                        FilledIconButton(
+                                            onClick: { navigator.value.navigateBack() },
+                                            colors: navigationIconButtonColors ?? IconButtonDefaults.filledIconButtonColors()
+                                        ) { backIcon() }
+                                    case Material3TopAppBarNavigationIconButtonStyle.iconButton:
+                                        IconButton(
+                                            onClick: { navigator.value.navigateBack() },
+                                            colors: navigationIconButtonColors ?? IconButtonDefaults.iconButtonColors()
+                                        ) { backIcon() }
                                     }
                                 }
                                 for renderable in topLeadingItems {
@@ -1319,11 +1342,18 @@ extension View {
 }
 
 #if SKIP
+public enum Material3TopAppBarNavigationIconButtonStyle {
+    case iconButton
+    case filledIconButton
+}
+
 // SKIP INSERT: @OptIn(ExperimentalMaterial3Api::class)
 public struct Material3TopAppBarOptions {
     public var title: @Composable () -> Void
     public var modifier: Modifier = Modifier
     public var navigationIcon: @Composable () -> Void = {}
+    public var navigationIconButtonStyle: Material3TopAppBarNavigationIconButtonStyle = .iconButton
+    public var navigationIconButtonColors: IconButtonColors? = nil
     public var colors: TopAppBarColors
     public var scrollBehavior: TopAppBarScrollBehavior? = nil
     public var preferCenterAlignedStyle = false
@@ -1333,12 +1363,24 @@ public struct Material3TopAppBarOptions {
         title: @Composable () -> Void = self.title,
         modifier: Modifier = self.modifier,
         navigationIcon: @Composable () -> Void = self.navigationIcon,
+        navigationIconButtonStyle: Material3TopAppBarNavigationIconButtonStyle = self.navigationIconButtonStyle,
+        navigationIconButtonColors: IconButtonColors? = self.navigationIconButtonColors,
         colors: TopAppBarColors = self.colors,
         scrollBehavior: TopAppBarScrollBehavior? = self.scrollBehavior,
         preferCenterAlignedStyle: Bool = self.preferCenterAlignedStyle,
         preferLargeStyle: Bool = self.preferLargeStyle
     ) -> Material3TopAppBarOptions {
-        return Material3TopAppBarOptions(title: title, modifier: modifier, navigationIcon: navigationIcon, colors: colors, scrollBehavior: scrollBehavior, preferCenterAlignedStyle: preferCenterAlignedStyle, preferLargeStyle: preferLargeStyle)
+        return Material3TopAppBarOptions(
+            title: title,
+            modifier: modifier,
+            navigationIcon: navigationIcon,
+            navigationIconButtonStyle: navigationIconButtonStyle,
+            navigationIconButtonColors: navigationIconButtonColors,
+            colors: colors,
+            scrollBehavior: scrollBehavior,
+            preferCenterAlignedStyle: preferCenterAlignedStyle,
+            preferLargeStyle: preferLargeStyle
+        )
     }
 }
 


### PR DESCRIPTION
My app uses a transparent top app bar, with underlying content that goes edge-to-edge to the top of the screen. The default navigation back button `IconButton` has a transparent background, making it hard to see when there's content behind it.

I tried using the existing `.material3TopAppBar` `navigationIcon` API to wrap the provided `options.navigationButton()` in a `Box` with a background, but the background filled the minimum interaction size of the button, making the button appear larger than it actually was. I needed the back button to be a `FilledIconButton`, so I could pass it a `containerColor` that would do the right thing.

This PR adds two new options to `Material3TopAppBarOptions`. There's a `navigationIconButtonColors: IconButtonColors` allowing clients to specify their own color options, and a `navigationIconButtonStyle` enum which can be `.iconButton` (the default) or `.filledIconButton`. We could add support for tonal/outlined, but I don't need it, and it's not clear whether anyone ever will.

Along the way, I upgraded us from Material 2 `androidx.compose.material.IconButton` to Material 3 `androidx.compose.material3.IconButton`. (They're visually indistinguishable to me.)

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
    Not needed; the `.material3TopAppBar` modifier can only be used from transpiled code
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor did a first draft, and I cleaned it up. I tested it in the Showcase Lite app by adding this to `PlaygroundNavigationView.swift`:

```swift
#if SKIP
.material3TopAppBar { $0.copy(
    navigationIconButtonStyle: Material3TopAppBarNavigationIconButtonStyle.filledIconButton,
    navigationIconButtonColors: androidx.compose.material3.IconButtonDefaults.filledIconButtonColors(
        containerColor: Color.blue.colorImpl()
    ),
) }
#endif
```

That gave the back button a blue background. (I also tested it in my own app.)