### PR TITLE
Use `BitmapFactory` on old versions of Android

### DIFF
--- a/Sources/SkipUI/SkipUI/UIKit/UIImage.swift
+++ b/Sources/SkipUI/SkipUI/UIKit/UIImage.swift
@@ -3,11 +3,13 @@
 #if !SKIP_BRIDGE
 import Foundation
 #if SKIP
-import android.content.Context
+import android.content.ContentResolver
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.ImageDecoder
 import android.net.Uri
+import android.os.Build
 import java.nio.ByteBuffer
-import android.graphics.Bitmap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 #endif
@@ -16,6 +18,22 @@ import kotlinx.coroutines.withContext
 public class UIImage {
     #if SKIP
     let bitmap: Bitmap?
+
+    private static func decodeBitmapFromData(bytes: kotlin.ByteArray) -> Bitmap? {
+        if Build.VERSION.SDK_INT >= Build.VERSION_CODES.P {
+            let source = ImageDecoder.createSource(ByteBuffer.wrap(bytes))
+            return ImageDecoder.decodeBitmap(source)
+        }
+        return BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+    }
+
+    private static func decodeBitmapFromUri(contentResolver: ContentResolver, uri: Uri) -> Bitmap? {
+        if Build.VERSION.SDK_INT >= Build.VERSION_CODES.P {
+            let source = ImageDecoder.createSource(contentResolver, uri)
+            return ImageDecoder.decodeBitmap(source)
+        }
+        return contentResolver.openInputStream(uri)?.use { stream in BitmapFactory.decodeStream(stream) }
+    }
     #endif
 
     @available(*, unavailable)
@@ -122,9 +140,8 @@ public class UIImage {
         do {
             let contentResolver = ProcessInfo.processInfo.androidContext.getContentResolver()
             let uri = Uri.parse(path)
-            let source = ImageDecoder.createSource(contentResolver, uri)
             
-            guard let bitmap = ImageDecoder.decodeBitmap(source) else {
+            guard let bitmap = Self.decodeBitmapFromUri(contentResolver: contentResolver, uri: uri) else {
                 return nil
             }
             
@@ -147,9 +164,8 @@ public class UIImage {
         #if SKIP
         do {
             let bytes = data.kotlin(nocopy: true)
-            let source = ImageDecoder.createSource(ByteBuffer.wrap(bytes))
             
-            guard let bitmap = ImageDecoder.decodeBitmap(source) else {
+            guard let bitmap = Self.decodeBitmapFromData(bytes: bytes) else {
                 return nil
             }
             


### PR DESCRIPTION
`ImageDecoder` was introduced in API level 28 (P)

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
    Not required
- [x] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app
    https://github.com/skiptools/skipapp-showcase/pull/108
-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor did a first draft; I refactored it. I tested it using https://github.com/skiptools/skipapp-showcase/pull/108