### PR TITLE
Support grouped asset catalog lookup

### DIFF
--- a/Sources/SkipUI/SkipUI/System/Assets.swift
+++ b/Sources/SkipUI/SkipUI/System/Assets.swift
@@ -22,9 +22,9 @@ func assetContentsURLs(name: String, bundle: Bundle) -> [URL] {
     var resourceURLs: [URL] = []
     for resourceName in resourceNames {
         let components = resourceName.split(separator: "/").map({ String($0) })
-        // return every *.xcassets/NAME/Contents.json
+        // Return every *.xcassets/**/NAME/Contents.json, including grouped asset folders.
         if components.first?.hasSuffix(".xcassets") == true
-            && components.dropFirst().first == name
+            && components.dropLast().last == name
             && components.last == "Contents.json",
            let contentsURL = bundle.url(forResource: resourceName, withExtension: nil) {
             resourceURLs.append(contentsURL)


### PR DESCRIPTION
Thank you for contributing to the Skip project! Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.


Codex generated the code, tested in-app, manually

-----

Fix: asset files from xcasset are not being picked up on Android unless found directly at the root of the xcasset directory

See screenshots from the [repro app](https://github.com/tifroz/skip-xcasset-group-test): in `Package.swift` toggle the reference to `skip-ui` (via `skip-fuse-ui` between patched / not patched to see the difference)



<img width="295" height="640" alt="Screenshot_20260605_143415 Medium" src="https://github.com/user-attachments/assets/fccd6640-36e2-4d5d-9bab-f9c499603da9" />
<img width="295" height="640" alt="Screenshot_20260605_141241 Medium" src="https://github.com/user-attachments/assets/e2beb425-b464-4bd8-8530-f650a95bcd8e" />

