### PR TITLE
Add badge support to TabView and refactor icon rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1463,16 +1463,8 @@ Support levels:
       <td><code>.backgroundStyle</code></td>
     </tr>
     <tr>
-      <td>🟡</td>
-      <td>
-          <details>
-              <summary><code>.badge</code></summary>
-              <ul>
-                  <li>Supported on <code>List</code> items</li>
-                  <li>Not yet supported on <code>TabView</code></li>
-              </ul>
-          </details>
-      </td>
+      <td>✅</td>
+      <td><code>.badge</code></td>
     </tr>
     <tr>
       <td>🟢</td>

--- a/Sources/SkipUI/SkipUI/Containers/List.swift
+++ b/Sources/SkipUI/SkipUI/Containers/List.swift
@@ -903,30 +903,6 @@ final class ListItemModifier: RenderModifier {
         return ListItemModifier(background: background, separator: separator)
     }
 }
-
-final class BadgeModifier: RenderModifier {
-    let badge: Text?
-    let prominence: BadgeProminence?
-
-    init(badge: Text? = nil, prominence: BadgeProminence? = nil) {
-        self.badge = badge
-        self.prominence = prominence
-        super.init()
-    }
-
-    static func combined(for renderable: Renderable) -> BadgeModifier {
-        var badge: Text? = nil
-        var prominence: BadgeProminence? = nil
-        renderable.forEachModifier {
-            if let badgeModifier = $0 as? BadgeModifier {
-                badge = badge ?? badgeModifier.badge
-                prominence = prominence ?? badgeModifier.prominence
-            }
-            return nil
-        }
-        return BadgeModifier(badge: badge, prominence: prominence)
-    }
-}
 #endif
 
 #if false

