### PR TITLE
Coerce @AppStorage values across primitive types instead of crashing

### DIFF
--- a/Sources/SkipUI/SkipUI/Properties/AppStorage.swift
+++ b/Sources/SkipUI/SkipUI/Properties/AppStorage.swift
@@ -63,13 +63,7 @@ public final class AppStorage<Value>: StateTracker {
         // Create our Compose-trackable backing state and keep it in sync with the store. Note that we have to seed the store with a value
         // for the key in order for our listener to work
         let store = self.currentStore
-        let object = store.object(forKey: key)
-        let value: Value?
-        if let object, let deserializer {
-            value = deserializer(object)
-        } else {
-            value = object as? Value
-        }
+        let value = storedValue(from: store.object(forKey: key), store: store)
         if let value {
             _wrappedValue = value
         } else if let serializer {
@@ -82,20 +76,48 @@ public final class AppStorage<Value>: StateTracker {
         // Caution: The preference manager does not currently store a strong reference to the listener. You must store a strong reference to the listener, or it will be susceptible to garbage collection. We recommend you keep a reference to the listener in the instance data of an object that will exist as long as you need the listener.
         // https://developer.android.com/reference/android/content/SharedPreferences.html#registerOnSharedPreferenceChangeListener(android.content.SharedPreferences.OnSharedPreferenceChangeListener)
         self.listener = store.registerOnSharedPreferenceChangeListener(key: key) {
-            let object = store.object(forKey: key)
-            let value: Value?
-            if let object, let deserializer {
-                value = deserializer(object)
-            } else {
-                value = object as? Value
-            }
-            if let value {
+            if let value = storedValue(from: store.object(forKey: key), store: store) {
                 _wrappedValue = value
                 _wrappedValueState?.value = value
             }
         }
         #endif
     }
+
+    #if SKIP
+    /// Read the stored `object` as our `Value`, coercing between primitive types the way `UserDefaults` does on iOS.
+    ///
+    /// `object as? Value` is a no-op under Kotlin's type erasure: it neither coerces (so `@AppStorage` would not
+    /// round-trip a value stored under one primitive type and read as another, unlike SwiftUI on iOS) nor rejects a
+    /// mismatched type (so a `String` stored value would flow into a `Double`-typed property and crash later with a
+    /// `ClassCastException` — see https://github.com/skiptools/skip-ui/issues/317). Instead we dispatch on the concrete
+    /// runtime type of the current wrapped value and use the matching typed `UserDefaults` accessor, mirroring the
+    /// coercion that the bridged `AppStorageSupport` performs.
+    private func storedValue(from object: Any?, store: UserDefaults) -> Value? {
+        guard let object else {
+            return nil
+        }
+        if let deserializer {
+            return deserializer(object)
+        }
+        switch _wrappedValue {
+        case is Bool:
+            return ((object as? Bool) ?? store.bool(forKey: key)) as? Value
+        case is Int:
+            return ((object as? Int) ?? store.integer(forKey: key)) as? Value
+        case is Double:
+            return ((object as? Double) ?? store.double(forKey: key)) as? Value
+        case is String:
+            return ((object as? String) ?? store.string(forKey: key)) as? Value
+        case is URL:
+            return ((object as? URL) ?? store.url(forKey: key)) as? Value
+        case is Data:
+            return ((object as? Data) ?? store.data(forKey: key)) as? Value
+        default:
+            return object as? Value
+        }
+    }
+    #endif
 
     /// The current active store
     private var currentStore: UserDefaults {

--- a/Tests/SkipUITests/AppStorageTests.swift
+++ b/Tests/SkipUITests/AppStorageTests.swift
@@ -1,0 +1,49 @@
+// Copyright 2026 Skip
+// SPDX-License-Identifier: MPL-2.0
+import Foundation
+import SwiftUI
+import XCTest
+#if SKIP
+import SkipModel
+#endif
+
+final class AppStorageTests: XCTestCase {
+
+    /// A value stored under one primitive type and read through an `@AppStorage` of another
+    /// must coerce (as `UserDefaults` does on iOS) rather than let the mismatched type through,
+    /// which crashed a later consumer with a `ClassCastException` (issue #317).
+    func testAppStorageCoercesStringToDouble() throws {
+        #if !SKIP
+        throw XCTSkip("@AppStorage type coercion is Android-only")
+        #else
+        let defaults = UserDefaults.standard
+        let key = "SkipUITests.appStorageStringToDouble"
+        defaults.removeObject(forKey: key)
+
+        defaults.set("1.0", forKey: key) // stored as a String
+        let storage = AppStorage(wrappedValue: 0.0, key) // read as a Double
+        storage.trackState()
+        XCTAssertEqual(storage.wrappedValue, 1.0)
+
+        defaults.removeObject(forKey: key)
+        #endif
+    }
+
+    /// An integer stored value read through a `Double`-typed `@AppStorage` should coerce as well.
+    func testAppStorageCoercesIntToDouble() throws {
+        #if !SKIP
+        throw XCTSkip("@AppStorage type coercion is Android-only")
+        #else
+        let defaults = UserDefaults.standard
+        let key = "SkipUITests.appStorageIntToDouble"
+        defaults.removeObject(forKey: key)
+
+        defaults.set(3, forKey: key) // stored as an Int
+        let storage = AppStorage(wrappedValue: 0.0, key) // read as a Double
+        storage.trackState()
+        XCTAssertEqual(storage.wrappedValue, 3.0)
+
+        defaults.removeObject(forKey: key)
+        #endif
+    }
+}


### PR DESCRIPTION
## Motivation

On iOS, `@AppStorage` coerces between primitive types: you can store a value as a `Double` and read it back as a `String`, or vice versa. On Android the same code crashes (#317) — e.g. store `"1.0"` under a key, then read it through a `Double`-typed `@AppStorage`:

```
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Number
```

## Root cause

`AppStorage<Value>.trackState()` read the stored object with:

```swift
value = object as? Value
```

Under Kotlin's type erasure `Value` is unknown at runtime, so `object as? Value` is a **no-op**: it neither coerces the value nor rejects a mismatched type. A `String` stored value flowed unchanged into a `Double`-typed property and crashed a later consumer.

The bridged `AppStorageSupport` doesn't have this problem because it captures a per-type `get` closure at init (e.g. `{ $1 as? Double ?? $0.double(forKey: key) }`) using `UserDefaults`' coercing typed accessors. The generic `AppStorage<Value>` has only one generic initializer, so it has no such per-type dispatch point — but its `_wrappedValue` still holds a concrete runtime value.

## Fix

Dispatch on the concrete runtime type of `_wrappedValue` and read through the matching typed `UserDefaults` accessor, mirroring `AppStorageSupport`'s coercion. Both the initial read and the change-listener read now go through a single `storedValue(from:store:)` helper. Behavior is otherwise unchanged: an absent key still returns `nil` (seeding the default), and a `deserializer`, when present, still takes priority.

## Testing

New `AppStorageTests` (runs under Robolectric via the transpiled test path):

- `testAppStorageCoercesStringToDouble` — stores `"1.0"`, reads a `Double`, expects `1.0`.
- `testAppStorageCoercesIntToDouble` — stores `3`, reads a `Double`, expects `3.0`.

Verified the tests are a real regression guard: against the pre-fix `object as? Value` both fail under Robolectric (`AssertionError: 1.0 != 1.0` — String vs Double — and `3 != 3.0`), and pass with the fix. Full transpiled `SkipUI` suite green (94 tests, 0 failures).
