### PR TITLE
Fix infinite recomposition in `Text.foregroundStyle(LinearGradient())`

### DIFF
--- a/Sources/SkipUI/SkipUI/Graphics/Gradient.swift
+++ b/Sources/SkipUI/SkipUI/Graphics/Gradient.swift
@@ -141,7 +141,9 @@ public struct LinearGradient : ShapeStyle, Renderable {
 
     @Composable override func asBrush(opacity: Double, animationContext: ComposeContext?) -> Brush? {
         let stops = gradient.colorStops(opacity: opacity)
-        return LinearGradientShaderBrush(colorStops: stops, startPoint: startPoint, endPoint: endPoint)
+        return remember(gradient, startPoint, endPoint, opacity) {
+            LinearGradientShaderBrush(colorStops: stops, startPoint: startPoint, endPoint: endPoint)
+        }
     }
 
     private struct LinearGradientShaderBrush: ShaderBrush {
@@ -207,7 +209,9 @@ public struct EllipticalGradient : ShapeStyle, Renderable {
 
     @Composable override func asBrush(opacity: Double, animationContext: ComposeContext?) -> Brush? {
         let stops = gradient.colorStops(opacity: opacity)
-        return RadialGradientShaderBrush(colorStops: stops, center: center, startFraction: startFraction, endFraction: endFraction)
+        return remember(gradient, center, startFraction, endFraction, opacity) {
+            RadialGradientShaderBrush(colorStops: stops, center: center, startFraction: startFraction, endFraction: endFraction)
+        }
     }
 
     private struct RadialGradientShaderBrush: ShaderBrush {
@@ -275,7 +279,9 @@ public struct RadialGradient : ShapeStyle, Renderable {
         let start = with(density) { startRadius.dp.toPx() }
         let end = with(density) { endRadius.dp.toPx() }
         let stops = gradient.colorStops(opacity: opacity)
-        return RadialGradientShaderBrush(colorStops: stops, center: center, startRadius: start, endRadius: end)
+        return remember(gradient, center, start, end, opacity) {
+            RadialGradientShaderBrush(colorStops: stops, center: center, startRadius: start, endRadius: end)
+        }
     }
 
     private struct RadialGradientShaderBrush: ShaderBrush {


### PR DESCRIPTION
Fixes https://github.com/skiptools/skip-ui/issues/437

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
    Not required
- [x] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app
    https://github.com/skiptools/skipapp-showcase/pull/107

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor tracked this down and fixed it. I manually tested it with https://github.com/skiptools/skipapp-showcase/pull/107 in Showcase Lite mode.