### PR TITLE
Add support for `.buttonStyle(.m3Text)` for Material 3 TextButton

### DIFF
--- a/Sources/SkipUI/SkipUI/Controls/Button.swift
+++ b/Sources/SkipUI/SkipUI/Controls/Button.swift
@@ -16,6 +16,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ButtonElevation
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.LocalRippleConfiguration
 import androidx.compose.material3.RippleConfiguration
 import androidx.compose.runtime.Composable
@@ -197,6 +198,8 @@ public struct Button : View, Renderable {
                 }
             case .plain:
                 RenderTextButton(label: label, context: context.content(modifier: modifier), role: role, isPlain: true, isEnabled: isEnabled, action: action)
+            case .m3Text:
+                RenderM3TextButton(label: label, context: context.content(modifier: modifier), role: role, isPlain: false, isEnabled: isEnabled, action: action)
             default:
                 RenderTextButton(label: label, context: context.content(modifier: modifier), role: role, isEnabled: isEnabled, action: action)
             }
@@ -233,6 +236,44 @@ public struct Button : View, Renderable {
             label.Compose(context: contentContext)
         }
     }
+
+    /// Render a Material3 text button style.
+    ///
+    /// - Parameters:
+    ///   - action: Pass nil if the given modifier already includes `clickable`
+    @Composable static func RenderM3TextButton(label: View, context: ComposeContext, role: ButtonRole? = nil, isPlain: Bool = false, isEnabled: Bool = EnvironmentValues.shared.isEnabled, action: (() -> Void)? = nil) {
+        let isHitTestingEnabled = EnvironmentValues.shared._isHitTestingEnabled
+        let baseForegroundStyle: ShapeStyle
+        if role == .destructive {
+            baseForegroundStyle = Color(colorImpl: { MaterialTheme.colorScheme.error })
+        } else {
+            baseForegroundStyle = EnvironmentValues.shared._foregroundStyle ?? (isPlain ? Color.primary : (EnvironmentValues.shared._tint ?? Color.accentColor))
+        }
+        var foregroundStyle = baseForegroundStyle
+        if !isEnabled {
+            let disabledAlpha = Double(ContentAlpha.disabled)
+            foregroundStyle = AnyShapeStyle(baseForegroundStyle, opacity: disabledAlpha)
+        }
+
+        let hasAction = action != nil && isHitTestingEnabled
+        let enabledContentColor = baseForegroundStyle.asColor(opacity: 1.0, animationContext: nil) ?? MaterialTheme.colorScheme.primary
+        let disabledContentColor = baseForegroundStyle.asColor(opacity: Double(ContentAlpha.disabled), animationContext: nil) ?? enabledContentColor.copy(alpha: ContentAlpha.disabled)
+        let colors = ButtonDefaults.textButtonColors(contentColor: enabledContentColor, disabledContentColor: disabledContentColor)
+        var options = Material3ButtonOptions(onClick: action ?? {}, modifier: context.modifier, enabled: isEnabled && hasAction, shape: ButtonDefaults.textShape, colors: colors, elevation: nil, border: nil, contentPadding: ButtonDefaults.TextButtonContentPadding, interactionSource: nil)
+        if let updateOptions = EnvironmentValues.shared._material3Button {
+            options = updateOptions(options)
+        }
+        let contentContext = context.content()
+
+        EnvironmentValues.shared.setValues {
+            $0.set_foregroundStyle(foregroundStyle)
+            return ComposeResult.ok
+        } in: {
+            TextButton(onClick: options.onClick, modifier: options.modifier, enabled: options.enabled, shape: options.shape, colors: options.colors, elevation: options.elevation, border: options.border, contentPadding: options.contentPadding, interactionSource: options.interactionSource) {
+                label.Compose(context: contentContext)
+            }
+        }
+    }
     #else
     public var body: some View {
         stubView()
@@ -252,6 +293,7 @@ public struct ButtonStyle: RawRepresentable, Equatable {
     public static let borderless = ButtonStyle(rawValue: 2) // For bridging
     public static let bordered = ButtonStyle(rawValue: 3) // For bridging
     public static let borderedProminent = ButtonStyle(rawValue: 4) // For bridging
+    public static let m3Text = ButtonStyle(rawValue: 7) // For bridging
     @available(*, unavailable)
     public static let glass = ButtonStyle(rawValue: 5) // For bridging
     @available(*, unavailable)


### PR DESCRIPTION
`.buttonStyle(.m3Text)` is more convenient to work with than `ComposeView`; it handles `role: destructive`, `allowsHitTesting`, `.foregroundStyle`, etc. and it supports setting it at the top level of a view to convert all of its buttons to M3 Text Buttons.

`TextButton` is nice because it has a proper ripple background. `Button("My Button") {}` is just clickable text; its ripple is a rectangle tightly wrapped around the text. `TextButton` has an invisible capsule around it, which ripples when you press down on it.

(This also forces `TextButton` to take up more space on the screen, reserving the space for its invisible ripple capsule, in addition to applying the default Compose minimum interactive component size.)

## Screenshots

<details><summary>Screenshots</summary>
<p>

<img width="180" height="400" alt="Screenshot_20260430_125139" src="https://github.com/user-attachments/assets/497528c6-2ab5-48d1-bdb6-78bc6bc35cc9" />
<img width="180" height="400" alt="Screenshot_20260430_125204" src="https://github.com/user-attachments/assets/98dd4ac5-2f0a-40ad-9baf-2dd7bf4a5e63" />
<img width="180" height="400" alt="Screenshot_20260430_125225" src="https://github.com/user-attachments/assets/8692eb0c-a749-4be5-bb29-e2dcd646542e" />

</p>
</details> 

<details><summary>Ripple examples</summary>
<p>

<img width="180" height="400" alt="Screenshot_20260430_125152" src="https://github.com/user-attachments/assets/eb4040cc-65a2-4288-b0b3-b73b5411292f" />
<img width="180" height="400" alt="Screenshot_20260430_125144" src="https://github.com/user-attachments/assets/745dd38c-057f-411f-aa9c-8cb76a589be4" />
<img width="180" height="400" alt="Screenshot_20260430_125225" src="https://github.com/user-attachments/assets/67621882-f2a7-404a-9f7e-a9e91b1b8189" />


</p>
</details> 

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
    PR incoming 
- [x] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app
    PRs incoming

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor did most of this. I manually tested it in both Showcase apps.