### PR TITLE
fix(NavigationStack): don't reserve top-bar inset for title-less roots

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -305,12 +305,24 @@ public struct NavigationStack : View, Renderable {
         let defaultTopBarHeight = 112.dp
         let topBarBottomPx = remember {
             // Default our initial value to the expected value, which helps avoid visual artifacts as we measure actual values and
-            // recompose with adjusted layouts
+            // recompose with adjusted layouts. Only reserve the inset when a bar will actually be
+            // shown: a title-less root has showTopBar == false and never composes the
+            // AnimatedVisibility content below, so its onDispose reset never runs — initializing to
+            // the bar height here would leave a phantom top inset (~safeArea + 112dp).
             let safeAreaTopPx = arguments.safeArea?.safeBoundsPx.top ?? Float(0.0)
-            mutableStateOf(with(density) { safeAreaTopPx + defaultTopBarHeight.toPx() })
+            mutableStateOf(showTopBar ? with(density) { safeAreaTopPx + defaultTopBarHeight.toPx() } : Float(0.0))
         }
         let topBarHeightPx = remember {
-            mutableStateOf(with(density) { defaultTopBarHeight.toPx() })
+            mutableStateOf(showTopBar ? with(density) { defaultTopBarHeight.toPx() } : Float(0.0))
+        }
+        // Reactively clear the reserved inset whenever the bar is hidden — covers both a
+        // title-less root (where AnimatedVisibility's onDispose never runs) and visible→hidden
+        // transitions where onDispose may not have fired yet.
+        LaunchedEffect(showTopBar) {
+            if !showTopBar {
+                topBarBottomPx.value = Float(0.0)
+                topBarHeightPx.value = Float(0.0)
+            }
         }
 
         let isSystemBackground = topBarPreferences?.isSystemBackground == true


### PR DESCRIPTION
Fixes #451. Regression from #414: the reset of `topBarBottomPx`/`topBarHeightPx` to 0 lives in `onDispose` inside `AnimatedVisibility(visible: showTopBar)`, which never composes (so never disposes) when `showTopBar` is `false` from the start — leaving a phantom ~`safeArea + 112dp` top inset on every title-less root (e.g. `TabView` tab roots with no `.navigationTitle`).

Initialize both to `0` when `!showTopBar`, and add a `LaunchedEffect(showTopBar)` to clear them on visible→hidden transitions. The 112dp anti-flash init is preserved for bars that are shown; pushed/detail screens (`showTopBar == true`) are unaffected.

Verified on Android (Skip Lite, a production app): the gap above title-less tab roots is gone and detail-screen bars/back buttons still render correctly.
