### PR TITLE
Bugfix: Disable Context Menu When No Items Are Present

### DIFF
--- a/Sources/SkipUI/SkipUI/Commands/ContextMenu.swift
+++ b/Sources/SkipUI/SkipUI/Commands/ContextMenu.swift
@@ -37,7 +37,8 @@ class ContextMenuModifier: RenderModifier {
     let nestedMenu = remember { mutableStateOf<Menu?>(nil) }
     let coroutineScope = rememberCoroutineScope()
     let contentContext = context.content()
-    let isContextMenuEnabled = EnvironmentValues.shared.isEnabled && EnvironmentValues.shared._isHitTestingEnabled
+    let primaryMenuItems = menuItems.Evaluate(context: contentContext, options: 0).filter { !$0.isSwiftUIEmptyView }
+    let isContextMenuEnabled = EnvironmentValues.shared.isEnabled && EnvironmentValues.shared._isHitTestingEnabled && primaryMenuItems.size > 0
     let replaceMenu: (Menu?) -> Void = { menu in
         coroutineScope.launch {
             delay(200)
@@ -105,7 +106,7 @@ class ContextMenuModifier: RenderModifier {
                     $0.set_placement(placement)
                     return ComposeResult.ok
                 } in: {
-                    let renderables = (nestedMenu.value?.content ?? menuItems).Evaluate(context: contentContext, options: 0)
+                    let renderables = nestedMenu.value?.content.Evaluate(context: contentContext, options: 0) ?? primaryMenuItems
                     Menu.RenderDropdownMenuItems(for: renderables, context: contentContext, replaceMenu: replaceMenu)
                 }
             }


### PR DESCRIPTION
Currently, a context menu can be triggered even when it contains no items. This causes haptic feedback even though no menu is displayed. However, on iOS, empty context menus are completely ignored. This PR aligns Skip's behavior with iOS by disabling context menus that contain no items.

---

Thank you for contributing to the Skip project! Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device
- [X] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

