### PR TITLE
TabView: Keep a stable SaveableStateHolder for each tab's backStack

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -673,12 +673,12 @@ public struct NavigationStack : View, Renderable {
 #if SKIP
 
 // SKIP INSERT: @Serializable
-public enum SkipNavigationStackRootKey : NavKey {
+public enum SkipNavigationStackRootKey : NavKey, Hashable {
     case root
 }
 
 // SKIP INSERT: @Serializable
-public struct SkipNavigationStackPushKey : NavKey {
+public struct SkipNavigationStackPushKey : NavKey, Hashable {
     public let destinationIndex: Int
     public let identifier: String
 }

--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -3,6 +3,8 @@
 #if !SKIP_BRIDGE
 import Foundation
 #if SKIP
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -59,9 +61,15 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
 #endif
 
 // SKIP @bridge
@@ -218,11 +226,13 @@ public struct TabView : View, Renderable {
             }
         }
 
+        let tabBackStacks = rememberSkipTabViewBackStacks()
         let selectedTabIndex = rememberSaveable(stateSaver: context.stateSaver as! Saver<Int, Any>) { mutableStateOf(0) }
         // Isolate access to current route within child Composable so route nav does not force us to recompose
-        navigateToCurrentRoute(selectedTabIndex: selectedTabIndex, tabRenderables: tabRenderables)
+        navigateToCurrentRoute(tabBackStacks: tabBackStacks, selectedTabIndex: selectedTabIndex, tabRenderables: tabRenderables)
 
         let tabBarPreferences = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<ToolbarBarPreferences>, Any>) { mutableStateOf(Preference<ToolbarBarPreferences>(key: TabBarPreferenceKey.self)) }
+        let tabBarPreferencesCollector = PreferenceCollector<ToolbarBarPreferences>(key: TabBarPreferenceKey.self, state: tabBarPreferences)
 
         let safeArea = EnvironmentValues.shared._safeArea
         let density = LocalDensity.current
@@ -372,62 +382,48 @@ public struct TabView : View, Renderable {
                 // Don't use a Scaffold: it clips content beyond its bounds and prevents .ignoresSafeArea modifiers from working
                 Column(modifier: modifier.background(Color.background.colorImpl())) {
                     let entryContext = context.content()
-                    let tabIndex = selectedTabIndex.value
-                    // Shared padding/safe area calculations (same for all tabs)
-                    let topPadding = ignoresSafeAreaEdges.contains(.top) ? WindowInsets.safeDrawing.asPaddingValues().calculateTopPadding() : 0.dp
-                    var bottomPadding = 0.dp
-                    if bottomBarTopPx.value <= Float(0.0) && ignoresSafeAreaEdges.contains(.bottom) {
-                        bottomPadding = max(0.dp, WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() - WindowInsets.ime.asPaddingValues().calculateBottomPadding())
-                    }
-                    let contentModifier = Modifier.fillMaxSize().padding(top: topPadding, bottom: bottomPadding)
-                    let contentSafeArea = safeArea?.insetting(.bottom, to: bottomBarTopPx.value)
-                    // Keep all visited tabs in composition simultaneously to preserve their full
-                    // state (scroll position, @State, navigation level, etc.) across tab switches.
-                    // Both @State and scroll state use plain `remember` (not rememberSaveable), so
-                    // the composition subtree must stay alive to retain them. Only the active tab is
-                    // visible; inactive tabs remain composed but hidden.
-                    Box(modifier: Modifier.fillMaxWidth().weight(Float(1.0))) {
-                        for ti in 0..<tabRenderables.size {
-                            // Key on the tab's identity (tag value) rather than index so that
-                            // state follows the tab if tabs are dynamically inserted or removed
-                            let tabKey: Any = tabTagValue(for: tabRenderables[ti]) ?? ti
-                            key(tabKey) {
-                                let isActive = ti == tabIndex
-                                // Track whether this tab has ever been active so we only compose
-                                // visited tabs (avoids composing all tabs at startup)
-                                let wasVisited = remember { mutableStateOf(isActive) }
-                                if isActive { wasVisited.value = true }
-                                if wasVisited.value {
-                                    // Each tab gets its own preference collector to keep the
-                                    // composition structure stable across active/inactive transitions
-                                    let perTabBarPreferences = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<ToolbarBarPreferences>, Any>) { mutableStateOf(Preference<ToolbarBarPreferences>(key: TabBarPreferenceKey.self)) }
-                                    let perTabCollector = PreferenceCollector<ToolbarBarPreferences>(key: TabBarPreferenceKey.self, state: perTabBarPreferences)
+                    let activeStack = tabBackStacks[selectedTabIndex.value]
+                    let tabDecorators = listOf(rememberSaveableStateHolderNavEntryDecorator<NavKey>())
+                    let tabEntryProvider: (NavKey) -> NavEntry<NavKey> = { key in
+                        let tabKey = key as! SkipTabViewRouteKey
+                        return NavEntry(tabKey, content: { key in
+                            let tabIndex = (key as! SkipTabViewRouteKey).index
+                            // Inset manually where our container ignored the safe area, but we aren't showing a bar
+                            let topPadding = ignoresSafeAreaEdges.contains(.top) ? WindowInsets.safeDrawing.asPaddingValues().calculateTopPadding() : 0.dp
+                            var bottomPadding = 0.dp
+                            if bottomBarTopPx.value <= Float(0.0) && ignoresSafeAreaEdges.contains(.bottom) {
+                                bottomPadding = max(0.dp, WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() - WindowInsets.ime.asPaddingValues().calculateBottomPadding())
+                            }
+                            let contentModifier = Modifier.fillMaxSize().padding(top: topPadding, bottom: bottomPadding)
+                            let contentSafeArea = safeArea?.insetting(.bottom, to: bottomBarTopPx.value)
 
-                                    // Special-case the first composition to avoid seeing the layout adjust. This is a common
-                                    // issue with nav stacks in particular, and they're common enough that we need to cater to them.
-                                    // Use an extra container to avoid causing the content itself to recompose
-                                    let hasComposed = remember { mutableStateOf(false) }
-                                    SideEffect { hasComposed.value = true }
-                                    let alpha: Float = (isActive && hasComposed.value) ? Float(1.0) : Float(0.0)
-                                    Box(modifier: Modifier.fillMaxSize()
-                                        .zIndex(isActive ? Float(1.0) : Float(0.0))
-                                        .graphicsLayer(alpha: alpha),
-                                        contentAlignment: androidx.compose.ui.Alignment.Center) {
-                                        let arguments = TabEntryArguments(tabIndex: ti, modifier: contentModifier, safeArea: contentSafeArea)
-                                        PreferenceValues.shared.collectPreferences([perTabCollector]) {
-                                            RenderEntry(with: arguments, context: entryContext)
-                                        }
-                                    }
-                                    // Only propagate active tab's preferences to the shared state
-                                    if isActive {
-                                        SideEffect {
-                                            tabBarPreferences.value = perTabBarPreferences.value
-                                        }
-                                    }
+                            // Special-case the first composition to avoid seeing the layout adjust. This is a common
+                            // issue with nav stacks in particular, and they're common enough that we need to cater to them.
+                            // Use an extra container to avoid causing the content itself to recompose
+                            let hasComposed = remember { mutableStateOf(false) }
+                            SideEffect { hasComposed.value = true }
+                            let alpha = hasComposed.value ? Float(1.0) : Float(0.0)
+                            Box(modifier: Modifier.alpha(alpha), contentAlignment: androidx.compose.ui.Alignment.Center) {
+                                // This block is called multiple times on tab switch. Use stable arguments that will prevent our entry from
+                                // recomposing when called with the same values
+                                let arguments = TabEntryArguments(tabIndex: tabIndex, modifier: contentModifier, safeArea: contentSafeArea)
+                                PreferenceValues.shared.collectPreferences([tabBarPreferencesCollector]) {
+                                    RenderEntry(with: arguments, context: entryContext)
                                 }
                             }
-                        }
+                        })
                     }
+                    NavDisplay(
+                        backStack: activeStack,
+                        modifier: Modifier.fillMaxWidth().weight(Float(1.0)),
+                        onBack: {
+                            if activeStack.size > 1 {
+                                activeStack.removeLastOrNull()
+                            }
+                        },
+                        entryDecorators: tabDecorators,
+                        entryProvider: tabEntryProvider
+                    )
                     bottomBar()
                 }
             }
@@ -494,7 +490,7 @@ public struct TabView : View, Renderable {
         }
     }
 
-    @Composable private func navigateToCurrentRoute(selectedTabIndex: MutableState<Int>, tabRenderables: kotlin.collections.List<Renderable>) {
+    @Composable private func navigateToCurrentRoute(tabBackStacks: kotlin.collections.List<NavBackStack<NavKey>>, selectedTabIndex: MutableState<Int>, tabRenderables: kotlin.collections.List<Renderable>) {
         let currentRoute = String(describing: selectedTabIndex.value)
         if let selection, selection.wrappedValue != tagValue(route: currentRoute, in: tabRenderables) {
             if let route = route(tagValue: selection.wrappedValue, in: tabRenderables), let idx = Int(string: route) {
@@ -510,6 +506,27 @@ public struct TabView : View, Renderable {
 }
 
 #if SKIP
+// SKIP INSERT: @Serializable
+public struct SkipTabViewRouteKey : NavKey {
+    public let index: Int
+}
+
+/// Fixed 100 persistent back stacks for tab bar content (matches legacy `0..<100` routes).
+@Composable public func rememberSkipTabViewBackStacks() -> kotlin.collections.List<NavBackStack<NavKey>> {
+    // Use a constant number of routes. Changing routes causes a NavHost to reset its state
+    // TODO is this necessary with NavDisplay?
+    let slots = remember { arrayOfNulls<NavBackStack<NavKey>?>(100) }
+    var tabIndex = 0
+    while tabIndex < 100 {
+        let ti = tabIndex
+        key(ti) {
+            slots[ti] = rememberNavBackStack(SkipTabViewRouteKey(index: ti))
+        }
+        tabIndex += 1
+    }
+    return slots.filterNotNull()
+}
+
 @Stable struct TabEntryArguments: Equatable {
     let tabIndex: Int
     let modifier: Modifier

--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -64,6 +64,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.rememberDecoratedNavEntries
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
@@ -383,7 +384,6 @@ public struct TabView : View, Renderable {
                 Column(modifier: modifier.background(Color.background.colorImpl())) {
                     let entryContext = context.content()
                     let activeStack = tabBackStacks[selectedTabIndex.value]
-                    let tabDecorators = listOf(rememberSaveableStateHolderNavEntryDecorator<NavKey>())
                     let tabEntryProvider: (NavKey) -> NavEntry<NavKey> = { key in
                         let tabKey = key as! SkipTabViewRouteKey
                         return NavEntry(tabKey, content: { key in
@@ -413,16 +413,30 @@ public struct TabView : View, Renderable {
                             }
                         })
                     }
+                    // Keep a stable SaveableStateHolder for each tab's backStack
+                    let decoratedEntrySlots = remember { arrayOfNulls<kotlin.collections.List<NavEntry<NavKey>>?>(100) }
+                    var tabIndex = 0
+                    while tabIndex < 100 {
+                        let ti = tabIndex
+                        key(ti) {
+                            let tabDecorators = listOf(rememberSaveableStateHolderNavEntryDecorator<NavKey>())
+                            decoratedEntrySlots[ti] = rememberDecoratedNavEntries(
+                                backStack: tabBackStacks[ti],
+                                entryDecorators: tabDecorators,
+                                entryProvider: tabEntryProvider
+                            )
+                        }
+                        tabIndex += 1
+                    }
+                    let activeEntries = decoratedEntrySlots[selectedTabIndex.value]!
                     NavDisplay(
-                        backStack: activeStack,
+                        entries: activeEntries,
                         modifier: Modifier.fillMaxWidth().weight(Float(1.0)),
                         onBack: {
                             if activeStack.size > 1 {
                                 activeStack.removeLastOrNull()
                             }
                         },
-                        entryDecorators: tabDecorators,
-                        entryProvider: tabEntryProvider
                     )
                     bottomBar()
                 }

--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -236,6 +236,8 @@ public struct TabView : View, Renderable {
         let tabBarPreferencesCollector = PreferenceCollector<ToolbarBarPreferences>(key: TabBarPreferenceKey.self, state: tabBarPreferences)
 
         let safeArea = EnvironmentValues.shared._safeArea
+        /// Latest TabView-scope safe area; use inside long-lived nav entry closures so inset updates (e.g. status bar hide) propagate without relying on lexical capture of `safeArea`.
+        let tabViewSafeAreaState = rememberUpdatedState(safeArea)
         let density = LocalDensity.current
         let defaultBottomBarHeight = 80.dp
         let bottomBarTopPx = remember {
@@ -395,7 +397,8 @@ public struct TabView : View, Renderable {
                                 bottomPadding = max(0.dp, WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding() - WindowInsets.ime.asPaddingValues().calculateBottomPadding())
                             }
                             let contentModifier = Modifier.fillMaxSize().padding(top: topPadding, bottom: bottomPadding)
-                            let contentSafeArea = safeArea?.insetting(.bottom, to: bottomBarTopPx.value)
+                            let tabViewSafeArea = tabViewSafeAreaState.value
+                            let contentSafeArea = tabViewSafeArea?.insetting(Edge.bottom, to: bottomBarTopPx.value)
 
                             // Special-case the first composition to avoid seeing the layout adjust. This is a common
                             // issue with nav stacks in particular, and they're common enough that we need to cater to them.


### PR DESCRIPTION
* Fixes #409 

Relevant links
* Bug #397
* PR #393
    * PR 393 would have fixed bug 397, but was closed in favor of PR 400
* PR #398
    * PR 398 would have fixed bug 397 differently, but was closed in favor of PR 400
    * If we'd merged it, it would have had "Bug 398x", defined below
* PR #400
    * PR 400 fixed bug 397, but caused Bug 409

This PR looks bigger than it is, but it's actually pretty lightweight, especially if you review it commit-by-commit, looking at it with `git log --first-parent`. 

Understanding it requires recapping recent history a bit.

## "Bug 398x"

PR #398 was my attempt to fix Bug #397 "the right way." It never merged, because @marcprux found a bug in it, which I didn't have time to fix last week:

> It does seem to work for restoring the scroll position for the top-level list in a tab (like the "Showcase" playground list), but then drilling into another view and switching tabs away and then back does not seem to restore the scroll position.

There was never a filed bug filed about that (which makes sense, because PR 398 never actually merged), but I'm calling that bug "398x".

"Bug 398x" wasn't restricted to scroll state. If we'd merged PR #398, _any_ state in views pushed onto the navigation stack would be forgotten when switching tabs. The simple repro for "Bug 398x" is:

* Navigate to the Button playground
* Tap one of the buttons; the Tap Count increases to 1
* Navigate to the About tab and then back to the Showcase tab; the Tap Count is now back down to 0.

**It turns out that Bug 398x had a very simple fix that took me _ages_ to track down.** I just needed to mark the `NavKey`s `SkipNavigationStackRootKey` and `SkipNavigationStackPushKey` as `Hashable`. A two-line fix, but figuring that out was… challenging.

## Problems with PR #400

Bug #409 was caused by PR #400. I think it would be possible to fix #409 building on top of PR #400, but I don't think that's wise.

PR #400's approach was to keep all of the tabs actually rendered, hiding them with alpha/zIndex, like PR #393.

[I had a comment on #393:](https://github.com/skiptools/skip-ui/pull/393#pullrequestreview-4130974414)

> This PR is keeping all of the tabs rendered at once, with inactive tabs transparent and zIndex'd behind the active tab.
> 
> I did a bunch of research into this, and I think this is not Google's recommended way to preserve scroll offset in Navigation 3. I filed a different PR that I think is the "right way."
> 
> * #398

This comment also applies to PR #400.

I think merging PR #400 last week was the right call, that in light of the fact that I wasn't available to fix PR #398. It would have been really bad if Bug #397 had been completely unfixed for an entire week.

But, now that we have some more time, I think we can and should fix this the "right way" here in this PR.

(FWIW, PR #400 caused bug #409 by confusing the preferences collector. It was getting its wires crossed with the other active tabs. My PR #398 never had bug #409 to begin with.)

## What this PR actually does

1. Revert PR 400 in ed093025c0e17f930cc0f9f144109c3b585934bd
2. Merge PR 398 (my "right way" PR) in 5c2decd55cedbe5d73160b3eb362e22401ea9887 (the meat is in the second parent 746b25e1b03ffc43805af254959d2e8371118c53)
3. Fix Bug 398x with a two-line fix in ab7cc9cee6e05c06e4d65fbe16903d8f9f19ce09
4. Fixing this bug created a new bug: `.statusBarHidden(:)` had broken layout; fixed in ffeddca057a3a1836fcc7de3540dfa9f68fe1646

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
    Not required
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

