### PR TITLE
fix(TabView): skip nil tabs so conditional tabs don't render a blank slot

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/TabView.swift
+++ b/Sources/SkipUI/SkipUI/Containers/TabView.swift
@@ -418,7 +418,10 @@ public struct TabView : View, Renderable {
                                     if layoutType == NavigationSuiteType.NavigationBar {
                                         NavigationBar(modifier: options.modifier.semantics { testTagsAsResourceId = true }.testTag("skip_ui_automation_tab_bar"), containerColor: options.containerColor, contentColor: options.contentColor, tonalElevation: options.tonalElevation) {
                                             for tabIndex in 0..<tabRenderables.size {
-                                                if tabs[tabIndex]?.isHidden == true {
+                                                // A tab from a `false` conditional branch (e.g. `if x { Tab(...) }`)
+                                                // maps to a nil entry above; skip it so it does not render a blank,
+                                                // equal-width navigation item (phantom slot / uneven spacing).
+                                                if tabs[tabIndex] == nil || tabs[tabIndex]?.isHidden == true {
                                                     continue
                                                 }
                                                 let route = String(describing: tabIndex)
@@ -445,7 +448,10 @@ public struct TabView : View, Renderable {
                                             // Center the item group vertically (Material navigation rail guidance for tablets).
                                             Spacer(modifier: Modifier.weight(Float(1.0)))
                                             for tabIndex in 0..<tabRenderables.size {
-                                                if tabs[tabIndex]?.isHidden == true {
+                                                // A tab from a `false` conditional branch (e.g. `if x { Tab(...) }`)
+                                                // maps to a nil entry above; skip it so it does not render a blank,
+                                                // equal-width navigation item (phantom slot / uneven spacing).
+                                                if tabs[tabIndex] == nil || tabs[tabIndex]?.isHidden == true {
                                                     continue
                                                 }
                                                 let route = String(describing: tabIndex)


### PR DESCRIPTION
## Problem

A tab declared inside a `false` conditional branch leaves a phantom, empty, equal-width slot in the tab bar:

```swift
TabView {
    HomeTab()
    if user.isAdmin { AdminTab() }   // false for most users
    SettingsTab()
}
```

For users where the condition is false, the bar shows the real tabs **plus a blank gap**, and the real tabs are squeezed/unevenly spaced. iOS SwiftUI omits the tab entirely in this case, so it's an Android-only divergence.

## Cause

In `RenderTabViewContent`, the renderable→`Tab` mapping returns `nil` when a renderable has no `TabItemModifier` (which is what a false conditional branch produces). The `NavigationBar` and `NavigationRail` loops iterate `0..<tabRenderables.size` and only `continue` on tabs explicitly marked `isHidden`:

```swift
for tabIndex in 0..<tabRenderables.size {
    if tabs[tabIndex]?.isHidden == true { continue }
    NavigationBarItem(icon: { tabs[tabIndex]?.RenderImage(...) }, label: { ... })
}
```

A `nil` tab is not `isHidden`, so it still emits a `NavigationBarItem` with an empty icon/label. Material3 distributes width equally across all items, so the empty item becomes a visible blank slot.

## Fix

Skip `nil` tabs in both the `NavigationBar` and `NavigationRail` loops, so only real tabs get a bar item. Content/selection are unaffected — `nil` tabs already carry no tag and are guarded with optional chaining everywhere else.

## Test

In a downstream app, a `TabView` with a speaker-only conditional tab rendered 4 real tabs + 1 blank slot (5 equal cells, ~216px each) for non-speakers. After the fix, the same screen shows 4 evenly-spaced cells (~270px each, centers 276px apart) with no gap; speakers still get all 5 tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)