### PR TITLE
Bugfix: Trailing Swipe Actions Order

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/List.swift
+++ b/Sources/SkipUI/SkipUI/Containers/List.swift
@@ -640,18 +640,21 @@ public final class List : View, Renderable {
         }
         let trailingButtonsRaw: kotlin.collections.List<Button> = trailingButtonsRawMutable
         let leadingButtonsRaw: kotlin.collections.List<Button> = leadingButtonsRawMutable
-        /* iOS reorders .destructive Buttons to the swipe-from edge regardless
-           of the order they were declared in. For trailing swipes that means
-           pinned to the right (last in the Row laid out with Arrangement.End);
-           for leading, pinned to the left (first with Arrangement.Start). The
-           destructive button also becomes the full-swipe target. */
+        /* iOS displays trailing swipe actions in the opposite visual order from
+           their declaration so the first declared action sits on the swipe edge.
+           Leading actions keep declaration order. iOS also reorders .destructive
+           Buttons to the swipe-from edge regardless of declaration order. For
+           trailing swipes that means pinned to the right (last in the Row laid
+           out with Arrangement.End); for leading, pinned to the left (first with
+           Arrangement.Start). The destructive button also becomes the full-swipe
+           target. */
         let trailingDestructive = trailingButtonsRaw.firstOrNull { $0.role == ButtonRole.destructive }
         let trailingNonDestructive = trailingButtonsRaw.filter { $0.role != ButtonRole.destructive }
         let trailingButtons: kotlin.collections.List<Button>
         if let trailingDestructive {
-            trailingButtons = (trailingNonDestructive + listOf(trailingDestructive))
+            trailingButtons = (trailingNonDestructive.reversed() + listOf(trailingDestructive))
         } else {
-            trailingButtons = trailingButtonsRaw
+            trailingButtons = trailingButtonsRaw.reversed()
         }
         let leadingDestructive = leadingButtonsRaw.firstOrNull { $0.role == ButtonRole.destructive }
         let leadingNonDestructive = leadingButtonsRaw.filter { $0.role != ButtonRole.destructive }


### PR DESCRIPTION
Since https://github.com/skiptools/skip-ui/pull/425, Skip UI supports swipe actions which is working great in general. However, while using this feature, I noticed that the order of trailing swipe actions behaves differently on Android and iOS.

This discrepancy can also be seen in the [video](https://github.com/skiptools/skip-ui/pull/425#issuecomment-4456140612) attached to the original pull request:

<img width="237" height="318" alt="Android" src="https://github.com/user-attachments/assets/68fb6463-a0a0-44fb-b5ff-19a20ca20214" /><img width="260" height="317" alt="iOS" src="https://github.com/user-attachments/assets/65f81fd7-a1d0-44bf-bef8-82964dfae503" />

This PR fixes the issue and ensures consistent behavior across platforms by reversing the order of trailing swipe actions.

---

Thank you for contributing to the Skip project! Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device
- [X] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

