### PR TITLE
Bugfix: Only Dismiss Keyboard on User Scroll

### DIFF
--- a/Sources/SkipUI/SkipUI/Compose/ComposeExtensions.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeExtensions.swift
@@ -1,6 +1,7 @@
 // Copyright 2023–2026 Skip
 // SPDX-License-Identifier: MPL-2.0
 #if SKIP
+import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -10,6 +11,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.requiredWidthIn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
@@ -19,12 +22,15 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import kotlin.math.abs
 
 extension Modifier {
     /// Fill available width similar to `.frame(maxWidth: .infinity)`.
@@ -154,10 +160,33 @@ extension Modifier {
         let focusManager = rememberUpdatedState(LocalFocusManager.current)
         let imeInsets = WindowInsets.ime
         let density = LocalDensity.current
+        let isUserScrollActive = remember { mutableStateOf(false) }
         let nestedScrollConnection = remember {
-            KeyboardDismissingNestedScrollConnection(keyboardController: keyboardController, focusManager: focusManager, imeInsets: imeInsets, density: density)
+            KeyboardDismissingNestedScrollConnection(keyboardController: keyboardController, focusManager: focusManager, imeInsets: imeInsets, density: density, isUserScrollActive: isUserScrollActive)
         }
-        return self.nestedScroll(nestedScrollConnection)
+        return self.pointerInput(mode) {
+            let slop = viewConfiguration.touchSlop
+            awaitEachGesture {
+                isUserScrollActive.value = false
+                let downEvent = awaitPointerEvent(pass: PointerEventPass.Initial)
+                guard let start = downEvent.changes.firstOrNull({ $0.pressed })?.position else {
+                    return
+                }
+                var pressed = true
+                while pressed {
+                    let event = awaitPointerEvent(pass: PointerEventPass.Initial)
+                    if let change = event.changes.firstOrNull() {
+                        pressed = change.pressed
+                        if abs(change.position.x - start.x) > slop || abs(change.position.y - start.y) > slop {
+                            isUserScrollActive.value = true
+                        }
+                    } else {
+                        pressed = false
+                    }
+                }
+                isUserScrollActive.value = false
+            }
+        }.nestedScroll(nestedScrollConnection)
     }
 }
 

--- a/Sources/SkipUI/SkipUI/System/Keyboard.swift
+++ b/Sources/SkipUI/SkipUI/System/Keyboard.swift
@@ -18,15 +18,17 @@ struct KeyboardDismissingNestedScrollConnection: NestedScrollConnection {
     let focusManager: State<FocusManager?>
     let imeInsets: WindowInsets
     let density: Density
+    let isUserScrollActive: State<Bool>
 
     override func onPreScroll(available: Offset, source: NestedScrollSource) -> Offset {
-        if source == NestedScrollSource.Drag {
-            let keyboardIsVisible = imeInsets.getBottom(density) > 0
-            if keyboardIsVisible {
-                keyboardController.value?.hide()
-                focusManager.value?.clearFocus()
-            }
+        guard source == NestedScrollSource.Drag,
+              imeInsets.getBottom(density) > 0,
+              isUserScrollActive.value else {
+            return Offset.Zero
         }
+
+        keyboardController.value?.hide()
+        focusManager.value?.clearFocus()
         return Offset.Zero
     }
 }


### PR DESCRIPTION
While testing a form with `scrollDismissesKeyboard` enabled, I noticed that the keyboard could be dismissed when the scroll was triggered programmatically. This can happen for example in cases where a focused `TextField` is scrolled into view using a `ScrollViewProxy`.

**Example:**
```
ScrollViewReader { proxy in
    Form {
        TextField("Notes", text: $notes)
            .id("notes")
            .onChange(of: isFocused) { _, isFocused in
                if isFocused {
                    proxy.scrollTo("notes", anchor: .bottom)
                }
            }
    }
    .scrollDismissesKeyboard(.immediately)
}
```

**Before:**
<img width="400" height="897" alt="Before" src="https://github.com/user-attachments/assets/c256b4d3-7a3b-4b8a-aaf0-7e2f85a19edb" />

**After:**
<img width="400" height="897" alt="After" src="https://github.com/user-attachments/assets/3608cd45-d3b4-4e0f-be15-6b879dc2ccfb" />

> As you can see here, before the change the keyboard dismisses immediately, making it impossible for the user to input anything into the field.

This PR fixes the issue by making keyboard dismissal only react to actual user scroll gestures. Programmatic scroll updates can still move content into view, while manually scrolling the view continues to dismiss the keyboard as expected.

**Update:**
You can also reproduce this bug using the `KeyboardScrollDismissPlayground` in the Showcase app by, for example, positioning the TextField at the top of the List so that it isn't fully within the view, causing it to scroll into view automatically. You'll then see that it is dismissed immediately, even though the user hasn't actively scrolled.

**Before:**
<img width="400" height="897" alt="Before Showcase" src="https://github.com/user-attachments/assets/2d956b05-c792-453e-a16d-78af5ae8faac" />

**After:**
<img width="400" height="897" alt="After Showcase" src="https://github.com/user-attachments/assets/4197b6a4-6267-4db5-8560-345a807b1ef5" />

---

Thank you for contributing to the Skip project! Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device
- [X] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

