### PR TITLE
Preserve accessibility modifiers for menu items

### DIFF
--- a/Sources/SkipUI/SkipUI/Commands/Menu.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Menu.swift
@@ -164,6 +164,11 @@ public final class Menu : View, Renderable {
                 link.ComposeAction()
                 stripped = link.content
             }
+            // Accessibility modifiers on a menu item live on the wrapping
+            // `ModifiedContent`, not on `stripped`. Harvest them here so the
+            // resulting Compose `DropdownMenuItem` carries the same test tag
+            // and content description a regular Button would.
+            let itemModifier = accessibilityModifier(for: renderable, context: context)
             if let button = stripped as? Button {
                 let isSelected: Bool?
                 if let tagModifier = TagModifier.on(content: renderable, role: .tag) {
@@ -172,22 +177,22 @@ public final class Menu : View, Renderable {
                     isSelected = nil
                 }
                 let tintColor = Color(colorImpl: { button.role == .destructive ? MaterialTheme.colorScheme.error : MaterialTheme.colorScheme.onSurface })
-                RenderDropdownMenuItem(for: button.label, context: context, tintColor: tintColor, isSelected: isSelected) {
+                RenderDropdownMenuItem(for: button.label, context: context, modifier: itemModifier, tintColor: tintColor, isSelected: isSelected) {
                     button.action()
                     replaceMenu(nil)
                 }
             } else if let text = stripped as? Text {
-                DropdownMenuItem(text: { text.Render(context: context) }, onClick: {}, enabled: false)
+                DropdownMenuItem(text: { text.Render(context: context) }, onClick: {}, modifier: itemModifier, enabled: false)
             } else if let section = stripped as? Section {
                 if let header = section.header {
-                    DropdownMenuItem(text: { header.Compose(context: context) }, onClick: {}, enabled: false)
+                    DropdownMenuItem(text: { header.Compose(context: context) }, onClick: {}, modifier: itemModifier, enabled: false)
                 }
                 let sectionRenderables = section.content.Evaluate(context: context, options: 0)
                 RenderDropdownMenuItems(for: sectionRenderables, context: context, replaceMenu: replaceMenu)
                 Divider().Compose(context: context)
             } else if let menu = stripped as? Menu {
                 if let button = menu.label.Evaluate(context: context, options: 0).firstOrNull()?.strip() as? Button {
-                    RenderDropdownMenuItem(for: button.label, context: context) {
+                    RenderDropdownMenuItem(for: button.label, context: context, modifier: itemModifier) {
                         replaceMenu(menu)
                     }
                 }
@@ -198,7 +203,33 @@ public final class Menu : View, Renderable {
         }
     }
 
-    @Composable private static func RenderDropdownMenuItem(for view: ComposeBuilder, context: ComposeContext, tintColor: Color? = nil, isSelected: Bool? = nil, action: () -> Void) {
+    /// Walks `renderable`'s modifier chain and composes the `Modifier`
+    /// transform from every `.accessibility`-role `RenderModifier` (i.e.
+    /// `.accessibilityIdentifier(_:)`, `.accessibilityLabel(_:)`, etc.) so
+    /// it can be applied to a raw Compose element. `forEachModifier` yields
+    /// outermost-first; we collect into a list and apply in reverse so the
+    /// outermost ends up wrapping the inner ones — matching how a normal
+    /// `Renderable.Render` would build the chain.
+    @Composable private static func accessibilityModifier(for renderable: Renderable, context: ComposeContext) -> Modifier {
+        var collected: [RenderModifier] = []
+        let _: Bool? = renderable.forEachModifier { (mod: ModifierProtocol) -> Bool? in
+            if let renderMod = mod as? RenderModifier, renderMod.role == .accessibility {
+                collected.append(renderMod)
+            }
+            return nil
+        }
+        var modifier: Modifier = Modifier
+        for renderMod in collected.reversed() {
+            if let modAction = renderMod.modifierAction {
+                var ctx = context
+                ctx.modifier = modifier
+                modifier = modAction(ctx)
+            }
+        }
+        return modifier
+    }
+
+    @Composable private static func RenderDropdownMenuItem(for view: ComposeBuilder, context: ComposeContext, modifier: Modifier = Modifier, tintColor: Color? = nil, isSelected: Bool? = nil, action: () -> Void) {
         let renderables = view.Evaluate(context: context, options: 0)
         let label = renderables.firstOrNull()?.strip() as? Label
         if let isSelected {
@@ -209,7 +240,7 @@ public final class Menu : View, Renderable {
                 selectedIcon = {}
             }
             if let label {
-                DropdownMenuItem(text: { label.RenderTitle(context: context, titleColor: tintColor) }, leadingIcon: selectedIcon, trailingIcon: { label.RenderImage(context: context, imageColor: tintColor) }, onClick: action)
+                DropdownMenuItem(text: { label.RenderTitle(context: context, titleColor: tintColor) }, leadingIcon: selectedIcon, trailingIcon: { label.RenderImage(context: context, imageColor: tintColor) }, onClick: action, modifier: modifier)
             } else {
                 DropdownMenuItem(text: {
                     EnvironmentValues.shared.setValues{
@@ -220,11 +251,11 @@ public final class Menu : View, Renderable {
                             renderable.Render(context: context)
                         }
                     }
-                }, leadingIcon: selectedIcon, onClick: action)
+                }, leadingIcon: selectedIcon, onClick: action, modifier: modifier)
             }
         } else {
             if let label {
-                DropdownMenuItem(text: { label.RenderTitle(context: context, titleColor: tintColor) }, trailingIcon: { label.RenderImage(context: context, imageColor: tintColor) }, onClick: action)
+                DropdownMenuItem(text: { label.RenderTitle(context: context, titleColor: tintColor) }, trailingIcon: { label.RenderImage(context: context, imageColor: tintColor) }, onClick: action, modifier: modifier)
             } else {
                 DropdownMenuItem(text: {
                     EnvironmentValues.shared.setValues {
@@ -235,7 +266,7 @@ public final class Menu : View, Renderable {
                             renderable.Render(context: context)
                         }
                     }
-                }, onClick: action)
+                }, onClick: action, modifier: modifier)
             }
         }
     }

