### PR TITLE
Allow accent color lookup to use supplied bundle

### DIFF
--- a/Sources/SkipUI/SkipUI/Color/Color.swift
+++ b/Sources/SkipUI/SkipUI/Color/Color.swift
@@ -191,11 +191,11 @@ public struct Color: ShapeStyle, Renderable, Hashable {
     }
 
     #if SKIP
-    @Composable static func assetAccentColor(colorScheme: ColorScheme) -> androidx.compose.ui.graphics.Color? {
+    @Composable static func assetAccentColor(colorScheme: ColorScheme, bundle: Bundle = Bundle.main) -> androidx.compose.ui.graphics.Color? {
         let name = "AccentColor"
-        let colorInfo = rememberCachedAsset(namedColorCache, AssetKey(name: name, bundle: Bundle.main)) { _ in
-            assetColorInfo(name: name, bundle: Bundle.main)
-        }
+        let colorInfo = rememberCachedAsset(namedColorCache, AssetKey(name: name, bundle: bundle)) { _ in
+            assetColorInfo(name: name, bundle: bundle)
+            }
         return colorInfo?.colorImpl(colorScheme: colorScheme)
     }
 

--- a/Sources/SkipUI/SkipUI/Color/ColorScheme.swift
+++ b/Sources/SkipUI/SkipUI/Color/ColorScheme.swift
@@ -1,6 +1,7 @@
 // Copyright 2023–2026 Skip
 // SPDX-License-Identifier: MPL-2.0
 #if !SKIP_BRIDGE
+import Foundation
 #if SKIP
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
@@ -24,7 +25,7 @@ public enum ColorScheme : Int, CaseIterable, Hashable {
     }
 
     /// Return the material color scheme for this scheme.
-    @Composable public func asMaterialTheme() -> androidx.compose.material3.ColorScheme {
+    @Composable public func asMaterialTheme(accentColorBundle: Bundle = Bundle.main) -> androidx.compose.material3.ColorScheme {
         let context = LocalContext.current
         let isDarkMode = self == ColorScheme.dark
         // Dynamic color is available on Android 12+
@@ -35,7 +36,7 @@ public enum ColorScheme : Int, CaseIterable, Hashable {
         } else {
             colorScheme = isDynamicColor ? dynamicLightColorScheme(context) : lightColorScheme()
         }
-        if let primary = Color.assetAccentColor(colorScheme: isDarkMode ? ColorScheme.dark : ColorScheme.light) {
+        if let primary = Color.assetAccentColor(colorScheme: isDarkMode ? ColorScheme.dark : ColorScheme.light, bundle: accentColorBundle) {
             colorScheme = colorScheme.copy(primary: primary)
         }
         guard let customization = EnvironmentValues.shared._material3ColorScheme else {

--- a/Sources/SkipUI/SkipUI/Containers/PresentationRoot.swift
+++ b/Sources/SkipUI/SkipUI/Containers/PresentationRoot.swift
@@ -27,15 +27,16 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import Foundation
 
 /// The root of a presentation, such as the root presentation or a sheet.
-@Composable public func PresentationRoot(defaultColorScheme: ColorScheme? = nil, absoluteSystemBarEdges systemBarEdges: Edge.Set = .all, context: ComposeContext, content: @Composable (ComposeContext) -> Void) {
+@Composable public func PresentationRoot(defaultColorScheme: ColorScheme? = nil, absoluteSystemBarEdges systemBarEdges: Edge.Set = .all, context: ComposeContext, accentColorBundle: Bundle = Bundle.main, content: @Composable (ComposeContext) -> Void) {
     launchUIApplicationActivity()
 
     let preferredColorScheme = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<PreferredColorScheme>, Any>) { mutableStateOf(Preference<PreferredColorScheme>(key: PreferredColorSchemePreferenceKey.self)) }
     let preferredColorSchemeCollector = PreferenceCollector<PreferredColorScheme>(key: PreferredColorSchemePreferenceKey.self, state: preferredColorScheme)
     PreferenceValues.shared.collectPreferences([preferredColorSchemeCollector]) {
-        let materialColorScheme = preferredColorScheme.value.reduced.colorScheme?.asMaterialTheme() ?? defaultColorScheme?.asMaterialTheme() ?? MaterialTheme.colorScheme
+        let materialColorScheme = preferredColorScheme.value.reduced.colorScheme?.asMaterialTheme(accentColorBundle: accentColorBundle) ?? defaultColorScheme?.asMaterialTheme(accentColorBundle: accentColorBundle) ?? MaterialTheme.colorScheme
         MaterialTheme(colorScheme: materialColorScheme) {
             let presentationBounds = remember { mutableStateOf(Rect.Zero) }
             let density = LocalDensity.current


### PR DESCRIPTION
## Summary

Adds a bundle-passing path for the Android `AccentColor` asset lookup so that callers are no longer limited to searching `Bundle.main`.

Issue #431 describes an `AccentColor` resource that may belong to an application's module bundle. However, `Color.assetAccentColor` currently searches only `Bundle.main`, preventing resources stored in another bundle from being found.

## Changes

- Updated `Color.assetAccentColor` to accept a supplied `Bundle`.
- Used the supplied bundle in both the `AssetKey` cache key and the `assetColorInfo` lookup.
- Updated `ColorScheme.asMaterialTheme` to accept and forward an `accentColorBundle`.
- Updated `PresentationRoot` to accept and forward the accent-color bundle.
- Preserved `Bundle.main` as the default for backward compatibility.

## Architectural note

This PR establishes the SkipUI-side path needed to supply the application's resource bundle to the accent-color lookup.

A generated application template or another application entry point may still need to pass its module bundle, such as `.module`, into `PresentationRoot`. I previously asked on Issue #431 whether that final integration should live in the generated template, `ComposeContext`, or another shared rendering mechanism.

I am submitting the implementation for review so the maintainers can determine the preferred integration point and whether a companion change is needed elsewhere.

## Testing

- `git diff --check`
- `swift test`

Test results:

- 92 tests
- 87 passed
- 5 skipped
- 0 failed

Related to #431

## Skip Pull Request Checklist

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI]