### PR TITLE
Fix Sheet `TopAppBar` insets

### DIFF
--- a/Sources/SkipUI/SkipUI/Commands/Toolbar.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Toolbar.swift
@@ -626,8 +626,8 @@ struct ToolbarContentPreferences: Equatable {
 struct ToolbarItems {
     let content: [View]
 
-    /// Proces our content items, dividing them into the locations at which they should render.
-    @Composable func Evaluate(context: ComposeContext) -> (titleMenu: ToolbarTitleMenu?, topLeading: kotlin.collections.List<Renderable>, topTrailing: kotlin.collections.List<Renderable>, bottom: kotlin.collections.List<Renderable>) {
+    /// Process our content items, dividing them into the locations at which they should render.
+    @Composable func Evaluate(context: ComposeContext) -> (titleMenu: ToolbarTitleMenu?, principal: Renderable?, topLeading: kotlin.collections.List<Renderable>, topTrailing: kotlin.collections.List<Renderable>, bottom: kotlin.collections.List<Renderable>) {
         var titleMenu: ToolbarTitleMenu? = nil
         let leading: kotlin.collections.MutableList<Renderable> = mutableListOf()
         let trailing: kotlin.collections.MutableList<Renderable> = mutableListOf()
@@ -642,6 +642,7 @@ struct ToolbarItems {
                     let placement = (renderable as? ToolbarItem)?.placement ?? (renderable as? ToolbarSpacer)?.placement ?? ToolbarItemPlacement.automatic
                     switch placement {
                     case .principal:
+                        // The navigation container renders principal content in the title slot.
                         principal = renderable
                     case .topBarLeading, .navigationBarLeading, .cancellationAction:
                         leading.add(renderable)
@@ -653,9 +654,6 @@ struct ToolbarItems {
                 }
             }
         }
-        if let principal {
-            leading.add(principal)
-        }
         // SwiftUI inserts a spacer before the last bottom item
         if bottom.size > 1 && !bottom.any({
             let stripped = $0.strip()
@@ -663,7 +661,7 @@ struct ToolbarItems {
         }) {
             bottom.add(1, Spacer())
         }
-        return (titleMenu, leading, trailing, bottom)
+        return (titleMenu, principal, leading, trailing, bottom)
     }
 }
 #endif

--- a/Sources/SkipUI/SkipUI/Commands/Toolbar.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Toolbar.swift
@@ -626,8 +626,8 @@ struct ToolbarContentPreferences: Equatable {
 struct ToolbarItems {
     let content: [View]
 
-    /// Process our content items, dividing them into the locations at which they should render.
-    @Composable func Evaluate(context: ComposeContext) -> (titleMenu: ToolbarTitleMenu?, principal: Renderable?, topLeading: kotlin.collections.List<Renderable>, topTrailing: kotlin.collections.List<Renderable>, bottom: kotlin.collections.List<Renderable>) {
+    /// Proces our content items, dividing them into the locations at which they should render.
+    @Composable func Evaluate(context: ComposeContext) -> (titleMenu: ToolbarTitleMenu?, topLeading: kotlin.collections.List<Renderable>, topTrailing: kotlin.collections.List<Renderable>, bottom: kotlin.collections.List<Renderable>) {
         var titleMenu: ToolbarTitleMenu? = nil
         let leading: kotlin.collections.MutableList<Renderable> = mutableListOf()
         let trailing: kotlin.collections.MutableList<Renderable> = mutableListOf()
@@ -642,7 +642,6 @@ struct ToolbarItems {
                     let placement = (renderable as? ToolbarItem)?.placement ?? (renderable as? ToolbarSpacer)?.placement ?? ToolbarItemPlacement.automatic
                     switch placement {
                     case .principal:
-                        // The navigation container renders principal content in the title slot.
                         principal = renderable
                     case .topBarLeading, .navigationBarLeading, .cancellationAction:
                         leading.add(renderable)
@@ -654,6 +653,9 @@ struct ToolbarItems {
                 }
             }
         }
+        if let principal {
+            leading.add(principal)
+        }
         // SwiftUI inserts a spacer before the last bottom item
         if bottom.size > 1 && !bottom.any({
             let stripped = $0.strip()
@@ -661,7 +663,7 @@ struct ToolbarItems {
         }) {
             bottom.add(1, Spacer())
         }
-        return (titleMenu, principal, leading, trailing, bottom)
+        return (titleMenu, leading, trailing, bottom)
     }
 }
 #endif

--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -462,11 +462,12 @@ public struct NavigationStack : View, Renderable {
                         }
                         // Use scrollBehavior (from the early call) for the TopAppBar to ensure it matches the nestedScrollConnection
                         options = options.copy(scrollBehavior: scrollBehavior)
+                        let topBarWindowInsets = EnvironmentValues.shared._sheetDepth > 0 ? WindowInsets(0.dp, 0.dp, 0.dp, 0.dp) : TopAppBarDefaults.windowInsets
                         if isInlineTitleDisplayMode {
                             if options.preferCenterAlignedStyle {
-                                CenterAlignedTopAppBar(title: options.title, modifier: options.modifier, navigationIcon: options.navigationIcon, actions: { topBarActions() }, colors: options.colors, scrollBehavior: options.scrollBehavior)
+                                CenterAlignedTopAppBar(title: options.title, modifier: options.modifier, navigationIcon: options.navigationIcon, actions: { topBarActions() }, colors: options.colors, windowInsets: topBarWindowInsets, scrollBehavior: options.scrollBehavior)
                             } else {
-                                TopAppBar(title: options.title, modifier: options.modifier, navigationIcon: options.navigationIcon, actions: { topBarActions() }, colors: options.colors, scrollBehavior: options.scrollBehavior)
+                                TopAppBar(title: options.title, modifier: options.modifier, navigationIcon: options.navigationIcon, actions: { topBarActions() }, colors: options.colors, windowInsets: topBarWindowInsets, scrollBehavior: options.scrollBehavior)
                             }
                         } else {
                             // Force a larger, bold title style in the uncollapsed state by replacing the headlineSmall style the bar uses
@@ -475,9 +476,9 @@ public struct NavigationStack : View, Renderable {
                             let appBarTypography = typography.copy(headlineSmall: appBarTitleStyle)
                             MaterialTheme(colorScheme: MaterialTheme.colorScheme, typography: appBarTypography, shapes: MaterialTheme.shapes) {
                                 if options.preferLargeStyle {
-                                    LargeTopAppBar(title: options.title, modifier: options.modifier, navigationIcon: options.navigationIcon, actions: { topBarActions() }, colors: options.colors, scrollBehavior: options.scrollBehavior)
+                                    LargeTopAppBar(title: options.title, modifier: options.modifier, navigationIcon: options.navigationIcon, actions: { topBarActions() }, colors: options.colors, windowInsets: topBarWindowInsets, scrollBehavior: options.scrollBehavior)
                                 } else {
-                                    MediumTopAppBar(title: options.title, modifier: options.modifier, navigationIcon: options.navigationIcon, actions: { topBarActions() }, colors: options.colors, scrollBehavior: options.scrollBehavior)
+                                    MediumTopAppBar(title: options.title, modifier: options.modifier, navigationIcon: options.navigationIcon, actions: { topBarActions() }, colors: options.colors, windowInsets: topBarWindowInsets, scrollBehavior: options.scrollBehavior)
                                 }
                             }
                         }

--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -258,8 +258,7 @@ public struct NavigationStack : View, Renderable {
         // content for each bar) prevents it from updating properly on recompose
         let toolbarContentReduced = toolbarContent.value.reduced
         let toolbarItems = ToolbarItems(content: toolbarContentReduced.content ?? [])
-        let (titleMenu, principalItem, topLeadingItems, topTrailingItems, bottomItems) = toolbarItems.Evaluate(context: context)
-        let hasPrincipalToolbarItem = principalItem != nil
+        let (titleMenu, topLeadingItems, topTrailingItems, bottomItems) = toolbarItems.Evaluate(context: context)
 
         let showTopBar: Bool
         switch topBarPreferences?.visibility ?? Visibility.automatic {
@@ -268,7 +267,7 @@ public struct NavigationStack : View, Renderable {
         case .visible:
             showTopBar = true
         case .automatic:
-            showTopBar = !arguments.isRoot || hasTitle || hasPrincipalToolbarItem || topLeadingItems.size > 0 || topTrailingItems.size > 0
+            showTopBar = !arguments.isRoot || hasTitle || topLeadingItems.size > 0 || topTrailingItems.size > 0
         }
         let searchFieldPadding = 16.dp
         let density = LocalDensity.current
@@ -287,10 +286,7 @@ public struct NavigationStack : View, Renderable {
         let navigationIconButtonStyle: Material3TopAppBarNavigationIconButtonStyle
         let navigationIconButtonColors: IconButtonColors?
         if let updateOptions = EnvironmentValues.shared._material3TopAppBar {
-            var tempOptions = Material3TopAppBarOptions(title: {}, modifier: Modifier, navigationIcon: {}, colors: TopAppBarDefaults.topAppBarColors(), scrollBehavior: initialScrollBehavior)
-            if hasPrincipalToolbarItem {
-                tempOptions = tempOptions.copy(preferCenterAlignedStyle: true)
-            }
+            let tempOptions = Material3TopAppBarOptions(title: {}, modifier: Modifier, navigationIcon: {}, colors: TopAppBarDefaults.topAppBarColors(), scrollBehavior: initialScrollBehavior)
             let updatedOptions = updateOptions(tempOptions)
             scrollBehavior = updatedOptions.scrollBehavior ?? initialScrollBehavior
             navigationIconButtonStyle = updatedOptions.navigationIconButtonStyle
@@ -407,11 +403,7 @@ public struct NavigationStack : View, Renderable {
                             titleContentColor: MaterialTheme.colorScheme.onSurface
                         )
                         let topBarTitle: @Composable () -> Void = {
-                            if let principalItem {
-                                // SwiftUI's .principal toolbar placement is the navigation title.
-                                // Render it in the Material top app bar title slot rather than as a leading toolbar item.
-                                principalItem.Render(context: context)
-                            } else if let titleMenu {
+                            if let titleMenu {
                                 let menuModifier = Modifier.clickable(interactionSource: interactionSource, indication: nil, onClick: {
                                     titleMenu.toggleMenu()
                                 })
@@ -465,9 +457,6 @@ public struct NavigationStack : View, Renderable {
                             }
                         }
                         var options = Material3TopAppBarOptions(title: topBarTitle, modifier: topBarModifier, navigationIcon: topBarNavigationIcon, colors: topBarColors, scrollBehavior: scrollBehavior)
-                        if hasPrincipalToolbarItem {
-                            options = options.copy(preferCenterAlignedStyle: true)
-                        }
                         if let updateOptions = EnvironmentValues.shared._material3TopAppBar {
                             options = updateOptions(options)
                         }

--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -472,8 +472,7 @@ public struct NavigationStack : View, Renderable {
                         // Use scrollBehavior (from the early call) for the TopAppBar to ensure it matches the nestedScrollConnection
                         options = options.copy(scrollBehavior: scrollBehavior)
                         let topBarWindowInsets = EnvironmentValues.shared._sheetDepth > 0 ? WindowInsets(0.dp, 0.dp, 0.dp, 0.dp) : TopAppBarDefaults.windowInsets
-                        if isInlineTitleDisplayMode {
-                            
+                        if isInlineTitleDisplayMode {                   
                             if options.preferCenterAlignedStyle {
                                 CenterAlignedTopAppBar(title: options.title, modifier: options.modifier, navigationIcon: options.navigationIcon, actions: { topBarActions() }, colors: options.colors, windowInsets: topBarWindowInsets, scrollBehavior: options.scrollBehavior)
                             } else {

--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -473,6 +473,7 @@ public struct NavigationStack : View, Renderable {
                         options = options.copy(scrollBehavior: scrollBehavior)
                         let topBarWindowInsets = EnvironmentValues.shared._sheetDepth > 0 ? WindowInsets(0.dp, 0.dp, 0.dp, 0.dp) : TopAppBarDefaults.windowInsets
                         if isInlineTitleDisplayMode {
+                            
                             if options.preferCenterAlignedStyle {
                                 CenterAlignedTopAppBar(title: options.title, modifier: options.modifier, navigationIcon: options.navigationIcon, actions: { topBarActions() }, colors: options.colors, windowInsets: topBarWindowInsets, scrollBehavior: options.scrollBehavior)
                             } else {

--- a/Sources/SkipUI/SkipUI/Containers/Navigation.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Navigation.swift
@@ -258,7 +258,8 @@ public struct NavigationStack : View, Renderable {
         // content for each bar) prevents it from updating properly on recompose
         let toolbarContentReduced = toolbarContent.value.reduced
         let toolbarItems = ToolbarItems(content: toolbarContentReduced.content ?? [])
-        let (titleMenu, topLeadingItems, topTrailingItems, bottomItems) = toolbarItems.Evaluate(context: context)
+        let (titleMenu, principalItem, topLeadingItems, topTrailingItems, bottomItems) = toolbarItems.Evaluate(context: context)
+        let hasPrincipalToolbarItem = principalItem != nil
 
         let showTopBar: Bool
         switch topBarPreferences?.visibility ?? Visibility.automatic {
@@ -267,7 +268,7 @@ public struct NavigationStack : View, Renderable {
         case .visible:
             showTopBar = true
         case .automatic:
-            showTopBar = !arguments.isRoot || hasTitle || topLeadingItems.size > 0 || topTrailingItems.size > 0
+            showTopBar = !arguments.isRoot || hasTitle || hasPrincipalToolbarItem || topLeadingItems.size > 0 || topTrailingItems.size > 0
         }
         let searchFieldPadding = 16.dp
         let density = LocalDensity.current
@@ -286,7 +287,10 @@ public struct NavigationStack : View, Renderable {
         let navigationIconButtonStyle: Material3TopAppBarNavigationIconButtonStyle
         let navigationIconButtonColors: IconButtonColors?
         if let updateOptions = EnvironmentValues.shared._material3TopAppBar {
-            let tempOptions = Material3TopAppBarOptions(title: {}, modifier: Modifier, navigationIcon: {}, colors: TopAppBarDefaults.topAppBarColors(), scrollBehavior: initialScrollBehavior)
+            var tempOptions = Material3TopAppBarOptions(title: {}, modifier: Modifier, navigationIcon: {}, colors: TopAppBarDefaults.topAppBarColors(), scrollBehavior: initialScrollBehavior)
+            if hasPrincipalToolbarItem {
+                tempOptions = tempOptions.copy(preferCenterAlignedStyle: true)
+            }
             let updatedOptions = updateOptions(tempOptions)
             scrollBehavior = updatedOptions.scrollBehavior ?? initialScrollBehavior
             navigationIconButtonStyle = updatedOptions.navigationIconButtonStyle
@@ -403,7 +407,11 @@ public struct NavigationStack : View, Renderable {
                             titleContentColor: MaterialTheme.colorScheme.onSurface
                         )
                         let topBarTitle: @Composable () -> Void = {
-                            if let titleMenu {
+                            if let principalItem {
+                                // SwiftUI's .principal toolbar placement is the navigation title.
+                                // Render it in the Material top app bar title slot rather than as a leading toolbar item.
+                                principalItem.Render(context: context)
+                            } else if let titleMenu {
                                 let menuModifier = Modifier.clickable(interactionSource: interactionSource, indication: nil, onClick: {
                                     titleMenu.toggleMenu()
                                 })
@@ -457,6 +465,9 @@ public struct NavigationStack : View, Renderable {
                             }
                         }
                         var options = Material3TopAppBarOptions(title: topBarTitle, modifier: topBarModifier, navigationIcon: topBarNavigationIcon, colors: topBarColors, scrollBehavior: scrollBehavior)
+                        if hasPrincipalToolbarItem {
+                            options = options.copy(preferCenterAlignedStyle: true)
+                        }
                         if let updateOptions = EnvironmentValues.shared._material3TopAppBar {
                             options = updateOptions(options)
                         }


### PR DESCRIPTION
Make sure that a `NavigationStack`, when presented via a `.sheet`, does not double the navigation bar's height.

| Before | After |
|---|---|
| <img width="400" alt="Before" src="https://github.com/user-attachments/assets/1842d41b-a689-43d6-9e9e-982444c5afb1" /> | <img width="400" alt="After" src="https://github.com/user-attachments/assets/3f83c1f7-7e1c-4c50-940d-f88c7b934306" /> |

# Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app