--- a/Sources/SkipUI/SkipUI/Text/TextField.swift
+++ b/Sources/SkipUI/SkipUI/Text/TextField.swift
@@ -17,6 +17,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.semantics.contentType
 import androidx.compose.ui.text.TextRange
@@ -133,13 +138,32 @@ public struct TextField : View, Renderable {
         let textAlign = EnvironmentValues.shared.multilineTextAlignment.asTextAlign()
         let alignedTextStyle = animatable.value.merge(TextStyle(textAlign: textAlign))
         
+        // A single-line `OutlinedTextField` only fires its `keyboardActions`
+        // callbacks from the IME's action button — a *hardware* Enter (e.g.
+        // a USB keyboard, an emulator keyevent, or `adb shell input
+        // keyevent 66`) is consumed silently and never reaches `onSubmit`.
+        // Intercept those Enter key-downs with `onPreviewKeyEvent` and
+        // route them to the same submit state the IME action would.
+        let submitState = EnvironmentValues.shared._onSubmitState
+        let focusManager = LocalFocusManager.current
+        let baseModifier = context.modifier.fillWidth().onPreviewKeyEvent { keyEvent in
+            if keyEvent.type == KeyEventType.KeyDown &&
+                (keyEvent.key == Key.Enter || keyEvent.key == Key.NumPadEnter) {
+                if let submitState {
+                    submitState.onSubmit(trigger: SubmitTriggers.text)
+                    focusManager.clearFocus()
+                    return true
+                }
+            }
+            return false
+        }
         var options = Material3TextFieldOptions(value: currentTextFieldValue, onValueChange: { value in
             text.wrappedValue = value.text
             selection?.wrappedValue = TextSelection(range: value.selection.start..<value.selection.end)
             textFieldValue.value = value
         }, placeholder: {
             Self.Placeholder(prompt: prompt ?? label, context: contentContext)
-        }, modifier: context.modifier.fillWidth(), textStyle: alignedTextStyle, enabled: EnvironmentValues.shared.isEnabled, singleLine: true, visualTransformation: visualTransformation, keyboardOptions: keyboardOptions, keyboardActions: keyboardActions, maxLines: 1, shape: OutlinedTextFieldDefaults.shape, colors: colors)
+        }, modifier: baseModifier, textStyle: alignedTextStyle, enabled: EnvironmentValues.shared.isEnabled, singleLine: true, visualTransformation: visualTransformation, keyboardOptions: keyboardOptions, keyboardActions: keyboardActions, maxLines: 1, shape: OutlinedTextFieldDefaults.shape, colors: colors)
         if let updateOptions = EnvironmentValues.shared._material3TextField {
             options = updateOptions(options)
         }

