### PR TITLE
Fix for android symbol rendering bug (font weights ignored)

### DIFF
--- a/Sources/SkipUI/SkipUI/Components/Image.swift
+++ b/Sources/SkipUI/SkipUI/Components/Image.swift
@@ -43,6 +43,7 @@ import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.layout.ScaleFactor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
@@ -277,8 +278,34 @@ public struct Image : View, Renderable, Equatable {
             parseSymbolXML(url)
         }
 
+        func swiftFontWeight(from composeFontWeight: FontWeight?) -> Font.Weight? {
+            guard let composeFontWeight else {
+                return nil
+            }
+            if composeFontWeight == FontWeight.Thin {
+                return .ultraLight
+            } else if composeFontWeight == FontWeight.ExtraLight {
+                return .thin
+            } else if composeFontWeight == FontWeight.Light {
+                return .light
+            } else if composeFontWeight == FontWeight.Normal {
+                return .regular
+            } else if composeFontWeight == FontWeight.Medium {
+                return .medium
+            } else if composeFontWeight == FontWeight.SemiBold {
+                return .semibold
+            } else if composeFontWeight == FontWeight.Bold {
+                return .bold
+            } else if composeFontWeight == FontWeight.ExtraBold {
+                return .heavy
+            } else if composeFontWeight == FontWeight.Black {
+                return .black
+            }
+            return nil
+        }
+
         // match the best symbol for the current font weight
-        let fontWeight = EnvironmentValues.shared._textEnvironment.fontWeight ?? Font.Weight.regular
+        let fontWeight = EnvironmentValues.shared._textEnvironment.fontWeight ?? swiftFontWeight(from: EnvironmentValues.shared.font?.fontImpl().fontWeight) ?? Font.Weight.regular
 
         // Exporting as "Static" will contain all 27 variants (9 weights * 3 sizes),
         // but "Variable" will only have 3: Ultralight-S, Regular-S, and Black-S


### PR DESCRIPTION
Thank you for contributing to the Skip project! Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Codex generated the code, tested manually on devices

-----



## Problem

On Android, custom SF Symbol images did not honor the weight passed through `.font(.system(size:weight:))`.

Text handled this correctly, but symbol image rendering only looked at `.fontWeight(...)`. As a result, icons using `.font(.system(size: 22, weight: .black))` rendered with the default/regular symbol weight on Android, while iOS rendered the expected heavier variant.

## Solution

Update SkipUI custom symbol rendering to derive the effective symbol weight from the current font when no explicit `.fontWeight(...)` override is present.

The selection order is now:

1. Explicit `.fontWeight(...)`
2. Weight embedded in `.font(.system(size:weight:))`
3. Regular

This keeps the fix scoped to custom symbol image rendering and avoids changing global text/font behavior.

## Validation

Verified on Android that the custom home symbol now renders distinct Thin, Light, Regular, Semibold, and Bold variants. (verified that iOS behavior is unchanged)

