### PR TITLE
Use `ResourcesCompat.getFont()` for backwards compatibility with API 24

### DIFF
--- a/Sources/SkipUI/SkipUI/Text/Font.swift
+++ b/Sources/SkipUI/SkipUI/Text/Font.swift
@@ -3,6 +3,7 @@
 #if !SKIP_BRIDGE
 #if SKIP
 import android.graphics.Typeface
+import androidx.core.content.res.ResourcesCompat
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
@@ -212,7 +213,7 @@ public struct Font : Hashable {
             } else {
                 android.util.Log.w("SkipUI", "unable to find font named: \(fontName) (\(name))")
             }
-        } else if let customTypeface = ctx.resources.getFont(fid) {
+        } else if let customTypeface = ResourcesCompat.getFont(ctx, fid) {
             fontFamily = FontFamily(customTypeface)
         } else {
             android.util.Log.w("SkipUI", "unable to find font named: \(name)")


### PR DESCRIPTION
Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
    Not required
- [x] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app
    https://github.com/skiptools/skipapp-showcase/pull/108

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

