### PR TITLE
Inherit the environment locale in presentations

### DIFF
--- a/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
+++ b/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
@@ -479,8 +479,12 @@ extension EnvironmentValues {
     }
     
     public var locale: Locale {
-        get { Locale(LocalConfiguration.current.locales[0]) }
+        get { builtinValue(key: "_locale", defaultValue: { nil }) as! Locale? ?? Locale(LocalConfiguration.current.locales[0]) }
         set {
+            // Presentations compose in their own Android window, where Compose re-provides
+            // `LocalConfiguration` from the platform. Track the override in our own composition
+            // local as well so that it survives into sheets, covers, alerts, and popups.
+            setBuiltinValue(key: "_locale", value: newValue, defaultValue: { nil })
             let action: @Composable () -> Void = {
                 // Requires a @Composable context to copy LocalConfiguration.current
                 let configuration = Configuration(LocalConfiguration.current)

--- a/Tests/SkipUITests/SkipUITests.swift
+++ b/Tests/SkipUITests/SkipUITests.swift
@@ -633,6 +633,33 @@ final class SkipUITests: SkipUITestCase {
         }
     }
 
+    func testSheetInheritsLocaleFromPresenter() throws {
+        #if !SKIP
+        throw XCTSkip("sheet content composes in a separate Android window")
+        #else
+        try testUI(view: {
+            SheetLocaleTestView()
+                .environment(\.locale, Locale(identifier: "fr"))
+                .accessibilityIdentifier("test-view")
+        }, eval: { rule in
+            rule.waitForIdle()
+            rule.onAllNodesWithTag("sheet-text").onFirst().assert(hasTextExactly("Terminé"))
+        })
+        #endif
+    }
+
+    struct SheetLocaleTestView: View {
+        @State var isPresented = true
+
+        var body: some View {
+            Text(verbatim: "Sheet Host")
+                .sheet(isPresented: $isPresented) {
+                    Text("Done", bundle: .module)
+                        .accessibilityIdentifier("sheet-text")
+                }
+        }
+    }
+
     // look up a localized string in the current bundle using the given language
     func localizedBundle(_ lang: String) throws -> Bundle {
         try XCTUnwrap(Bundle(url: XCTUnwrap(Bundle.module.url(forResource: "Localizable", withExtension: "strings", subdirectory: nil, localization: lang)).deletingLastPathComponent()))


### PR DESCRIPTION
Fixes #501.

`.environment(\.locale, …)` set on an ancestor did not reach the content of a `.sheet` or `.fullScreenCover`: the presented content resolved `Text` catalog keys, and reported `@Environment(\.locale)`, in the device locale.

`locale` is the only environment value not held in one of our own composition locals — it reads and writes Compose's `LocalConfiguration`. Presented content composes in a separate Android window, and `ProvideAndroidCompositionLocals` re-provides `LocalConfiguration` there from the platform, discarding the ancestor's override. Everything stored in our own composition locals — including custom `EnvironmentKey`s, `layoutDirection`, and `timeZone` — crosses the boundary correctly; #501 has the measurements.

The setter now records the override in our own composition local as well, and the getter prefers it over `LocalConfiguration`. `LocalConfiguration` is still written, so Android resource resolution keeps following the locale within the same window.

### Design note

The alternative is to re-provide the presenter's `LocalConfiguration` inside each presentation window, which would additionally fix Compose-native resource lookups (`stringResource`, Material date pickers) inside sheets. I did not take it: it has to be repeated at every window-creating call site — sheets, covers, alerts, confirmation dialogs, menus, popups — and overriding the whole `Configuration` risks clobbering the dialog window's own metrics, which `SheetPresentation` reads for detent insets. Happy to switch if you would rather close that gap in one place.

### Testing

`testSheetInheritsLocaleFromPresenter` asserts that a `Text` catalog key inside a `.sheet` resolves against the presenter's locale. Verified it fails without the source change (`Failed to assert the following: (Text + EditableText = [Terminé])`) and passes with it.

`swift test` passes: 94 tests, 0 failures, native and transpiled.

Also verified on an Android emulator with a Skip Lite app whose device language is `en-US` and which sets `.environment(\.locale, Locale(identifier: "fr"))` once at the root. `.sheet` and `.fullScreenCover` content reported `en_US` and rendered the base-language string before the change; both report `fr` and render the French string after it.

Skip Fuse UI needs no companion change: `\.locale` is bridged through `EnvironmentValues.builtinBridged`/`setBuiltinBridged`, which read and write this same property.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app

-----

- [x] AI was used to generate or assist with generating this PR. Claude Code was used to isolate the cause and write the change and the test. Verification was done by measurement rather than review: the environment values were probed side by side across inline, pushed, sheet and cover contexts on a running emulator to establish that only `locale` was lost; `ProvideAndroidCompositionLocals` was confirmed to provide `LocalConfiguration` by disassembling `ui-android`; and the new test was confirmed to fail without the source change before the PR was opened.

-----