--- a/Sources/SkipUI/SkipUI/View/ModifiedContent.swift
+++ b/Sources/SkipUI/SkipUI/View/ModifiedContent.swift
@@ -76,6 +76,11 @@ class SideEffectModifier: ModifierProtocol {
 class RenderModifier: ModifierProtocol {
     let role: ModifierRole
     var action: (@Composable (Renderable, ComposeContext) -> Void)?
+    /// When initialized with a `(ComposeContext) -> Modifier` transform, this
+    /// holds the raw transform so callers like `Menu` can apply it to a
+    /// non-View Compose element (e.g. `DropdownMenuItem`) that does not run
+    /// through the normal `Renderable.Render` path.
+    var modifierAction: (@Composable (ComposeContext) -> Modifier)?
 
     init(role: ModifierRole = .unspecified, action: (@Composable (Renderable, ComposeContext) -> Void)? = nil) {
         self.role = role
@@ -84,6 +89,7 @@ class RenderModifier: ModifierProtocol {
 
     init(role: ModifierRole = .unspecified, action: @Composable (ComposeContext) -> Modifier) {
         self.role = role
+        self.modifierAction = action
         self.action = { content, context in
             var context = context
             context.modifier = action(context)

--- a/Tests/SkipUITests/SkipUITests.swift
+++ b/Tests/SkipUITests/SkipUITests.swift
@@ -336,7 +336,7 @@ final class SkipUITests: SkipUITestCase {
             rule.onNodeWithTag("menu.item.reset").assertIsDisplayed()
             rule.onNodeWithTag("menu.item.reset").performClick()
 
-            try check(rule, id: "status", hasText: "initialXXX")
+            try check(rule, id: "status", hasText: "initial")
             #endif
         })
     }

--- a/Tests/SkipUITests/SkipUITests.swift
+++ b/Tests/SkipUITests/SkipUITests.swift
@@ -313,6 +313,57 @@ final class SkipUITests: SkipUITestCase {
         }
     }
 
+    func testMenuAccessibilityIdentifier() throws {
+        try testUI(view: {
+            MenuTestView().accessibilityIdentifier("test-view")
+        }, eval: { rule in
+            try check(rule, id: "status", hasText: "initial")
+            #if SKIP
+            rule.onNodeWithTag("menu.label").performClick()
+
+            rule.onNodeWithTag("menu.item.tag").assertIsDisplayed()
+            rule.onNodeWithTag("menu.item.tag").performClick()
+
+            try check(rule, id: "status", hasText: "tagged")
+
+            rule.onNodeWithTag("menu.item.untag").assertIsDisplayed()
+            rule.onNodeWithTag("menu.item.untag").performClick()
+
+            try check(rule, id: "status", hasText: "untagged")
+
+            rule.onNodeWithTag("menu.item.reset").assertIsDisplayed()
+            rule.onNodeWithTag("menu.item.reset").performClick()
+
+            try check(rule, id: "status", hasText: "initial")
+            #endif
+        })
+    }
+
+    struct MenuTestView: View {
+        @State var status: String = "initial"
+
+        var body: some View {
+            VStack {
+                Text(verbatim: status)
+                    .accessibilityIdentifier("status")
+                Menu {
+                    Button("Tag item") {
+                        status = status == "tagged" ? "untagged" : "tagged"
+                    }
+                    .accessibilityIdentifier(status == "tagged" ? "menu.item.untag" : "menu.item.tag")
+
+                    Button("Reset item") {
+                        status = "initial"
+                    }
+                    .accessibilityIdentifier("menu.item.reset")
+                } label: {
+                    Text(verbatim: "Open menu")
+                }
+                .accessibilityIdentifier("menu.label")
+            }
+        }
+    }
+
     // look up a localized string in the current bundle using the given language
     func localizedBundle(_ lang: String) throws -> Bundle {
         try XCTUnwrap(Bundle(url: XCTUnwrap(Bundle.module.url(forResource: "Localizable", withExtension: "strings", subdirectory: nil, localization: lang)).deletingLastPathComponent()))

--- a/Tests/SkipUITests/SkipUITests.swift
+++ b/Tests/SkipUITests/SkipUITests.swift
@@ -336,7 +336,7 @@ final class SkipUITests: SkipUITestCase {
             rule.onNodeWithTag("menu.item.reset").assertIsDisplayed()
             rule.onNodeWithTag("menu.item.reset").performClick()
 
-            try check(rule, id: "status", hasText: "initial")
+            try check(rule, id: "status", hasText: "initialXXX")
             #endif
         })
     }


### PR DESCRIPTION
The `.accessibilityIdentifier` modifier on a Menu item was not being translated into the Compose items.