### PR TITLE
Fix IllegalAccessException reading non-public PreferenceKey/EnvironmentKey (#243)

### DIFF
--- a/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
+++ b/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
@@ -28,7 +28,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import kotlin.reflect.full.companionObjectInstance
+import kotlin.reflect.full.companionObject
 #endif
 
 public protocol EnvironmentKey {
@@ -40,6 +40,18 @@ public protocol EnvironmentKey {
 public protocol EnvironmentKeyCompanion {
     associatedtype Value
     var defaultValue: Value { get }
+}
+
+/// Companion object instance for `type`, via Java reflection with `isAccessible = true`.
+/// Kotlin's `companionObjectInstance` omits that and throws `IllegalAccessException` for
+/// non-`public` key types, whose generated class is package-private (issue #243).
+func companionInstance(ofType type: Any.Type) -> Any? {
+    var instance: Any? = nil
+    // SKIP INSERT: val name = type.companionObject?.simpleName ?: "Companion"
+    // SKIP INSERT: val field = type.java.getDeclaredField(name)
+    // SKIP INSERT: field.isAccessible = true
+    // SKIP INSERT: instance = field.get(null)
+    return instance
 }
 #endif
 
@@ -145,7 +157,7 @@ public final class EnvironmentValues {
 
     /// The Compose `CompositionLocal` for the given environment value key type.
     public func valueCompositionLocal(key: Any.Type) -> ProvidableCompositionLocal<Any> {
-        // SKIP INSERT: val defaultValue = { (key.companionObjectInstance as EnvironmentKeyCompanion<*>).defaultValue }
+        // SKIP INSERT: val defaultValue = { (companionInstance(key) as EnvironmentKeyCompanion<*>).defaultValue }
         return compositionLocal(key: key, defaultValue: defaultValue)
     }
 

--- a/Sources/SkipUI/SkipUI/Environment/PreferenceKey.swift
+++ b/Sources/SkipUI/SkipUI/Environment/PreferenceKey.swift
@@ -19,7 +19,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
-import kotlin.reflect.full.companionObjectInstance
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 #endif
@@ -137,7 +136,7 @@ struct PreferenceCollector<Value> {
 
     init(key: Any.Type, initialValue: Value? = nil) {
         self.key = key
-        let companion = key.companionObjectInstance as! PreferenceKeyCompanion<Value>
+        let companion = companionInstance(ofType: key) as! PreferenceKeyCompanion<Value>
         self.initialValue = initialValue ?? companion.defaultValue
         self.reducer = { value, nextValue in
             var updatedValue = value
@@ -200,8 +199,8 @@ extension View {
     public func onPreferenceChange<K>(_ key: K.Type /* = K.self */, perform action: @escaping (K.Value) -> Void) -> any View where K : PreferenceKey {
         #if SKIP
         // Work around transpiler bug
-        // SKIP REPLACE: val companion = key.companionObjectInstance as PreferenceKeyCompanion<V>
-        let companion = key.companionObjectInstance as! PreferenceKeyCompanion<V>
+        // SKIP REPLACE: val companion = companionInstance(key) as PreferenceKeyCompanion<V>
+        let companion = companionInstance(ofType: key) as! PreferenceKeyCompanion<V>
         return onPreferenceChange(key: key, defaultValue: companion.defaultValue, reducer: { value, nextValue in
             var updatedValue = value as! V
             companion.reduce(value: &updatedValue, nextValue: { nextValue as! V })

--- a/Tests/SkipUITests/SkipUITests.swift
+++ b/Tests/SkipUITests/SkipUITests.swift
@@ -845,6 +845,28 @@ final class SkipUITests: SkipUITestCase {
         }
     }
 
+    // Reading a non-public `PreferenceKey` reflects its companion the same way a
+    // non-public `EnvironmentKey` does. Composing `.onPreferenceChange` for a private
+    // key must not throw `IllegalAccessException` (issue #243); the label renders only
+    // if composition completes without that crash.
+    func testCustomPreferenceKey() throws {
+        try testUI(view: {
+            PreferenceValueView()
+                .accessibilityIdentifier("test-view")
+        }, eval: { rule in
+            try check(rule, id: "preference-label", hasText: "content")
+        })
+    }
+    struct PreferenceValueView: View {
+        var body: some View {
+            VStack {
+                Text("content")
+                    .accessibilityIdentifier("preference-label")
+            }
+            .onPreferenceChange(PreferenceTestKey.self) { _ in }
+        }
+    }
+
 //    func testObservability() throws {
 //        try testUI(view: {
 //            ObservablesOuterView()
@@ -1005,13 +1027,21 @@ extension SemanticsNode {
 #endif
 
 // Used in `testCustomEnvironmentValue`
-public struct EnvironmentValueTestKey: EnvironmentKey {
-    public static let defaultValue = "default"
+private struct EnvironmentValueTestKey: EnvironmentKey {
+    static let defaultValue = "default"
 }
 
 extension EnvironmentValues {
-    public var testValue: String {
+    fileprivate var testValue: String {
         get { self[EnvironmentValueTestKey.self] }
         set { self[EnvironmentValueTestKey.self] = newValue }
+    }
+}
+
+// Used in `testCustomPreferenceKey`; non-public to reproduce issue #243.
+private struct PreferenceTestKey: PreferenceKey {
+    static let defaultValue = "preferred"
+    static func reduce(value: inout String, nextValue: () -> String) {
+        value = nextValue()
     }
 }


### PR DESCRIPTION
## Motivation

A custom `PreferenceKey` or `EnvironmentKey` declared `private` or `fileprivate` crashes the first time its value is read. On Android the key transpiles to a package-private Kotlin class, and reading its companion object via Kotlin reflection throws:

```
java.lang.IllegalAccessException: class kotlin.reflect.jvm.internal.KClassImpl$Data
cannot access a member of class skip.ui.<Key> with modifiers "public static final"
```

## Root cause

`PreferenceKey.swift` and `EnvironmentValues.swift` read the companion via `kotlin.reflect.full.companionObjectInstance`:

- `Preference.init(key:)` — `key.companionObjectInstance as! PreferenceKeyCompanion<Value>`
- `View.onPreferenceChange(_:perform:)` — `key.companionObjectInstance as PreferenceKeyCompanion<V>`
- `EnvironmentValues.valueCompositionLocal(key:)` — `key.companionObjectInstance as EnvironmentKeyCompanion<*>`

The synthesized companion `INSTANCE` field is `public static final`, but the enclosing key class is package-private when the Swift type is `private`/`fileprivate`. Kotlin's `companionObjectInstance` reads that field without calling `isAccessible = true`, so the JVM access check fails with `IllegalAccessException`.

## Fix

Introduce a small `companionInstance(ofType:)` helper that resolves the companion via Java reflection with `field.isAccessible = true`, and route the three call sites through it:

```kotlin
internal fun companionInstance(ofType: KClass<*>): Any? {
    val name = ofType.companionObject?.simpleName ?: "Companion"
    val field = ofType.java.getDeclaredField(name)
    field.isAccessible = true
    return field.get(null)
}
```

This is the minimal root-level fix — it removes the one missing `isAccessible = true` rather than forcing every custom key to be `public`.

## Testing

The regression test was previously worked around in 3a7de72 ("Make test PreferenceKey implementation public, working around #243") by making the test `EnvironmentKey` and its accessor `public`. This PR reverts that to `private`/`fileprivate`, restoring `testCustomEnvironmentValue` as a genuine reproduction.

- **Before the fix** (test key `private`): `testCustomEnvironmentValue$SkipUI` fails on Robolectric with the `IllegalAccessException` above — `JUNIT ... PASSED 0 FAILED 1`.
- **After the fix**: `JUNIT ... PASSED 1 FAILED 0`.

Verified with the real Skip SDK via `swift test` (Robolectric): transpiles, `compileDebugKotlin` succeeds, and `testCustomEnvironmentValue` passes with the test key `private`.

## Related

#310 reports what looks like the same root cause surfacing as a `null cannot be cast to non-null type ...PreferenceKeyCompanion` NPE (a non-public `@AppStorage`/preference key whose companion reflection fails). This change should resolve it too, though only #243 was reproduced here.

Fixes #243
