### PR TITLE
Implement presentationDragIndicator(_:)

### DIFF
--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -132,6 +132,8 @@ private let AlertDialogMaxWidth: Dp = 560.dp
             // Producers contribute under the value type rather than the `PreferenceKey` type, so override `collectorKey`.
             let (detentPreferences, detentPreferencesCollector) = rememberSaveablePreferenceCollector(key: PresentationDetentPreferenceKey.self, stateSaver: context.stateSaver as! Saver<Preference<PresentationDetentPreferences>, Any>, collectorKey: PresentationDetentPreferences.self)
             let reducedDetentPreferences = detentPreferences.value.reduced
+            let (dragIndicatorPreferences, dragIndicatorPreferencesCollector) = rememberSaveablePreferenceCollector(key: PresentationDragIndicatorPreferenceKey.self, stateSaver: context.stateSaver as! Saver<Preference<PresentationDragIndicatorPreferences>, Any>, collectorKey: PresentationDragIndicatorPreferences.self)
+            let reducedDragIndicatorVisibility = dragIndicatorPreferences.value.reduced.visibility
 
             if !isFullScreen && verticalSizeClass != .compact {
                 systemBarEdges.remove(.top)
@@ -162,7 +164,13 @@ private let AlertDialogMaxWidth: Dp = 560.dp
                 // Draw the drag handle and the presentation root content area below it
                 androidx.compose.foundation.layout.Spacer(modifier: Modifier.height(inset - handleHeight - handlePadding))
                 Row(modifier: Modifier.fillMaxWidth(), horizontalArrangement: Arrangement.Center) {
-                    Capsule().fill(Color.primary.opacity(0.4)).frame(width: 60.0, height: Double(handleHeight.value)).Compose(context: context)
+                    // Honor `presentationDragIndicator(.hidden)` by suppressing the capsule while
+                    // preserving its vertical footprint so the content does not shift.
+                    if reducedDragIndicatorVisibility == Visibility.hidden {
+                        androidx.compose.foundation.layout.Spacer(modifier: Modifier.height(handleHeight))
+                    } else {
+                        Capsule().fill(Color.primary.opacity(0.4)).frame(width: 60.0, height: Double(handleHeight.value)).Compose(context: context)
+                    }
                 }
                 androidx.compose.foundation.layout.Spacer(modifier: Modifier.height(handlePadding))
             } else if !isEdgeToEdge {
@@ -191,7 +199,7 @@ private let AlertDialogMaxWidth: Dp = 560.dp
                         $0.setdismiss(DismissAction(action: { isPresented.set(false) }))
                         return ComposeResult.ok
                     } in: {
-                        PreferenceValues.shared.collectPreferences([interactiveDismissDisabledCollector, detentPreferencesCollector]) {
+                        PreferenceValues.shared.collectPreferences([interactiveDismissDisabledCollector, detentPreferencesCollector, dragIndicatorPreferencesCollector]) {
                             for renderable in contentRenderables {
                                 renderable.Render(context: context)
                             }
@@ -817,6 +825,30 @@ struct PresentationDetentPreferences: Equatable {
         return lhs.detent == rhs.detent
     }
 }
+
+struct PresentationDragIndicatorPreferenceKey: PreferenceKey {
+    static let defaultValue = PresentationDragIndicatorPreferences()
+
+    static func reduce(value: inout PresentationDragIndicatorPreferences, nextValue: () -> PresentationDragIndicatorPreferences) {
+        value = value.reduce(nextValue())
+    }
+}
+
+struct PresentationDragIndicatorPreferences: Equatable {
+    let visibility: Visibility
+
+    init(visibility: Visibility = .automatic) {
+        self.visibility = visibility
+    }
+
+    func reduce(_ next: PresentationDragIndicatorPreferences) -> PresentationDragIndicatorPreferences {
+        return next
+    }
+
+    public static func ==(lhs: PresentationDragIndicatorPreferences, rhs: PresentationDragIndicatorPreferences) -> Bool {
+        return lhs.visibility == rhs.visibility
+    }
+}
 #endif
 
 
@@ -1178,9 +1210,17 @@ extension View {
         return self
     }
 
-    @available(*, unavailable)
-    public func presentationDragIndicator(_ visibility: Visibility) -> some View {
+    public func presentationDragIndicator(_ visibility: Visibility) -> any View {
+        #if SKIP
+        return preference(key: PresentationDragIndicatorPreferences.self, value: PresentationDragIndicatorPreferences(visibility: visibility))
+        #else
         return self
+        #endif
+    }
+
+    // SKIP @bridge
+    public func presentationDragIndicator(bridgedVisibility: Int) -> any View {
+        return presentationDragIndicator(Visibility(rawValue: bridgedVisibility) ?? .automatic)
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
## What

Implements `presentationDragIndicator(_:)`, which is currently `@available(*, unavailable)`.

## Why

The bottom-sheet presentation (`SheetPresentation`) already draws its own grab-handle capsule for non-fullscreen sheets, so `.visible` / `.automatic` happen to look correct today. But because the modifier is unavailable, `.hidden` has no effect — there is no way to suppress the handle on Android, which diverges from SwiftUI on iOS.

## How

- Add a collected `PresentationDragIndicatorPreferences` (a `Visibility`), mirroring the existing `PresentationDetentPreferences` machinery, and read its reduced value in `SheetPresentation` to gate the capsule.
- When `.hidden`, the capsule is replaced by a spacer of identical height so the sheet content does not shift.
- Replace the unavailable stub with a real implementation, plus a `// SKIP @bridge` `presentationDragIndicator(bridgedVisibility:)` variant taking the `Visibility` raw value — matching the existing `confirmationDialog(bridgedTitleVisibility:)` bridging pattern.

Single-file change in `Layout/Presentation.swift`.

## Verification

Built and exercised on an Android emulator from a SkipFuse app via a small debug gallery presenting medium/large-detent sheets:
- `.visible` and `.automatic` → grab-handle capsule shown.
- `.hidden` → no capsule, content stays in place.

## Paired PR

Forwarding the bridge from the SkipSwiftUI layer: skiptools/skip-fuse-ui#120
