### PR TITLE
fix(android): disable List item placement animations

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/List.swift
+++ b/Sources/SkipUI/SkipUI/Containers/List.swift
@@ -289,9 +289,12 @@ public final class List : View, Renderable {
             // Read move trigger here so that a move will recompose list content
             let _ = moveTrigger.value
             let shouldAnimateItems: @Composable () -> Bool = {
-                // We disable animation to prevent filtered items from animating when they return
-                let animate = !forceUnanimatedItems.value && EnvironmentValues.shared._searchableState?.isSearching.value != true
-                return animate
+                // Algumon temporary performance patch: Compose's permanent
+                // animateItem modifier causes measurable jank while scrolling
+                // large, image-rich lists. Keep LazyColumn virtualization and
+                // stable keys, but disable placement animation until SkipUI
+                // exposes a public opt-out.
+                return false
             }
 
             // Initialize the factory context with closures that use the LazyListScope to generate items


### PR DESCRIPTION
SkipUI applies Compose animateItem to every List row. Disable it temporarily for Algumon because device profiling shows sustained scroll jank. LazyColumn virtualization, stable keys, and list behavior remain unchanged.

Thank you for contributing to the Skip project! Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [ ] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [ ] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device
- [ ] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

