### PR TITLE
Revert "Fix crash on state reset when preferences are queried"

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -137,10 +137,14 @@ public struct NavigationStack : View, Renderable {
 
     #if SKIP
     @Composable public override func Render(context: ComposeContext) {
-        // Have to use rememberSaveable for e.g. a nav stack in each tab. Make the collectors non-erasable so that
-        // destinations defined at e.g. the root nav stack layer don't disappear when you push.
-        let (destinations, destinationsCollector) = rememberSaveablePreferenceCollector(key: NavigationDestinationsPreferenceKey.self, stateSaver: context.stateSaver as! Saver<Preference<NavigationDestinations>, Any>, isErasable: false)
-        let (destinationLayoutHints, destinationLayoutHintsCollector) = rememberSaveablePreferenceCollector(key: NavigationDestinationLayoutHintsPreferenceKey.self, stateSaver: context.stateSaver as! Saver<Preference<NavigationDestinationLayoutHintsMap>, Any>, isErasable: false)
+        // Have to use rememberSaveable for e.g. a nav stack in each tab
+        let destinations = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<NavigationDestinations>, Any>) { mutableStateOf(Preference<NavigationDestinations>(key: NavigationDestinationsPreferenceKey.self))
+        }
+        // Make this collector non-erasable so that destinations defined at e.g. the root nav stack layer don't disappear when you push
+        let destinationsCollector = PreferenceCollector<NavigationDestinations>(key: NavigationDestinationsPreferenceKey.self, state: destinations, isErasable: false)
+        let destinationLayoutHints = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<NavigationDestinationLayoutHintsMap>, Any>) { mutableStateOf(Preference<NavigationDestinationLayoutHintsMap>(key: NavigationDestinationLayoutHintsPreferenceKey.self))
+        }
+        let destinationLayoutHintsCollector = PreferenceCollector<NavigationDestinationLayoutHintsMap>(key: NavigationDestinationLayoutHintsPreferenceKey.self, state: destinationLayoutHints, isErasable: false)
         let reducedDestinations = destinations.value.reduced
         let reducedDestinationLayoutHints = destinationLayoutHints.value.reduced
         let mergedDestinations = mergeNavigationDestinationsWithLayoutHints(reducedDestinations, layoutHints: reducedDestinationLayoutHints)
@@ -165,9 +169,12 @@ public struct NavigationStack : View, Renderable {
                             }
                             // These preferences are per-entry, but if we put them in RenderEntry then their initial values don't show
                             // during the navigation animation. We have to collect them here
