### PR TITLE
Cancel `.task` task on dispose, instead of crashing the app

### DIFF
--- a/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
+++ b/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberUpdatedState
@@ -1351,8 +1350,13 @@ extension View {
         #if SKIP
         return ModifiedContent(content: self, modifier: SideEffectModifier { _ in
             let handler = rememberUpdatedState(action)
-            LaunchedEffect(value) {
-                handler.value()
+            DisposableEffect(value) {
+                let task = Task(priority: priority) {
+                    handler.value()
+                }
+                onDispose {
+                    task.cancel()
+                }
             }
             return ComposeResult.ok
         })
@@ -1366,15 +1370,20 @@ extension View {
         #if SKIP
         return ModifiedContent(content: self, modifier: SideEffectModifier { _ in
             let actionState = rememberUpdatedState(bridgedAction)
-            LaunchedEffect(value) {
-                kotlinx.coroutines.suspendCancellableCoroutine { continuation in
-                    let completionHandler = CompletionHandler({
-                        do { continuation.resume(Unit, nil) } catch {}
-                    })
-                    continuation.invokeOnCancellation { _ in
-                        completionHandler.onCancel?()
+            DisposableEffect(value) {
+                let task = Task {
+                    kotlinx.coroutines.suspendCancellableCoroutine { continuation in
+                        let completionHandler = CompletionHandler({
+                            do { continuation.resume(Unit, nil) } catch {}
+                        })
+                        continuation.invokeOnCancellation { _ in
+                            completionHandler.onCancel?()
+                        }
+                        actionState.value(completionHandler)
                     }
-                    actionState.value(completionHandler)
+                }
+                onDispose {
+                    task.cancel()
                 }
             }
             return ComposeResult.ok


### PR DESCRIPTION
Fixes https://github.com/skiptools/skip/issues/688

I guess we could argue about whether this is the "right thing." The old `LaunchedEffect` would cause a Kotlin cancellation to happen when the view left the component tree. Swift task cancellation is cooperative, asking implementors to remember to call Task.isCancelled / Task.checkCancellation(); typical Kotlin APIs are not going to have the foresight to check this. Intuitively, it would be better to actually "cancel" these tasks.

IMO, it's more important to prevent the app from crashing than it is to correctly manage cancellation.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
    I "checked", but I can't tell, because of https://github.com/skiptools/skip/issues/687
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor did this one. I tested the Skip Lite version using the Skip Lite repro. I didn't test the Skip Fuse version, because https://github.com/skiptools/skip/issues/687 prevents me from even reproducing https://github.com/skiptools/skip/issues/688 in the first place.