### PR TITLE
Fix hex color component parsing

### DIFF
--- a/Sources/SkipUI/SkipUI/Color/Color.swift
+++ b/Sources/SkipUI/SkipUI/Color/Color.swift
@@ -622,11 +622,83 @@ private struct ColorSet : Decodable {
         let blue: String?
         let alpha: String?
 
+        private static func hexDigitValue(_ character: Character) -> Int? {
+            switch character {
+            case "0":
+                return 0
+            case "1":
+                return 1
+            case "2":
+                return 2
+            case "3":
+                return 3
+            case "4":
+                return 4
+            case "5":
+                return 5
+            case "6":
+                return 6
+            case "7":
+                return 7
+            case "8":
+                return 8
+            case "9":
+                return 9
+            case "a", "A":
+                return 10
+            case "b", "B":
+                return 11
+            case "c", "C":
+                return 12
+            case "d", "D":
+                return 13
+            case "e", "E":
+                return 14
+            case "f", "F":
+                return 15
+            default:
+                return nil
+            }
+        }
+
+        private static func parseHexComponent(_ value: String) -> Double? {
+            let hexValue = value.dropFirst(2)
+
+            if hexValue.isEmpty {
+                return nil
+            }
+
+            var intValue = 0
+
+            for character in hexValue {
+                guard let digit = Self.hexDigitValue(character) else {
+                    return nil
+                }
+
+                intValue = intValue * 16 + digit
+            }
+
+            return Double(intValue) / 255.0
+        }
+
+        private static func parseComponent(_ value: String?, defaultValue: Double) -> Double {
+            guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+                return defaultValue
+            }
+
+            if value.hasPrefix("0x") || value.hasPrefix("0X") {
+                return Self.parseHexComponent(value) ?? defaultValue
+            }
+
+            return Double(value) ?? defaultValue
+        }
+
         var color: Color {
-            let redValue = Double(red ?? "") ?? 0.0
-            let greenValue = Double(green ?? "") ?? 0.0
-            let blueValue = Double(blue ?? "") ?? 0.0
-            let alphaValue = Double(alpha ?? "") ?? 1.0
+            let redValue = Self.parseComponent(red, defaultValue: 0.0)
+            let greenValue = Self.parseComponent(green, defaultValue: 0.0)
+            let blueValue = Self.parseComponent(blue, defaultValue: 0.0)
+            let alphaValue = Self.parseComponent(alpha, defaultValue: 1.0)
+
             return Color(red: redValue, green: greenValue, blue: blueValue, opacity: alphaValue)
         }
     }


### PR DESCRIPTION
Thank you for contributing to the Skip project! Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

This PR fixes custom `.colorset` parsing when asset catalog component values are stored as hexadecimal strings such as `"0x94"` or `"0XFF"`.

The existing parser attempted to parse every color component with `Double(...)`, which works for normalized decimal strings like `"1.000"` but fails for hex component strings. This change adds a small parsing path for `0x` / `0X` values and converts those 8-bit channel values into normalized `Double` values between 0 and 1, while keeping the existing decimal parsing behavior unchanged.

Closes #146

Skip Pull Request Checklist:

- [ ] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository
- [ ] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*:

AI was used to review the implementation for correctness and scope before submission. I manually reviewed the code changes, checked that the implementation specifically handles `0x` / `0X` hex component strings, preserved the existing decimal parsing behavior, and tested the project locally with `swift test`.