### PR TITLE
Guard geometry state writes against sub-pixel bounds jitter to prevent idle recomposition loops

### DIFF
--- a/Sources/SkipUI/SkipUI/Compose/ComposeExtensions.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeExtensions.swift
@@ -127,6 +127,11 @@ extension Modifier {
     }
 
     /// Invoke the given closure with the modified view's root bounds.
+    ///
+    /// - Warning: Callbacks can deliver bounds that differ from the previous pass by sub-pixel
+    ///   amounts (float rounding, scroll settle, in-progress animations). Callers that gate
+    ///   composed content on remembered bounds state should guard their state write with
+    ///   `Rect.isApproximatelyEqual(to:)` to avoid an idle recomposition loop.
     @Composable func onGloballyPositionedInRoot(perform: (Rect) -> Void) -> Modifier {
         return self.onGloballyPositioned {
             let bounds = $0.boundsInRoot()
@@ -182,6 +187,30 @@ extension PaddingValues {
             end: (insets1.trailing + insets2.trailing).dp,
             bottom: (insets1.bottom + insets2.bottom).dp
         )
+    }
+}
+
+/// The maximum per-edge delta at which two bounds rects are treated as visually identical.
+///
+/// Global-position callbacks can report bounds that differ from the previous layout pass by
+/// sub-pixel amounts (float rounding, scroll settle, in-progress animations). Writing such a
+/// rect into gating state closes a write → recompose → remeasure → write loop that recomposes
+/// continuously while the screen is idle. Half a pixel is below anything visually meaningful.
+let boundsEpsilonPx = Float(0.5)
+
+extension Rect {
+    /// Whether every edge of this rect is within `boundsEpsilonPx` of `other`'s.
+    ///
+    /// Use to guard remembered-bounds state writes in global-position callbacks; see
+    /// `onGloballyPositionedInRoot`.
+    func isApproximatelyEqual(to other: Rect?) -> Bool {
+        guard let other else {
+            return false
+        }
+        return abs(left - other.left) < boundsEpsilonPx
+            && abs(top - other.top) < boundsEpsilonPx
+            && abs(right - other.right) < boundsEpsilonPx
+            && abs(bottom - other.bottom) < boundsEpsilonPx
     }
 }
 

--- a/Sources/SkipUI/SkipUI/Compose/ComposeExtensions.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeExtensions.swift
@@ -207,11 +207,16 @@ extension Rect {
         guard let other else {
             return false
         }
-        return abs(left - other.left) < boundsEpsilonPx
-            && abs(top - other.top) < boundsEpsilonPx
-            && abs(right - other.right) < boundsEpsilonPx
-            && abs(bottom - other.bottom) < boundsEpsilonPx
+        return isWithinEpsilon(left, other.left)
+            && isWithinEpsilon(top, other.top)
+            && isWithinEpsilon(right, other.right)
+            && isWithinEpsilon(bottom, other.bottom)
     }
+}
+
+private func isWithinEpsilon(_ a: Float, _ b: Float) -> Bool {
+    let delta = a - b
+    return delta < boundsEpsilonPx && delta > -boundsEpsilonPx
 }
 
 #endif

--- a/Sources/SkipUI/SkipUI/Containers/PresentationRoot.swift
+++ b/Sources/SkipUI/SkipUI/Containers/PresentationRoot.swift
@@ -53,8 +53,12 @@ import androidx.compose.ui.platform.LocalLayoutDirection
                 rootModifier = rootModifier.imePadding()
             }
             rootModifier = rootModifier.background(Color.background.colorImpl())
