### PR TITLE
Implement Color.mix(with:by:in:) for Compose

### DIFF
--- a/Sources/SkipUI/SkipUI/Color/Color.swift
+++ b/Sources/SkipUI/SkipUI/Color/Color.swift
@@ -10,6 +10,8 @@ import androidx.compose.material.ContentAlpha
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.colorspace.ColorSpaces
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.unit.dp
 #endif
 
@@ -338,6 +340,33 @@ public struct Color: ShapeStyle, Renderable, Hashable {
         #else
         return self
         #endif
+    }
+
+    public func mix(with rhs: Color, by fraction: Double, in colorSpace: Gradient.ColorSpace = .perceptual) -> Color {
+        #if SKIP
+        let clampedFraction = Self.clamp(fraction)
+        return Color(colorImpl: {
+            if colorSpace == .device {
+                let start = colorImpl().convert(ColorSpaces.Srgb)
+                let stop = rhs.colorImpl().convert(ColorSpaces.Srgb)
+                return androidx.compose.ui.graphics.Color(
+                    red: start.red + (stop.red - start.red) * clampedFraction,
+                    green: start.green + (stop.green - start.green) * clampedFraction,
+                    blue: start.blue + (stop.blue - start.blue) * clampedFraction,
+                    alpha: start.alpha + (stop.alpha - start.alpha) * clampedFraction)
+            } else {
+                // Compose's lerp interpolates in the Oklab color space, matching SwiftUI's .perceptual
+                return lerp(colorImpl(), rhs.colorImpl(), clampedFraction)
+            }
+        })
+        #else
+        return self
+        #endif
+    }
+
+    // SKIP @bridge
+    public func mix(with rhs: Color, by fraction: Double, bridgedColorSpace: Int) -> Color {
+        return mix(with: rhs, by: fraction, in: bridgedColorSpace == 0 ? .device : .perceptual)
     }
 
     // SKIP @bridge

--- a/Sources/SkipUI/SkipUI/Graphics/Gradient.swift
+++ b/Sources/SkipUI/SkipUI/Graphics/Gradient.swift
@@ -71,8 +71,14 @@ public struct Gradient : ShapeStyle, Hashable {
     #endif
 
     public struct ColorSpace : Hashable {
-        public static let device = Gradient.ColorSpace()
-        public static let perceptual = Gradient.ColorSpace()
+        let identifier: Int
+
+        init(identifier: Int) {
+            self.identifier = identifier
+        }
+
+        public static let device = Gradient.ColorSpace(identifier: 0)
+        public static let perceptual = Gradient.ColorSpace(identifier: 1)
     }
 
     public func colorSpace(_ space: Gradient.ColorSpace) -> AnyGradient {

--- a/Tests/SkipUITests/ColorTests.swift
+++ b/Tests/SkipUITests/ColorTests.swift
@@ -14,6 +14,37 @@ final class ColorTests: XCSnapshotTestCase {
         XCTAssertEqual("F", try render(compact: 1, view: Color.white.frame(width: 1.0, height: 1.0)).pixmap)
     }
 
+    func testColorMixFullFraction() throws {
+        if #available(iOS 18.0, macOS 15.0, *) {
+            XCTAssertEqual("0", try render(compact: 1, view: Color.white.mix(with: Color.black, by: 1.0).frame(width: 1.0, height: 1.0)).pixmap)
+        }
+    }
+
+    func testColorMixFractionClampedAbove() throws {
+        if #available(iOS 18.0, macOS 15.0, *) {
+            XCTAssertEqual("F", try render(compact: 1, view: Color.black.mix(with: Color.white, by: 2.0).frame(width: 1.0, height: 1.0)).pixmap)
+        }
+    }
+
+    func testColorMixFractionClampedBelow() throws {
+        if #available(iOS 18.0, macOS 15.0, *) {
+            XCTAssertEqual("0", try render(compact: 1, view: Color.black.mix(with: Color.white, by: -1.0).frame(width: 1.0, height: 1.0)).pixmap)
+        }
+    }
+
+    func testColorMixDevice() throws {
+        if #available(iOS 18.0, macOS 15.0, *) {
+            XCTAssertEqual(plaf("808080"), try render(view: Color.black.mix(with: Color.white, by: 0.5, in: .device).frame(width: 1.0, height: 1.0)).pixmap)
+        }
+    }
+
+    func testColorMixPerceptual() throws {
+        if #available(iOS 18.0, macOS 15.0, *) {
+            // A 50% black/white mix in the default perceptual (Oklab) color space resolves to Oklab L = 0.5, i.e. #636363
+            XCTAssertEqual(plaf("636363"), try render(view: Color.black.mix(with: Color.white, by: 0.5).frame(width: 1.0, height: 1.0)).pixmap)
+        }
+    }
+
     // Issue #146 follow-up: all three .colorset Input Methods must render the same color (#04F188).
     // Skipped on Robolectric — Bundle.module colorset decoding falls back to gray there (pre-existing runner limitation).
 


### PR DESCRIPTION
## Summary

Implements SwiftUI's [`Color.mix(with:by:in:)`](https://developer.apple.com/documentation/swiftui/color/mix(with:by:in:)) (iOS 18 / macOS 15) for Compose.

- **`.perceptual` (the SwiftUI default):** uses Compose's `androidx.compose.ui.graphics.lerp`, which interpolates in the Oklab color space — the same space SwiftUI uses for perceptual mixing, so results match iOS exactly (verified by the new snapshot tests).
- **`.device`:** converts both colors to sRGB and interpolates component-wise (including alpha).
- The fraction is clamped to `0...1`, matching SwiftUI.
- `Gradient.ColorSpace` previously had no stored properties, making `.device == .perceptual`; it now carries an `identifier` so the two are distinguishable.
- Adds a `// SKIP @bridge` variant taking the color space as an `Int` (0 = device, 1 = perceptual) so skip-fuse-ui can lift its `@available(*, unavailable)` marker on `mix` in a follow-up.

Because the mixed color is computed inside `colorImpl` at composition time, mixing dynamic colors (e.g. asset catalog colors with dark-mode variants) resolves against the current color scheme, as on iOS.

## Testing

`skip test --filter ColorTests`: all tests pass on both macOS (native SwiftUI, validating the expected pixel values against Apple's implementation) and Android (Robolectric):

- `testColorMixPerceptual`: 50% black/white mix renders `#636363` (Oklab L = 0.5) on both platforms
- `testColorMixDevice`: 50% black/white device-space mix renders `#808080` on both platforms
- `testColorMixFullFraction`, `testColorMixFractionClampedAbove`, `testColorMixFractionClampedBelow`: endpoint and clamping behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)