### PR TITLE
Fix tab bar flicker on hide/show

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVGrid.swift
@@ -76,11 +76,15 @@ public struct LazyVGrid: View, Renderable {
         let renderables = content.EvaluateLazyItems(level: 0, context: context)
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
         ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true) { modifier in
-            IgnoresSafeAreaLayout(expandInto: [], checkEdges: [.bottom], modifier: modifier, logTag: "LazyVGrid") { _, safeAreaEdges in
+            let gridState = rememberLazyGridState(initialFirstVisibleItemIndex = isSearchable ? 1 : 0)
+            let flingBehavior = scrollTargetBehavior is ViewAlignedScrollTargetBehavior ? rememberSnapFlingBehavior(gridState, SnapPosition.Start) : ScrollableDefaults.flingBehavior()
+            let coroutineScope = rememberCoroutineScope()
+            if scrollAxes.contains(Axis.Set.vertical) {
+                PreferenceValues.shared.contribute(context: context, key: ToolbarPreferenceKey.self, value: ToolbarPreferences(scrollableState: gridState, for: [ToolbarPlacement.bottomBar]))
+                PreferenceValues.shared.contribute(context: context, key: TabBarPreferenceKey.self, value: ToolbarBarPreferences(scrollableState: gridState))
+            }
+            IgnoresSafeAreaLayout(expandInto: [], checkEdges: [.bottom], modifier: modifier, logTag: "LazyVGrid") { _, _ in
                 // Integrate with our scroll-to-top and ScrollViewReader
-                let gridState = rememberLazyGridState(initialFirstVisibleItemIndex = isSearchable ? 1 : 0)
-                let flingBehavior = scrollTargetBehavior is ViewAlignedScrollTargetBehavior ? rememberSnapFlingBehavior(gridState, SnapPosition.Start) : ScrollableDefaults.flingBehavior()
-                let coroutineScope = rememberCoroutineScope()
                 PreferenceValues.shared.contribute(context: context, key: ScrollToTopPreferenceKey.self, value: ScrollToTopAction(key: gridState) {
                     coroutineScope.launch {
                         gridState.animateScrollToItem(0)
@@ -98,10 +102,6 @@ public struct LazyVGrid: View, Renderable {
                     }
                 }
                 PreferenceValues.shared.contribute(context: context, key: ScrollToIDPreferenceKey.self, value: scrollToID)
-                if safeAreaEdges.contains(Edge.Set.bottom) {
-                    PreferenceValues.shared.contribute(context: context, key: ToolbarPreferenceKey.self, value: ToolbarPreferences(scrollableState: gridState, for: [ToolbarPlacement.bottomBar]))
-                    PreferenceValues.shared.contribute(context: context, key: TabBarPreferenceKey.self, value: ToolbarBarPreferences(scrollableState: gridState))
-                }
 
                 // Observe scroll position changes and contribute them via preferences
                 let scrollPositionState = remember { mutableStateOf<ScrollPositionState?>(nil) }

--- a/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
+++ b/Sources/SkipUI/SkipUI/Containers/LazyVStack.swift
@@ -69,11 +69,15 @@ public struct LazyVStack : View, Renderable {
         let renderables = content.EvaluateLazyItems(level: 0, context: context)
         let itemCollector = remember { mutableStateOf(LazyItemCollector()) }
         ComposeContainer(axis: .vertical, scrollAxes: scrollAxes, modifier: context.modifier, fillWidth: true) { modifier in
-            IgnoresSafeAreaLayout(expandInto: [], checkEdges: [.bottom], modifier: modifier, logTag: "LazyVStack") { _, safeAreaEdges in
+            let listState = rememberLazyListState(initialFirstVisibleItemIndex = isSearchable ? 1 : 0)
+            let flingBehavior = scrollTargetBehavior is ViewAlignedScrollTargetBehavior ? rememberSnapFlingBehavior(listState, SnapPosition.Start) : ScrollableDefaults.flingBehavior()
+            let coroutineScope = rememberCoroutineScope()
+            if scrollAxes.contains(Axis.Set.vertical) {
+                PreferenceValues.shared.contribute(context: context, key: ToolbarPreferenceKey.self, value: ToolbarPreferences(scrollableState: listState, for: [ToolbarPlacement.bottomBar]))
+                PreferenceValues.shared.contribute(context: context, key: TabBarPreferenceKey.self, value: ToolbarBarPreferences(scrollableState: listState))
+            }
+            IgnoresSafeAreaLayout(expandInto: [], checkEdges: [.bottom], modifier: modifier, logTag: "LazyVStack") { _, _ in
                 // Integrate with our scroll-to-top and ScrollViewReader
-                let listState = rememberLazyListState(initialFirstVisibleItemIndex = isSearchable ? 1 : 0)
-                let flingBehavior = scrollTargetBehavior is ViewAlignedScrollTargetBehavior ? rememberSnapFlingBehavior(listState, SnapPosition.Start) : ScrollableDefaults.flingBehavior()
-                let coroutineScope = rememberCoroutineScope()
                 PreferenceValues.shared.contribute(context: context, key: ScrollToTopPreferenceKey.self, value: ScrollToTopAction(key: listState) {
                     coroutineScope.launch {
                         listState.animateScrollToItem(0)
@@ -91,10 +95,6 @@ public struct LazyVStack : View, Renderable {
                     }
                 }
                 PreferenceValues.shared.contribute(context: context, key: ScrollToIDPreferenceKey.self, value: scrollToID)
-                if safeAreaEdges.contains(Edge.Set.bottom) {
-                    PreferenceValues.shared.contribute(context: context, key: ToolbarPreferenceKey.self, value: ToolbarPreferences(scrollableState: listState, for: [ToolbarPlacement.bottomBar]))
-                    PreferenceValues.shared.contribute(context: context, key: TabBarPreferenceKey.self, value: ToolbarBarPreferences(scrollableState: listState))
-                }
 
                 // Observe scroll position changes and contribute them via preferences
                 let scrollPositionState = remember { mutableStateOf<ScrollPositionState?>(nil) }

--- a/Sources/SkipUI/SkipUI/Containers/ScrollView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/ScrollView.swift
@@ -80,14 +80,14 @@ public struct ScrollView : View, Renderable {
 
         let contentContext = context.content()
         ComposeContainer(scrollAxes: effectiveScrollAxes, modifier: context.modifier, fillWidth: axes.contains(.horizontal), fillHeight: axes.contains(.vertical)) { modifier in
+            if wantsVerticalScroll && !isScrollDisabled {
+                PreferenceValues.shared.contribute(context: context, key: ToolbarPreferenceKey.self, value: ToolbarPreferences(scrollableState: scrollState, for: [ToolbarPlacement.bottomBar]))
+                PreferenceValues.shared.contribute(context: context, key: TabBarPreferenceKey.self, value: ToolbarBarPreferences(scrollableState: scrollState))
+            }
             IgnoresSafeAreaLayout(expandInto: [], checkEdges: [.bottom], modifier: modifier, logTag: "ScrollView") { _, safeAreaEdges in
                 var containerModifier: Modifier = Modifier
                 if wantsVerticalScroll {
                     containerModifier = containerModifier.fillMaxHeight()
-                    if !isScrollDisabled && safeAreaEdges.contains(Edge.Set.bottom) {
-                        PreferenceValues.shared.contribute(context: context, key: ToolbarPreferenceKey.self, value: ToolbarPreferences(scrollableState: scrollState, for: [ToolbarPlacement.bottomBar]))
-                        PreferenceValues.shared.contribute(context: context, key: TabBarPreferenceKey.self, value: ToolbarBarPreferences(scrollableState: scrollState))
-                    }
                 }
                 if wantsHorizontalScroll {
                     containerModifier = containerModifier.fillMaxWidth()


### PR DESCRIPTION
Contributed preferences automatically erase themselves in a `DisposableEffect`. We were contributing a preference that only ran when the `IgnoresSafeAreaLayout` detected that we were adjacent to the bottom of the screen, but that can be unstable, as `IgnoresSafeAreaLayout` waits for `onGloballyPositionedInWindow`.

Contributing the preferences outside `IgnoresSafeAreaLayout` ensures that they don't erase themselves when ISAL is temporarily incorrect.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
    Not required
- [ ] OPTIONAL: I have added an example of any UI changes in the [Showcase](https://github.com/skiptools/skipapp-showcase-fuse) sample app

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor did this; I tested it in Showcase Lite with the Safe Area --> Geometry Reader playground. Hide the bottom bar before hiding/showing the tab bar.

(You'll still see a flicker if you show/hide the tab bar with the bottom bar showing. I tried working on this last week when I implemented #414, and that was one of the things that stumped me. I don't use a bottom bar; fixing _that_ flicker will be a separate PR, perhaps much more difficult.)