### PR TITLE
Inline drag indicator preference collector to handle removal of rememberSaveablePreferenceCollector

### DIFF
--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -133,7 +133,10 @@ private let AlertDialogMaxWidth: Dp = 560.dp
             let detentPreferences = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<PresentationDetentPreferences>, Any>) { mutableStateOf(Preference<PresentationDetentPreferences>(key: PresentationDetentPreferenceKey.self)) }
             let detentPreferencesCollector = PreferenceCollector<PresentationDetentPreferences>(key: PresentationDetentPreferences.self, state: detentPreferences)
             let reducedDetentPreferences = detentPreferences.value.reduced
-            let (dragIndicatorPreferences, dragIndicatorPreferencesCollector) = rememberSaveablePreferenceCollector(key: PresentationDragIndicatorPreferenceKey.self, stateSaver: context.stateSaver as! Saver<Preference<PresentationDragIndicatorPreferences>, Any>, collectorKey: PresentationDragIndicatorPreferences.self)
+
+            let dragIndicatorPreferences = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<PresentationDragIndicatorPreferences>, Any>) { mutableStateOf(Preference<PresentationDragIndicatorPreferences>(key: PresentationDragIndicatorPreferenceKey.self)) }
+            let dragIndicatorPreferencesCollector = PreferenceCollector<PresentationDragIndicatorPreferences>(key: PresentationDragIndicatorPreferences.self, state: dragIndicatorPreferences)
+
             let reducedDragIndicatorVisibility = dragIndicatorPreferences.value.reduced.visibility
 
             if !isFullScreen && verticalSizeClass != .compact {


### PR DESCRIPTION
Fixed collision introduced by the removal of `rememberSaveablePreferenceCollector` in https://github.com/skiptools/skip-ui/pull/441#issuecomment-4730760120 and the referencing of the function in https://github.com/skiptools/skip-ui/pull/455.