-                            let (title, titleCollector) = rememberSaveablePreferenceCollector(key: NavigationTitlePreferenceKey.self, stateSaver: state.stateSaver as! Saver<Preference<Text>, Any>)
-                            let (toolbarPreferences, toolbarPreferencesCollector) = rememberSaveablePreferenceCollector(key: ToolbarPreferenceKey.self, stateSaver: state.stateSaver as! Saver<Preference<ToolbarPreferences>, Any>)
-                            let (toolbarContentPreferences, toolbarContentPreferencesCollector) = rememberSaveablePreferenceCollector(key: ToolbarContentPreferenceKey.self, stateSaver: state.stateSaver as! Saver<Preference<ToolbarContentPreferences>, Any>)
+                            let title = rememberSaveable(stateSaver: state.stateSaver as! Saver<Preference<Text>, Any>) { mutableStateOf(Preference<Text>(key: NavigationTitlePreferenceKey.self)) }
+                            let titleCollector = PreferenceCollector<Text>(key: NavigationTitlePreferenceKey.self, state: title)
+                            let toolbarPreferences = rememberSaveable(stateSaver: state.stateSaver as! Saver<Preference<ToolbarPreferences>, Any>) { mutableStateOf(Preference<ToolbarPreferences>(key: ToolbarPreferenceKey.self)) }
+                            let toolbarPreferencesCollector = PreferenceCollector<ToolbarPreferences>(key: ToolbarPreferenceKey.self, state: toolbarPreferences)
+                            let toolbarContentPreferences = rememberSaveable(stateSaver: state.stateSaver as! Saver<Preference<ToolbarContentPreferences>, Any>) { mutableStateOf(Preference<ToolbarContentPreferences>(key: ToolbarContentPreferenceKey.self)) }
+                            let toolbarContentPreferencesCollector = PreferenceCollector<ToolbarContentPreferences>(key: ToolbarContentPreferenceKey.self, state: toolbarContentPreferences)
                             let arguments = NavigationEntryArguments(isRoot: true, state: state, safeArea: safeArea, ignoresSafeAreaEdges: ignoresSafeAreaEdges, title: title.value.reduced, toolbarPreferences: toolbarPreferences.value.reduced)
                             PreferenceValues.shared.collectPreferences([titleCollector, toolbarPreferencesCollector, toolbarContentPreferencesCollector, destinationsCollector, destinationLayoutHintsCollector]) {
                                 RenderEntry(navigator: navigator, toolbarContent: toolbarContentPreferences, arguments: arguments, context: context) { context in
@@ -181,9 +188,12 @@ public struct NavigationStack : View, Renderable {
                             }
                             // These preferences are per-entry, but if we put them in RenderEntry then their initial values don't show
                             // during the navigation animation. We have to collect them here
-                            let (title, titleCollector) = rememberSaveablePreferenceCollector(key: NavigationTitlePreferenceKey.self, stateSaver: state.stateSaver as! Saver<Preference<Text>, Any>)
-                            let (toolbarPreferences, toolbarPreferencesCollector) = rememberSaveablePreferenceCollector(key: ToolbarPreferenceKey.self, stateSaver: state.stateSaver as! Saver<Preference<ToolbarPreferences>, Any>)
-                            let (toolbarContentPreferences, toolbarContentPreferencesCollector) = rememberSaveablePreferenceCollector(key: ToolbarContentPreferenceKey.self, stateSaver: state.stateSaver as! Saver<Preference<ToolbarContentPreferences>, Any>)
+                            let title = rememberSaveable(stateSaver: state.stateSaver as! Saver<Preference<Text>, Any>) { mutableStateOf(Preference<Text>(key: NavigationTitlePreferenceKey.self)) }
+                            let titleCollector = PreferenceCollector<Text>(key: NavigationTitlePreferenceKey.self, state: title)
+                            let toolbarPreferences = rememberSaveable(stateSaver: state.stateSaver as! Saver<Preference<ToolbarPreferences>, Any>) { mutableStateOf(Preference<ToolbarPreferences>(key: ToolbarPreferenceKey.self)) }
+                            let toolbarPreferencesCollector = PreferenceCollector<ToolbarPreferences>(key: ToolbarPreferenceKey.self, state: toolbarPreferences)
+                            let toolbarContentPreferences = rememberSaveable(stateSaver: state.stateSaver as! Saver<Preference<ToolbarContentPreferences>, Any>) { mutableStateOf(Preference<ToolbarContentPreferences>(key: ToolbarContentPreferenceKey.self)) }
+                            let toolbarContentPreferencesCollector = PreferenceCollector<ToolbarContentPreferences>(key: ToolbarContentPreferenceKey.self, state: toolbarContentPreferences)
                             EnvironmentValues.shared.setValues {
                                 $0.setdismiss(DismissAction(action: { navigator.value.navigateBack() }))
                                 return ComposeResult.ok
@@ -267,9 +277,11 @@ public struct NavigationStack : View, Renderable {
         let searchFieldOffsetPx = rememberSaveable(stateSaver: context.stateSaver as! Saver<Float, Any>) { mutableStateOf(Float(0.0)) }
         let searchFieldScrollConnection = remember { SearchFieldScrollConnection(heightPx: searchFieldHeightPx, offsetPx: searchFieldOffsetPx) }
 
-        let (searchableStatePreference, searchableStateCollector) = rememberSaveablePreferenceCollector(key: SearchableStatePreferenceKey.self, stateSaver: context.stateSaver as! Saver<Preference<SearchableState?>, Any>)
+        let searchableStatePreference = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<SearchableState?>, Any>) { mutableStateOf(Preference<SearchableState?>(key: SearchableStatePreferenceKey.self)) }
+        let searchableStateCollector = PreferenceCollector<SearchableState?>(key: SearchableStatePreferenceKey.self, state: searchableStatePreference)
 
-        let (scrollToTop, scrollToTopCollector) = rememberSaveablePreferenceCollector(key: ScrollToTopPreferenceKey.self, stateSaver: context.stateSaver as! Saver<Preference<ScrollToTopAction>, Any>)
+        let scrollToTop = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<ScrollToTopAction>, Any>) { mutableStateOf(Preference<ScrollToTopAction>(key: ScrollToTopPreferenceKey.self)) }
+        let scrollToTopCollector = PreferenceCollector<ScrollToTopAction>(key: ScrollToTopPreferenceKey.self, state: scrollToTop)
 
         let initialScrollBehavior = isInlineTitleDisplayMode ? TopAppBarDefaults.pinnedScrollBehavior() : TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
         // Determine the final scrollBehavior early by checking if the environment value would modify it

--- a/Sources/SkipUI/SkipUI/Containers/PresentationRoot.swift
+++ b/Sources/SkipUI/SkipUI/Containers/PresentationRoot.swift
@@ -32,7 +32,8 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 @Composable public func PresentationRoot(defaultColorScheme: ColorScheme? = nil, absoluteSystemBarEdges systemBarEdges: Edge.Set = .all, context: ComposeContext, content: @Composable (ComposeContext) -> Void) {
     launchUIApplicationActivity()
 
-    let (preferredColorScheme, preferredColorSchemeCollector) = rememberSaveablePreferenceCollector(key: PreferredColorSchemePreferenceKey.self, stateSaver: context.stateSaver as! Saver<Preference<PreferredColorScheme>, Any>)
+    let preferredColorScheme = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<PreferredColorScheme>, Any>) { mutableStateOf(Preference<PreferredColorScheme>(key: PreferredColorSchemePreferenceKey.self)) }
+    let preferredColorSchemeCollector = PreferenceCollector<PreferredColorScheme>(key: PreferredColorSchemePreferenceKey.self, state: preferredColorScheme)
     PreferenceValues.shared.collectPreferences([preferredColorSchemeCollector]) {
         let materialColorScheme = preferredColorScheme.value.reduced.colorScheme?.asMaterialTheme() ?? defaultColorScheme?.asMaterialTheme() ?? MaterialTheme.colorScheme
         MaterialTheme(colorScheme: materialColorScheme) {

--- a/Sources/SkipUI/SkipUI/Containers/ScrollView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/ScrollView.swift
@@ -52,7 +52,8 @@ public struct ScrollView : View, Renderable {
     // SKIP INSERT: @OptIn(ExperimentalMaterialApi::class)
     @Composable override func Render(context: ComposeContext) {
         // Some components in Compose have their own scrolling built in
-        let (builtinScrollAxisSet, builtinScrollAxisSetCollector) = rememberSaveablePreferenceCollector(key: BuiltinScrollAxisSetPreferenceKey.self, stateSaver: context.stateSaver as! Saver<Preference<Axis.Set>, Any>)
+        let builtinScrollAxisSet = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<Axis.Set>, Any>) { mutableStateOf(Preference<Axis.Set>(key: BuiltinScrollAxisSetPreferenceKey.self)) }
+        let builtinScrollAxisSetCollector = PreferenceCollector<Axis.Set>(key: BuiltinScrollAxisSetPreferenceKey.self, state: builtinScrollAxisSet)
 
         let scrollState = rememberScrollState()
         let coroutineScope = rememberCoroutineScope()

--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -242,7 +242,8 @@ public struct TabView : View, Renderable {
         // Isolate access to current route within child Composable so route nav does not force us to recompose
         navigateToCurrentRoute(tabBackStacks: tabBackStacks, selectedTabIndex: selectedTabIndex, tabRenderables: tabRenderables)
 
-        let (tabBarPreferences, tabBarPreferencesCollector) = rememberSaveablePreferenceCollector(key: TabBarPreferenceKey.self, stateSaver: context.stateSaver as! Saver<Preference<ToolbarBarPreferences>, Any>)
+        let tabBarPreferences = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<ToolbarBarPreferences>, Any>) { mutableStateOf(Preference<ToolbarBarPreferences>(key: TabBarPreferenceKey.self)) }
+        let tabBarPreferencesCollector = PreferenceCollector<ToolbarBarPreferences>(key: TabBarPreferenceKey.self, state: tabBarPreferences)
 
         let safeArea = EnvironmentValues.shared._safeArea
         /// Latest TabView-scope safe area; use inside long-lived nav entry closures so inset updates (e.g. status bar hide) propagate without relying on lexical capture of `safeArea`.

--- a/Sources/SkipUI/SkipUI/Environment/PreferenceKey.swift
+++ b/Sources/SkipUI/SkipUI/Environment/PreferenceKey.swift
@@ -166,30 +166,6 @@ struct PreferenceCollector<Value> {
     }
 }
 
-/// Wraps `rememberSaveable` for a `Preference<V>` with defensive null handling.
-///
-/// After certain Android configuration changes (e.g. a system font scale change) the activity is recreated and the
-/// in-memory map backing our `ComposeStateSaver` is lost, so saved keys no longer resolve to their values and the
-/// restored `MutableState` ends up holding null. Reading `.reduced` on a null `Preference` then crashes. Reset to
-/// the value produced by `initial` whenever the state value is null. See https://github.com/skiptools/skip-ui/issues/300.
-@Composable func rememberSaveablePreference<V>(stateSaver: Saver<Preference<V>, Any>, initial: () -> Preference<V>) -> MutableState<Preference<V>> {
-    let state = rememberSaveable(stateSaver: stateSaver) { mutableStateOf(initial()) }
-    if (state.value as Any?) == nil {
-        state.value = initial()
-    }
-    return state
-}
-
-/// Combines `rememberSaveablePreference` with the matching `PreferenceCollector` so callers don't have to repeat
-/// the value type or the key. The generic `V` is supplied once on the `stateSaver` cast and inferred elsewhere.
-/// Pass `collectorKey` for cases where producers contribute under a different key than the `PreferenceKey` companion
-/// (e.g. when the producer keys on the value type itself rather than the `PreferenceKey` type).
-@Composable func rememberSaveablePreferenceCollector<V>(key: Any.Type, stateSaver: Saver<Preference<V>, Any>, collectorKey: Any? = nil, isErasable: Bool = true) -> (state: MutableState<Preference<V>>, collector: PreferenceCollector<V>) {
-    let state = rememberSaveablePreference(stateSaver: stateSaver) { Preference<V>(key: key) }
-    let collector = PreferenceCollector<V>(key: collectorKey ?? key, state: state, isErasable: isErasable)
-    return (state: state, collector: collector)
-}
-
 struct PreferenceNode<Value>: Equatable {
     let id: Int
     let value: Value
@@ -242,8 +218,8 @@ extension View {
     public func onPreferenceChange(key: Any, defaultValue: Any?, reducer: @escaping (Any?, Any?) -> Any?, action: @escaping (Any?) -> Void) -> any View {
         #if SKIP
         return ModifiedContent(content: self, modifier: RenderModifier { renderable, context in
-            let preference = rememberSaveablePreference(stateSaver: context.stateSaver as! Saver<Preference<Any?>, Any>) {
-                Preference<Any?>(key: key, initialValue: defaultValue, reducer: reducer)
+            let preference = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<Any?>, Any>) {
+                mutableStateOf(Preference<Any?>(key: key, initialValue: defaultValue, reducer: reducer))
             }
             let preferenceCollector = PreferenceCollector<Any?>(key: key, state: preference)
             let currentAction = rememberUpdatedState(action)

--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -92,7 +92,8 @@ private let AlertDialogMaxWidth: Dp = 560.dp
 
 // SKIP INSERT: @OptIn(ExperimentalMaterial3Api::class)
 @Composable func SheetPresentation(isPresented: Binding<Bool>, isFullScreen: Bool, context: ComposeContext, content: () -> any View, onDismiss: (() -> Void)?) {
-    let (interactiveDismissDisabledPreference, interactiveDismissDisabledCollector) = rememberSaveablePreferenceCollector(key: InteractiveDismissDisabledPreferenceKey.self, stateSaver: context.stateSaver as! Saver<Preference<Bool>, Any>)
+    let interactiveDismissDisabledPreference = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<Bool>, Any>) { mutableStateOf(Preference<Bool>(key: InteractiveDismissDisabledPreferenceKey.self)) }
+    let interactiveDismissDisabledCollector = PreferenceCollector<Bool>(key: InteractiveDismissDisabledPreferenceKey.self, state: interactiveDismissDisabledPreference)
 
     let sheetState = rememberModalBottomSheetState(skipPartiallyExpanded: true)
     let isPresentedValue = isPresented.get()
@@ -129,8 +130,8 @@ private let AlertDialogMaxWidth: Dp = 560.dp
             let sheetDepth = EnvironmentValues.shared._sheetDepth
             var systemBarEdges: Edge.Set = isFullScreen ? .all : [.top, .bottom]
 
-            // Producers contribute under the value type rather than the `PreferenceKey` type, so override `collectorKey`.
-            let (detentPreferences, detentPreferencesCollector) = rememberSaveablePreferenceCollector(key: PresentationDetentPreferenceKey.self, stateSaver: context.stateSaver as! Saver<Preference<PresentationDetentPreferences>, Any>, collectorKey: PresentationDetentPreferences.self)
+            let detentPreferences = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<PresentationDetentPreferences>, Any>) { mutableStateOf(Preference<PresentationDetentPreferences>(key: PresentationDetentPreferenceKey.self)) }
+            let detentPreferencesCollector = PreferenceCollector<PresentationDetentPreferences>(key: PresentationDetentPreferences.self, state: detentPreferences)
             let reducedDetentPreferences = detentPreferences.value.reduced
 
             if !isFullScreen && verticalSizeClass != .compact {


### PR DESCRIPTION
This reverts commit 23cf094ecec5d142e11034b1100590329e86ee62 (PR #418).

Fixes #440

This PR may feel a bit trollish, but, I think it might actually be the right thing to do.

#418 caused #440 by reading preference state (thus declaring a dependency on that state) while constructing a nav entry, triggering a recomposition infinite loop. I've only come up with one good way to accomplish what #418 accomplishes without reading the state… and that's to clean up the state in `Main.kt`.

Remember, the reason we couldn't reproduce #300 or #417 is that Showcase's `Main.kt` had `SideEffect { saveableStateHolder.removeState(true) }` in it. In #418, @marcprux commented:

> As mentioned at [#417 (comment)](https://github.com/skiptools/skip-ui/issues/417#issuecomment-4412493161), we don't see this in Showcase due to [skiptools/skipapp-showcase@5bb3049#diff-e7075a061fc36788a2762feb445a61db436a6f07c529859334189e53914a04f7R53](https://github.com/skiptools/skipapp-showcase/commit/5bb3049be6c883a6d55aa52d52e0f3109a8628ba#diff-e7075a061fc36788a2762feb445a61db436a6f07c529859334189e53914a04f7R53) which adds to Main.kt:
> 
> ```
> SideEffect { saveableStateHolder.removeState(true) }
> ```
> 
> I wonder if we should be adding that to every project's Main.kt, @aabewhite?

We already _do_ add that to every project's `Main.kt`. Abe updated the project template to add that line in October 2024. https://github.com/skiptools/skipstone/commit/f53a2ced5250e84dbd61168162842afed497b78d It shipped as part of skip 1.7.0.

PR #418 is a heroic attempt to fix #300 / #417 without requiring users to update their `Main.kt` file. But, since that causes #440, I think users should just update their `Main.kt` files, instead. (Maybe we could/should add a `skip verify` step to check for this or something.)

To be clear, here are my test results:

1. When I run my 300 repro test on main skip-ui and main Showcase, it passes.
1. When I revert 418 in `skip-ui` and run my 300 repro test on main Showcase, it still passes, because of `SideEffect { saveableStateHolder.removeState(true) }` in `Main.kt`.
1. When I run my 300 repro test on main skip-ui and remove `SideEffect { saveableStateHolder.removeState(true) }` from Showcase's `Main.kt`, it still passes, because 418 is doing its job.
1. Only when I _both_ revert 418 _and_ remove `SideEffect { saveableStateHolder.removeState(true) }`, _then_ my 300 repro test fails.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
    Not required
- [ ] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

