### PR TITLE
fixedSize() / fixedSize(horizontal:vertical:)

### DIFF
--- a/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
+++ b/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
@@ -9,6 +9,8 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -512,14 +514,32 @@ extension View {
         return self
     }
 
-    @available(*, unavailable)
-    public func fixedSize(horizontal: Bool, vertical: Bool) -> some View {
+    // SKIP @bridge
+    public func fixedSize(horizontal: Bool, vertical: Bool) -> any View {
+        #if SKIP
+        guard horizontal || vertical else {
+            return self
+        }
+        // Fix an axis to the content's ideal size by measuring it unbounded on that axis, mirroring
+        // SwiftUI's fixedSize (the view is proposed its ideal size and won't be compressed/truncated).
+        // A non-fixed axis is left untouched so the flexible-width layout system still governs it.
+        return ModifiedContent(content: self, modifier: RenderModifier { context in
+            var modifier = context.modifier
+            if horizontal {
+                modifier = modifier.wrapContentWidth(unbounded: true)
+            }
+            if vertical {
+                modifier = modifier.wrapContentHeight(unbounded: true)
+            }
+            return modifier
+        })
+        #else
         return self
+        #endif
     }
 
-    @available(*, unavailable)
-    public func fixedSize() -> some View {
-        return self
+    public func fixedSize() -> any View {
+        return fixedSize(horizontal: true, vertical: true)
     }
 
     // SKIP @bridge


### PR DESCRIPTION
## What

Implements `fixedSize()` and `fixedSize(horizontal:vertical:)`, previously `@available(*, unavailable)`.

## How

Maps SwiftUI's fixedSize to Compose by measuring the fixed axis unbounded via a `RenderModifier`:

- `horizontal: true` → `Modifier.wrapContentWidth(unbounded: true)`
- `vertical: true` → `Modifier.wrapContentHeight(unbounded: true)`

So the view takes its ideal size on a fixed axis and is not compressed or truncated, matching SwiftUI semantics. A non-fixed axis is left untouched, so the existing flexible-width layout system still governs it. Exposed as `// SKIP @bridge` for SkipSwiftUI.

## Note: when this is (and isn't) a no-op

`fixedSize` changes layout only when an axis would otherwise be constrained. On Compose, `Text` already wraps to the available width and grows to its full intrinsic height, so:

- `fixedSize(horizontal: false, vertical: true)` is a **no-op for a `Text` that isn't height-constrained** (a plain `Text` in a `VStack`/`ScrollView` already shows in full) — same as on iOS. It has a real effect when the height *is* constrained (an explicit `frame(height:)` / `maxHeight:`, or a parent that limits height), where it lets the content keep its ideal height instead of being clipped.
- `fixedSize(horizontal: true, ...)` changes layout whenever the text would otherwise wrap or truncate — it keeps the text at its ideal width (even overflowing a narrower container), which is essentially never a no-op for wrappable text.

The before/after gallery used to verify this deliberately constrains each axis, so every case shows a visible difference.

## Pairing

Bridged for SkipSwiftUI in skiptools/skip-fuse-ui#119.

## Testing

Verified on an Android emulator with a SkipFuse app via before/after pairs:

- `fixedSize(horizontal: false, vertical: true)` shows a height-clipped text in full.
- `fixedSize(horizontal: true, vertical: false)` keeps a label on one line at its ideal width instead of wrapping into a narrow frame.
- `fixedSize()` keeps a label from truncating when squeezed in an `HStack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
