### PR TITLE
Implement listRowSpacing(_:)

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/List.swift
+++ b/Sources/SkipUI/SkipUI/Containers/List.swift
@@ -285,7 +285,9 @@ public final class List : View, Renderable {
         if let contentMargins = EnvironmentValues.shared._contentMargins?.asComposePaddingValues(for: .automatic) {
             contentPadding = contentPadding.adding(contentMargins)
         }
-        LazyColumn(state: reorderableState.listState, modifier: modifier, contentPadding: contentPadding) {
+        let listRowSpacing = EnvironmentValues.shared._listRowSpacing
+        let listVerticalArrangement = listRowSpacing != nil ? Arrangement.spacedBy(listRowSpacing!.dp) : Arrangement.Top
+        LazyColumn(state: reorderableState.listState, modifier: modifier, contentPadding: contentPadding, verticalArrangement: listVerticalArrangement) {
             // Read move trigger here so that a move will recompose list content
             let _ = moveTrigger.value
             let shouldAnimateItems: @Composable () -> Bool = {
@@ -1369,9 +1371,13 @@ extension View {
         return self
     }
 
-    @available(*, unavailable)
-    public func listRowSpacing(_ spacing: CGFloat?) -> some View {
+    // SKIP @bridge
+    public func listRowSpacing(_ spacing: CGFloat?) -> any View {
+        #if SKIP
+        return environment(\._listRowSpacing, spacing, affectsEvaluate: false)
+        #else
         return self
+        #endif
     }
 
     @available(*, unavailable)

--- a/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
+++ b/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
@@ -789,6 +789,11 @@ extension EnvironmentValues {
         set { setBuiltinValue(key: "_contentMargins", value: newValue, defaultValue: { nil }) }
     }
 
+    var _listRowSpacing: CGFloat? {
+        get { builtinValue(key: "_listRowSpacing", defaultValue: { nil }) as! CGFloat? }
+        set { setBuiltinValue(key: "_listRowSpacing", value: newValue, defaultValue: { nil }) }
+    }
+
     /// Allow users to revert to previous layout behavior.
     var _layoutImplementationVersion: Int {
         get { builtinValue(key: "_layoutImplementationVersion", defaultValue: { 2 }) as! Int }


### PR DESCRIPTION
Closes #351

Implements `View.listRowSpacing(_:)`, previously `@available(*, unavailable)`. Threads the spacing value through `EnvironmentValues` (matching the existing `contentMargins` pattern: a `_listRowSpacing: CGFloat?` builtin value set via `environment(\._listRowSpacing, spacing, affectsEvaluate: false)`), then reads it where `List`'s `LazyColumn` is constructed and passes it into `verticalArrangement: Arrangement.spacedBy(spacing.dp)`. When the modifier isn't used, `verticalArrangement` falls back to `Arrangement.Top`, matching `LazyColumn`'s existing default so unset behavior is unchanged.

The modifier is tagged `// SKIP @bridge` and returns `any View`, matching the existing convention for other modifiers taking directly-bridgeable scalar parameters (e.g. `listItemTint(_: Color?)`, `Spacer.init(minLength: CGFloat?)`) as opposed to modifiers needing an enum-to-Int bridge shim.

Files changed:
- `Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift`: added `_listRowSpacing: CGFloat?` builtin environment value, next to `_contentMargins`.
- `Sources/SkipUI/SkipUI/Containers/List.swift`: replaced the unavailable `listRowSpacing` stub with a real implementation; threaded `_listRowSpacing` into the single `LazyColumn(...)` call site (grepped the file — it's the only List rendering path that builds a `LazyColumn`).

**Verified:**
- `swift build` passes clean.
- Hand-verified against the existing working `contentMargins` (ScrollView.swift) and `LazyHStack`'s `Arrangement.spacedBy` idiom for correctness of the Kotlin-ish `#if SKIP` code, since that portion isn't type-checked by `swift build`.
- Attempted `swift test --filter ListTests` with `ANDROID_HOME` set; it progressed through Skip's Swift-to-Kotlin transpilation and Gradle project generation for the test target with no errors related to this change, but then failed with `error: no such module 'XCTest'` while emitting the `SkipTest` module — a local toolchain/environment issue (this Swift toolchain lacks a usable XCTest for macOS in this sandbox), not something caused by this change. I was not able to run the tests to completion (no gradle/emulator run occurred).

**Not verified:** actual on-device/emulator Android rendering of row spacing. There's no existing dedicated List-modifier test file (`Tests/SkipUITests/SkipUITests.swift` has one `List(...)` usage inside an unrelated sheet-dismissal Compose-UI-test, using `onAllNodesWithTag`/gesture APIs that require the Android test harness above); given that harness couldn't be exercised in this environment, I did not add a new test rather than force something fragile and unverified.

Scope: intentionally limited to `listRowSpacing`; the neighboring still-unavailable `listSectionSpacing` and `listRowInsets` stubs are untouched (separate issues).