-                .onGloballyPositionedInWindow {
-                    presentationBounds.value = $0
+                .onGloballyPositionedInWindow { bounds in
+                    // Guard against sub-pixel jitter: the presented content below is gated on
+                    // this state, so unfiltered writes can recompose in a loop while idle
+                    if !bounds.isApproximatelyEqual(to: presentationBounds.value) {
+                        presentationBounds.value = bounds
+                    }
                 }
             Box(modifier: rootModifier) {
                 guard presentationBounds.value != Rect.Zero else {

--- a/Sources/SkipUI/SkipUI/Layout/GeometryReader.swift
+++ b/Sources/SkipUI/SkipUI/Layout/GeometryReader.swift
@@ -25,8 +25,12 @@ public struct GeometryReader : View, Renderable {
     #if SKIP
     @Composable override func Render(context: ComposeContext) {
         let rememberedGlobalFramePx = remember { mutableStateOf<Rect?>(nil) }
-        Box(modifier: context.modifier.fillSize().onGloballyPositionedInRoot {
-            rememberedGlobalFramePx.value = $0
+        Box(modifier: context.modifier.fillSize().onGloballyPositionedInRoot { bounds in
+            // Guard against sub-pixel jitter: the content below is gated on this state, so
+            // unfiltered writes can recompose in a loop while the screen is idle
+            if !bounds.isApproximatelyEqual(to: rememberedGlobalFramePx.value) {
+                rememberedGlobalFramePx.value = bounds
+            }
         }) {
             if let globalFramePx = rememberedGlobalFramePx.value {
                 let proxy = GeometryProxy(globalFramePx: globalFramePx, density: LocalDensity.current, safeArea: EnvironmentValues.shared._safeArea)

--- a/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
+++ b/Sources/SkipUI/SkipUI/View/AdditionalViewModifiers.swift
@@ -1025,7 +1025,11 @@ extension View {
 
             var updatedContext = context
             updatedContext.modifier = context.modifier.onGloballyPositionedInRoot { rect in
-                globalFramePx.value = rect
+                // Guard against sub-pixel jitter: the transform/action above reads this state,
+                // so unfiltered writes can recompose in a loop while the screen is idle
+                if !rect.isApproximatelyEqual(to: globalFramePx.value) {
+                    globalFramePx.value = rect
+                }
             }
             renderable.Render(context: updatedContext)
         })


### PR DESCRIPTION
Fixes #488.

## Problem

`GeometryReader`, `onGeometryChange`, and `PresentationRoot` write raw float `Rect` bounds from global-position callbacks into remembered state that gates their composed content. Bounds can differ from the previous layout pass by sub-pixel amounts (float rounding, scroll settle, in-progress animations, or content that sizes itself against the reported geometry), and `mutableStateOf`'s structural equality only deduplicates bit-identical rects — so a sub-pixel delta closes a write → recompose → remeasure → write loop that recomposes continuously while the screen is idle. We hit this as a sustained idle-recomposition loop in our production Fuse app (skip-ui 1.57-era): a `GeometryReader`-centered empty state recomposed continuously at rest, and scoping the `GeometryReader` to a smaller subtree removed the trigger — which limits blast radius but leaves the unguarded write in place. Full mechanism citations in #488.

## Change

Adds `Rect.isApproximatelyEqual(to:)` (all four edges within `boundsEpsilonPx = 0.5f` — half a device pixel, below anything visually meaningful) and guards the three gating state writes with it:

- `GeometryReader.Render` — `rememberedGlobalFramePx`
- `onGeometryChangeErased` — `globalFramePx`
- `PresentationRoot` — `presentationBounds`

Deliberately **not** changed: the shared `onGloballyPositionedInRoot`/`InWindow` helpers still deliver every callback. Deduplicating there would silently change semantics for callers whose derived values depend on more than the bounds — e.g. the safe-area edge probing in `ComposeLayouts.swift` recomputes edges from bounds *plus* the current safe area, and must not be suppressed when the safe area changes while bounds don't. Instead the helpers' doc comment now warns that callers gating content on remembered bounds should guard their writes.

The comparison intentionally avoids `abs()` — the transpiled `skip.lib` form is not comparable against a Kotlin `Float` (caught by the Android Kotlin compile).

## Verification

Verified with CI-built APKs of a standalone counter-instrumented app (https://github.com/Aecasorg/skip-fuse-perf-repro), on an API 35 emulator, comparing stock skip-ui 1.57.0, stock 1.59.1, and 1.59.1 + this patch:

- **Regression-free:** four GeometryReader shapes (plain fillSize, inside ScrollView, refreshable ScrollView, proxy-derived text) plus unrelated-state and onChange control scenes behave identically with and without the patch — same body-evaluation counts, same settle points.
- **Honest disclosure:** the *pure idle loop* did **not** reproduce in those minimal synthetic shapes at either skip-ui version on the emulator — counters settle at 26–28 evaluations and stay flat. The production loop we observed evidently needs conditions the minimal scenes don't capture (device density, concurrent animation, richer layout). We're framing this change as a cheap, verified-safe guard against a demonstrated-in-production hazard rather than claiming a synthetic before/after.

Happy to adjust the epsilon, naming, or approach — including pushing the guard into the shared helpers instead if you'd rather own the call-site audit.

