### PR TITLE
Android: allow pull-to-dismiss in `sheets()` with scrollable content in Sheet()

### DIFF
--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -177,7 +177,8 @@ private let AlertDialogMaxWidth: Dp = 560.dp
             }
 
             let clipShape = RoundedCornerShape(topStart: isFullScreen ? 0.dp : overlayPresentationCornerRadius.dp, topEnd: isFullScreen ? 0.dp : overlayPresentationCornerRadius.dp)
-            Box(modifier: Modifier.weight(Float(1.0)).clip(clipShape).nestedScroll(DisableScrollToDismissConnection())) {
+            let contentModifier = Modifier.weight(Float(1.0)).clip(clipShape)
+            Box(modifier: interactiveDismissDisabled ? contentModifier.nestedScroll(DisableScrollToDismissConnection()) : contentModifier) {
                 // Place outside of PresentationRoot recomposes
                 let stateSaver = remember { ComposeStateSaver() }
                 let presentationContext = context.content(stateSaver: stateSaver)

--- a/Tests/SkipUITests/SkipUITests.swift
+++ b/Tests/SkipUITests/SkipUITests.swift
@@ -98,6 +98,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.moveTo
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
@@ -310,6 +312,71 @@ final class SkipUITests: SkipUITestCase {
                 Text(pressed ? "yes" : "no")
                     .accessibilityIdentifier("status")
             }
+        }
+    }
+
+    func testSheetWithScrollableContentDismissesOnDownwardOverscroll() throws {
+        #if !SKIP
+        throw XCTSkip("sheet overscroll dismissal is a Compose behavior")
+        #else
+        let didDismiss = mutableStateOf(false)
+        try testUI(view: {
+            SheetOverscrollDismissTestView(interactiveDismissDisabled: false, onDismiss: { didDismiss.value = true })
+                .accessibilityIdentifier("test-view")
+        }, eval: { rule in
+            rule.waitForIdle()
+            XCTAssertFalse(didDismiss.value)
+            rule.onAllNodesWithTag("sheet-list").onFirst().assertIsDisplayed()
+            dragSheetListDown(rule)
+            rule.waitForIdle()
+            XCTAssertTrue(didDismiss.value)
+        })
+        #endif
+    }
+
+    func testSheetWithScrollableContentKeepsOverscrollBlockedWhenInteractiveDismissDisabled() throws {
+        #if !SKIP
+        throw XCTSkip("sheet overscroll dismissal is a Compose behavior")
+        #else
+        let didDismiss = mutableStateOf(false)
+        try testUI(view: {
+            SheetOverscrollDismissTestView(interactiveDismissDisabled: true, onDismiss: { didDismiss.value = true })
+                .accessibilityIdentifier("test-view")
+        }, eval: { rule in
+            rule.waitForIdle()
+            XCTAssertFalse(didDismiss.value)
+            rule.onAllNodesWithTag("sheet-list").onFirst().assertIsDisplayed()
+            dragSheetListDown(rule)
+            rule.waitForIdle()
+            XCTAssertFalse(didDismiss.value)
+        })
+        #endif
+    }
+
+    #if SKIP
+    func dragSheetListDown(_ rule: any SkipUIEvaluator) {
+        rule.onAllNodesWithTag("sheet-list").onFirst().performGesture {
+            down(Offset(Float(120.0), Float(80.0)))
+            moveTo(Offset(Float(120.0), Float(720.0)))
+            up()
+        }
+    }
+    #endif
+
+    struct SheetOverscrollDismissTestView: View {
+        @State var isPresented = true
+        let interactiveDismissDisabled: Bool
+        let onDismiss: () -> Void
+
+        var body: some View {
+            Text("Sheet Host")
+                .sheet(isPresented: $isPresented, onDismiss: onDismiss) {
+                    List(0..<40) { index in
+                        Text("Row \(index)")
+                    }
+                    .accessibilityIdentifier("sheet-list")
+                    .interactiveDismissDisabled(interactiveDismissDisabled)
+                }
         }
     }
 


### PR DESCRIPTION
Current pull-to-dismiss-sheet only works in iOS when the content is scrollable. This PR bring parity behavior to Android

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Codex generated the code under supervision + manual testing from a sandbox app

-----


https://github.com/user-attachments/assets/6aaab9e8-15da-40c7-b8ec-682c73a7da09

