### PR TITLE
Don't inherit the presenter's scroll axes into a presentation

### DIFF
--- a/Sources/SkipUI/SkipUI/Compose/ComposeLayouts.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeLayouts.swift
@@ -235,7 +235,12 @@ private func flexibleLayoutFloat(_ value: CGFloat?) -> Float? {
             guard !measurables.isEmpty() else {
                 return layout(width: 0, height: 0) {}
             }
-            let updatedConstraints = constraints.copy(maxWidth: constraints.maxWidth + expansionLeft + expansionRight, maxHeight: constraints.maxHeight + expansionTop + expansionBottom)
+            // Guard the arithmetic: in an intrinsic measurement pass (e.g. a parent fill in a
+            // scroll direction using IntrinsicSize.Max) Compose calls measure with
+            // maxHeight == Constraints.Infinity, and adding the expansion overflows Int to a
+            // negative value, crashing Constraints.copy. Preserve Infinity and never go below
+            // the min constraints
+            let updatedConstraints = constraints.copy(maxWidth: constraint(constraints.maxWidth, adding: expansionLeft + expansionRight, atLeast: constraints.minWidth), maxHeight: constraint(constraints.maxHeight, adding: expansionTop + expansionBottom, atLeast: constraints.minHeight))
             let targetPlaceables = measurables.map { $0.measure(updatedConstraints) }
             layout(width: targetPlaceables[0].width, height: targetPlaceables[0].height) {
                 // Layout will center extra space by default
@@ -337,6 +342,13 @@ private func constraint(_ value: Int, subtracting: Int) -> Int {
         return value
     }
     return max(0, value - subtracting)
+}
+
+private func constraint(_ value: Int, adding: Int, atLeast: Int) -> Int {
+    guard value != Int.MAX_VALUE else {
+        return value
+    }
+    return max(atLeast, value + adding)
 }
 
 private func placeContent(width: Int, height: Int, inWidth: Int, inHeight: Int, alignment: Alignment) -> (Int, Int) {

--- a/Sources/SkipUI/SkipUI/Containers/PresentationRoot.swift
+++ b/Sources/SkipUI/SkipUI/Containers/PresentationRoot.swift
@@ -79,6 +79,14 @@ import androidx.compose.ui.platform.LocalLayoutDirection
                         $0.set_isEdgeToEdge(safeBounds != presentationBounds.value)
                     }
                     $0.set_safeArea(safeArea)
+                    // A presentation is a new layout root: scroll axes inherited from the presenting
+                    // context (e.g. a sheet presented from a button inside a ScrollView) must not
+                    // leak in. Otherwise expanding content in the presentation is sized with
+                    // IntrinsicSize as if it were in the presenter's scroll direction, which crashes
+                    // when that content contains a lazy container: intrinsic measurement of
+                    // SubcomposeLayout-based components is unsupported in Compose
+                    $0.set_layoutScrollAxes(Axis.Set(rawValue: 0))
+                    $0.set_scrollAxes(Axis.Set(rawValue: 0))
                     return ComposeResult.ok
                 } in: {
                     Box(modifier: Modifier.fillMaxSize().padding(safeArea), contentAlignment = androidx.compose.ui.Alignment.Center) {


### PR DESCRIPTION
## Problem

Presenting a `.sheet` whose content is a `List` (or any lazy container) from a button **inside a `ScrollView`** crashes on Android. It works fine on iOS.

```
java.lang.IllegalStateException: Asking for intrinsic measurements of SubcomposeLayout
layouts is not supported. This includes components that are built on top of
SubcomposeLayout, such as lazy lists, BoxWithConstraints, TabRow, etc.
```

and, on the path before the lazy content is reached, the intrinsic measurement (`maxHeight == Constraints.Infinity`) also overflows `IgnoresSafeAreaLayout`'s expansion arithmetic:

```
java.lang.IllegalArgumentException: maxWidth must be >= than minWidth, ...
  at skip.ui.ComposeLayoutsKt$IgnoresSafeAreaLayout$...measure(ComposeLayouts.kt)
```

## Cause

A presentation is a new layout root, but `PresentationRoot` left the **presenter's** `_scrollAxes` / `_layoutScrollAxes` in the environment. When the sheet is presented from within a `ScrollView`, `ComposeFlexibleContainer` then sizes expanding content in the sheet with `Modifier.height(IntrinsicSize.Max)` — the "fill in a scroll direction" path — as if the sheet were laid out in the presenter's scroll direction. Asking a `List` for its intrinsic height is what Compose forbids, hence the crash.

## Fix

- **`PresentationRoot`**: reset `_layoutScrollAxes` and `_scrollAxes` to empty at the presentation boundary, so the presentation lays out from a clean root and doesn't inherit an intrinsic-sizing regime from whatever presented it.
- **`IgnoresSafeAreaLayout`**: guard the safe-area expansion against an `Infinity` incoming constraint the same way the existing `constraint(_:subtracting:)` helper does (preserve `Infinity`, clamp to the min constraints), so any intrinsic measurement pass can't overflow `Int` into a negative `maxWidth`.

## Reproduce

Present a sheet containing a `List` from a `Button` inside a `ScrollView`. Crashes on Android before this change; renders and scrolls after.

## Verification

Built and run on an Android emulator: the sheet (including a sheet-presented-from-a-sheet, and a `List` with sub-rows) renders, scrolls, and dismisses cleanly. iOS behavior is unchanged. Related to #191, though that report is a genuinely-nested scroll case; this one is scroll-axis inheritance leaking across the presentation boundary.