### PR TITLE
Support the 8-bit (0-255) .colorset input method (follow-up to #471)

### DIFF
--- a/Sources/SkipUI/SkipUI/Color/Color.swift
+++ b/Sources/SkipUI/SkipUI/Color/Color.swift
@@ -690,6 +690,11 @@ private struct ColorSet : Decodable {
                 return Self.parseHexComponent(value) ?? defaultValue
             }
 
+            // "8-bit (0-255)" input method (e.g. "148"): a bare integer with no decimal point, normalized by /255.
+            if !value.contains("."), let intValue = Int(value) {
+                return Double(intValue) / 255.0
+            }
+
             return Double(value) ?? defaultValue
         }
 

--- a/Tests/SkipUITests/ColorTests.swift
+++ b/Tests/SkipUITests/ColorTests.swift
@@ -14,6 +14,34 @@ final class ColorTests: XCSnapshotTestCase {
         XCTAssertEqual("F", try render(compact: 1, view: Color.white.frame(width: 1.0, height: 1.0)).pixmap)
     }
 
+    // Issue #146 follow-up: a custom .colorset must render the same color regardless of which Input Method
+    // Xcode used to encode its components. #471 handled the "0x" hexadecimal form; these also cover the
+    // "8-bit (0-255)" and "Floating Point" methods. All three fixtures encode the same color (#04F188).
+    //
+    // DISABLED-prefixed (device/emulator only): decoding a bundled component .colorset from Bundle.module
+    // throws a kotlin-reflect IllegalAccessException under the Robolectric *unit* runner (it can't access the
+    // DecodableCompanion Skip generates for the nested ColorSet types), so the color falls back to gray. This
+    // is a pre-existing test-runner limitation, independent of the parser; the parsing itself is covered by a
+    // standalone logic harness, and these render correctly on a real device/emulator.
+
+    func DISABLEDtestHexColorset() throws {
+        #if SKIP
+        XCTAssertEqual("04F188", try render(compact: 1, view: Color("HexColor", bundle: .module).frame(width: 1.0, height: 1.0)).pixmap)
+        #endif
+    }
+
+    func DISABLEDtestIntColorset() throws {
+        #if SKIP
+        XCTAssertEqual("04F188", try render(compact: 1, view: Color("IntColor", bundle: .module).frame(width: 1.0, height: 1.0)).pixmap)
+        #endif
+    }
+
+    func DISABLEDtestFloatColorset() throws {
+        #if SKIP
+        XCTAssertEqual("04F188", try render(compact: 1, view: Color("FloatColor", bundle: .module).frame(width: 1.0, height: 1.0)).pixmap)
+        #endif
+    }
+
     // Disabled tests (due to slow performance when running against emulator)
 
     func DISABLEDtestColorClearDark() throws {

--- a/Tests/SkipUITests/ColorTests.swift
+++ b/Tests/SkipUITests/ColorTests.swift
@@ -14,30 +14,26 @@ final class ColorTests: XCSnapshotTestCase {
         XCTAssertEqual("F", try render(compact: 1, view: Color.white.frame(width: 1.0, height: 1.0)).pixmap)
     }
 
-    // Issue #146 follow-up: a custom .colorset must render the same color regardless of which Input Method
-    // Xcode used to encode its components. #471 handled the "0x" hexadecimal form; these also cover the
-    // "8-bit (0-255)" and "Floating Point" methods. All three fixtures encode the same color (#04F188).
-    //
-    // DISABLED-prefixed (device/emulator only): decoding a bundled component .colorset from Bundle.module
-    // throws a kotlin-reflect IllegalAccessException under the Robolectric *unit* runner (it can't access the
-    // DecodableCompanion Skip generates for the nested ColorSet types), so the color falls back to gray. This
-    // is a pre-existing test-runner limitation, independent of the parser; the parsing itself is covered by a
-    // standalone logic harness, and these render correctly on a real device/emulator.
+    // Issue #146 follow-up: all three .colorset Input Methods must render the same color (#04F188).
+    // Skipped on Robolectric — Bundle.module colorset decoding falls back to gray there (pre-existing runner limitation).
 
-    func DISABLEDtestHexColorset() throws {
+    func testHexColorset() throws {
         #if SKIP
+        if isRobolectric { throw XCTSkip("Bundle.module colorset decoding requires Android emulator") }
         XCTAssertEqual("04F188", try render(compact: 1, view: Color("HexColor", bundle: .module).frame(width: 1.0, height: 1.0)).pixmap)
         #endif
     }
 
-    func DISABLEDtestIntColorset() throws {
+    func testIntColorset() throws {
         #if SKIP
+        if isRobolectric { throw XCTSkip("Bundle.module colorset decoding requires Android emulator") }
         XCTAssertEqual("04F188", try render(compact: 1, view: Color("IntColor", bundle: .module).frame(width: 1.0, height: 1.0)).pixmap)
         #endif
     }
 
-    func DISABLEDtestFloatColorset() throws {
+    func testFloatColorset() throws {
         #if SKIP
+        if isRobolectric { throw XCTSkip("Bundle.module colorset decoding requires Android emulator") }
         XCTAssertEqual("04F188", try render(compact: 1, view: Color("FloatColor", bundle: .module).frame(width: 1.0, height: 1.0)).pixmap)
         #endif
     }

--- a/Tests/SkipUITests/Resources/Assets.xcassets/FloatColor.colorset/Contents.json
+++ b/Tests/SkipUITests/Resources/Assets.xcassets/FloatColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.533333",
+          "green" : "0.945098",
+          "red" : "0.015686"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/SkipUITests/Resources/Assets.xcassets/HexColor.colorset/Contents.json
+++ b/Tests/SkipUITests/Resources/Assets.xcassets/HexColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x88",
+          "green" : "0xF1",
+          "red" : "0x04"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/SkipUITests/Resources/Assets.xcassets/IntColor.colorset/Contents.json
+++ b/Tests/SkipUITests/Resources/Assets.xcassets/IntColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "255",
+          "blue" : "136",
+          "green" : "241",
+          "red" : "4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
<!-- Suggested labels: bug -->

## Why

#471 (thanks @haaaaaaarshs!) fixed the common case — `.colorset` channels authored with Xcode's **8-bit Hexadecimal** input method (`0x..`) now parse correctly instead of rendering black. Following up on @marcprux's note on #468, this rounds out the last numeric Input Method: **8-bit (0–255)**.

Xcode's "8-bit (0–255)" method writes each channel as a bare integer (e.g. `"148"`). That currently falls through to `Double("148") = 148.0`, which clamps to white — so a color authored with that method still renders wrong. This normalizes a bare integer (one with no decimal point) by `/255`, matching the hex path.

There also isn't yet any test coverage around colorset component parsing, so this adds fixtures + render tests for all three numeric methods (hexadecimal, 8-bit 0–255, floating point) — all encoding the same color — to guard against regressions.

## What

- `ColorComponents.parseComponent`: adds one branch — a bare integer (no `.`) is treated as an 8-bit (0–255) value and normalized `/255`. The hexadecimal and floating-point paths are unchanged.
- Adds `HexColor` / `IntColor` / `FloatColor` fixtures (the same `#04F188` encoded via each method) and render tests asserting all three agree.

A note on the tests: they're `DISABLED`-prefixed because decoding a bundled component `.colorset` throws a `kotlin-reflect` `IllegalAccessException` under the Robolectric **unit** runner (it can't access the generated `DecodableCompanion` for the nested `ColorSet` types), so it falls back to gray there. This is a pre-existing test-runner limitation independent of this change — the tests pass on a real device/emulator, and the parsing logic is additionally covered by a standalone check.

## Before / After evidence

Standalone check of the parsing over all three methods (same color):

```
hex  0x04 / 0xF1 / 0x88   -> 0.0157 / 0.9451 / 0.5333
8bit 4    / 241  / 136    -> 0.0157 / 0.9451 / 0.5333   (before: "148"-style values clamped to white)
float 0.0157 / 0.9451 / 0.5333 -> unchanged
```

`swift test --filter ColorTests` passes; `skip test --filter ColorTests` builds/transpiles and the suite stays green.

## Acceptance criteria
- [x] Test added for the new behavior (8-bit fixtures + render tests) plus hex/float regression fixtures
- [x] Existing test suite passes (`swift test`; `skip test` on Robolectric)
- [x] Follows project style (extends the existing `parseComponent`, reusing #471's helpers)
- [x] No breaking changes (hex and floating-point paths unchanged)

Refs #146, builds on #471.

-----

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in Skip Fuse UI — none needed (internal colorset parsing; no public API change)
- [ ] OPTIONAL: I have added an example of any UI changes to the Showcase sample app

-----

- [x] AI was used to assist with this PR. **How:** I used Claude Code to extend the parser, add fixtures/tests, and run the suite. **Verification:** I read and understood every line, confirmed the 8-bit normalization against the hex/float encodings of the same color, and ran `swift test` + `skip test` plus a standalone logic check.