--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -39,6 +39,8 @@ import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.NavigationRail
 import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.NavigationRailItemDefaults
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.contentColorFor
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
@@ -228,10 +230,16 @@ public struct TabView : View, Renderable {
         let tabRenderables = EvaluateContent(context: tabContext)
         let tabs: kotlin.collections.List<Tab?> = tabRenderables.map {
             let renderable = $0 as Renderable // Let transpiler understand type
-            if let tab = renderable.strip() as? Tab {
+            let badgeModifier = BadgeModifier.combined(for: renderable)
+            if var tab = renderable.strip() as? Tab {
+                if let badge = badgeModifier.badge {
+                    tab.badge = badge
+                }
                 return tab
             } else if let tabItemModifier = renderable.forEachModifier(perform: { $0 as? TabItemModifier }) as? TabItemModifier {
-                return Tab(content: { renderable.asView() }, label: { tabItemModifier.label })
+                var tab = Tab(content: { renderable.asView() }, label: { tabItemModifier.label })
+                tab.badge = badgeModifier.badge
+                return tab
             } else {
                 return nil
             }
@@ -743,6 +751,7 @@ public enum AdaptableTabBarPlacement : Hashable {
 public protocol TabContent : View {
     var isHidden: Bool { get set }
     var isDisabled: Bool { get set }
+    var badge: Text? { get set }
 }
 
 // SKIP @bridge
@@ -850,6 +859,7 @@ public struct Tab : TabContent, Renderable {
 
     public var isHidden = false
     public var isDisabled = false
+    public var badge: Text? = nil
 
     #if SKIP
     @Composable override func Render(context: ComposeContext) {
@@ -888,7 +898,7 @@ public struct Tab : TabContent, Renderable {
                 renderable.Render(context: context)
             }
         }
-        Box(modifier: outerModifier, contentAlignment: androidx.compose.ui.Alignment.Center) {
+        let iconContent: (@Composable () -> ()) = {
             Box(modifier: Modifier.graphicsLayer(scaleX: Float(1.5), scaleY: Float(1.5)), contentAlignment: androidx.compose.ui.Alignment.Center) {
                 // Default to a lighter symbol weight so tab icons approximate SwiftUI sizing
                 if EnvironmentValues.shared._textEnvironment.fontWeight == nil {
@@ -903,6 +913,22 @@ public struct Tab : TabContent, Renderable {
                 } else {
                     renderImage()
                 }
+            }
+        }
+
+        Box(modifier: outerModifier, contentAlignment: androidx.compose.ui.Alignment.Center) {
+            if let badge {
+                BadgedBox(
+                    badge: {
+                        Badge {
+                            badge.Render(context: context)
+                        }
+                    }
+                ) {
+                    iconContent()
+                }
+            } else {
+                iconContent()
             }
         }
     }
@@ -960,6 +986,7 @@ public struct TabSection : TabContent, Renderable {
 
     public var isHidden = false
     public var isDisabled = false
+    public var badge: Text? = nil
 
     #if SKIP
     @Composable override func Evaluate(context: ComposeContext, options: Int) -> kotlin.collections.List<Renderable> {
@@ -970,6 +997,9 @@ public struct TabSection : TabContent, Renderable {
             }
             if isDisabled {
                 (renderable as? TabContent)?.isDisabled = true
+            }
+            if let badge {
+                (renderable as? TabContent)?.badge = badge
             }
         }
         return renderables
@@ -1078,29 +1108,34 @@ extension TabContent {
         return self
     }
 
-    @available(*, unavailable)
     public func badge(_ count: Int) -> some TabContent {
-        return self
+        var tabContent = self
+        tabContent.badge = count > 0 ? Text(String(count)) : nil
+        return tabContent
     }
 
-    @available(*, unavailable)
     public func badge(_ label: Text?) -> some TabContent {
-        return self
+        var tabContent = self
+        tabContent.badge = label
+        return tabContent
     }
 
-    @available(*, unavailable)
     public func badge(_ key: LocalizedStringKey) -> some TabContent {
-        return self
+        var tabContent = self
+        tabContent.badge = Text(key)
+        return tabContent
     }
 
-    @available(*, unavailable)
     public func badge(_ resource: LocalizedStringResource) -> some TabContent {
-        return self
+        var tabContent = self
+        tabContent.badge = Text(resource)
+        return tabContent
     }
 
-    @available(*, unavailable)
     public func badge(_ label: String) -> some TabContent {
-        return self
+        var tabContent = self
+        tabContent.badge = Text(label)
+        return tabContent
     }
 
     @available(*, unavailable)

--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.safeDrawing
@@ -898,8 +899,11 @@ public struct Tab : TabContent, Renderable {
                 renderable.Render(context: context)
             }
         }
-        let iconContent: (@Composable () -> ()) = {
-            Box(modifier: Modifier.graphicsLayer(scaleX: Float(1.5), scaleY: Float(1.5)), contentAlignment: androidx.compose.ui.Alignment.Center) {
+        let renderIcon: (@Composable () -> ()) = {
+            Box(
+                modifier: Modifier.graphicsLayer(scaleX: Float(1.5), scaleY: Float(1.5)),
+                contentAlignment: androidx.compose.ui.Alignment.Center
+            ) {
                 // Default to a lighter symbol weight so tab icons approximate SwiftUI sizing
                 if EnvironmentValues.shared._textEnvironment.fontWeight == nil {
                     EnvironmentValues.shared.setValues {
@@ -920,15 +924,15 @@ public struct Tab : TabContent, Renderable {
             if let badge {
                 BadgedBox(
                     badge: {
-                        Badge {
-                            badge.Render(context: context)
+                        Badge(modifier: Modifier.offset(x: 8.dp, y: -4.dp)) {
+                            badge.foregroundStyle(Color.white).Render(context: context)
                         }
                     }
                 ) {
-                    iconContent()
+                    renderIcon()
                 }
             } else {
-                iconContent()
+                renderIcon()
             }
         }
     }

--- a/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
+++ b/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
@@ -1487,6 +1487,30 @@ final class AspectRatioModifier: RenderModifier {
     }
 }
 
+final class BadgeModifier: RenderModifier {
+    let badge: Text?
+    let prominence: BadgeProminence?
+
+    init(badge: Text? = nil, prominence: BadgeProminence? = nil) {
+        self.badge = badge
+        self.prominence = prominence
+        super.init()
+    }
+
+    static func combined(for renderable: Renderable) -> BadgeModifier {
+        var badge: Text? = nil
+        var prominence: BadgeProminence? = nil
+        renderable.forEachModifier {
+            if let badgeModifier = $0 as? BadgeModifier {
+                badge = badge ?? badgeModifier.badge
+                prominence = prominence ?? badgeModifier.prominence
+            }
+            return nil
+        }
+        return BadgeModifier(badge: badge, prominence: prominence)
+    }
+}
+
 final class DisabledModifier: EnvironmentModifier {
     let disabled: Bool
 


### PR DESCRIPTION
Thank you for contributing to the Skip project! Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

This pull request adds support for tab badges in the `TabView` component, allowing badges to be displayed on tabs and sections. The implementation introduces a `badge` property to relevant types, provides new badge modifier methods, and updates rendering logic to show badges using Material3 components on Android.

**Tab badge support:**

* Added a `badge` property to `Tab`, `TabSection`, and the `TabContent` protocol, enabling tabs and tab sections to display badge indicators.
* Implemented badge rendering in the Compose/Android code path: if a tab has a badge, it is displayed using `BadgedBox` and `Badge` from Material3, with proper positioning and styling.
* Updated tab and section evaluation logic to propagate badge values from modifiers to the tab data structures.

**Badge modifier improvements:**

* Implemented badge modifier methods on `TabContent`, allowing users to easily add badges with different types of content (e.g., count, `Text`, localized strings). These methods now set the `badge` property appropriately.
* Moved the `BadgeModifier` class from `List.swift` to `AdditionalViewModifiers.swift` for better organization and code reuse, and removed the old definition.

Fixes #251 

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI was used to help reason about the implementation approach, Compose integration, and architectural consistency with existing SkipUI patterns (such as how List consumes BadgeModifier).

The actual implementation, integration, debugging, and validation were performed manually in Xcode and on-device/emulator builds. I manually verified:
- Tab(...).badge(...)
- .tabItem { ... }.badge(...)
- badge rendering and positioning
- hidden behavior for .badge(0)
- integration with existing BadgeModifier infrastructure
- Android Compose rendering behavior

-----

