### PR TITLE
Don't try to `navigateBack` if the `path`/`navigationPath` are empty

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -880,9 +880,9 @@ private func mergeNavigationDestinationsWithLayoutHints(_ destinations: Navigati
         // that are not represented in the bound path
         if let lastKey = navBackStack.lastOrNull() as? SkipNavigationStackPushKey, lastKey.destinationIndex == viewDestinationIndex {
             navBackStack.removeLastOrNull()
-        } else if let path {
+        } else if let path, !path.wrappedValue.isEmpty {
             path.wrappedValue.popLast()
-        } else if let navigationPath {
+        } else if let navigationPath, !navigationPath.wrappedValue.isEmpty {
             navigationPath.wrappedValue.removeLast()
         } else if !isRoot {
             navBackStack.removeLastOrNull()


### PR DESCRIPTION
Fixes #443

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
    Not required
- [ ] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app
    I have a repro branch, but it adds a busy wait that I think would probably not be appropriate to merge into the live Showcase. https://github.com/dfabulich/skipapp-showcase/commit/85a4fb89bd49f5cd838fb3ceca0a396a44c917fb
-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor did this one. I manually tested the changes using my repro branch in the Showcase in Lite mode.