### PR TITLE
Compose sheets with final presentation-preference values on first composition; stop presenter churn re-evaluating confirmation dialogs

### DIFF
--- a/Sources/SkipUI/SkipUI/Environment/PreferenceKey.swift
+++ b/Sources/SkipUI/SkipUI/Environment/PreferenceKey.swift
@@ -181,16 +181,35 @@ struct PreferenceNode<Value>: Equatable {
         return lhs.value == rhs.value
     }
 }
+
+/// The modifier produced by `preference(key:value:)`.
+///
+/// Contributes through the standard collector at render time like any side effect, but
+/// carries its key and value as inspectable fields so that presentation containers can
+/// harvest statically-applied preferences from an evaluated renderable chain *before*
+/// their first composition (see `SheetPresentation`), instead of waiting for the
+/// contribution to settle a composition later.
+final class PreferenceModifier: SideEffectModifier {
+    let key: Any
+    let value: Any?
+
+    init(key: Any, value: Any?) {
+        self.key = key
+        self.value = value
+        super.init()
+        self.action = { context in
+            PreferenceValues.shared.contribute(context: context, key: key, value: value)
+            return ComposeResult.ok
+        }
+    }
+}
 #endif
 
 extension View {
     // SKIP @bridge
     public func preference(key: Any, value: Any?) -> any View {
         #if SKIP
-        return ModifiedContent(content: self, modifier: SideEffectModifier { context in
-            PreferenceValues.shared.contribute(context: context, key: key, value: value)
-            return ComposeResult.ok
-        })
+        return ModifiedContent(content: self, modifier: PreferenceModifier(key: key, value: value))
         #else
         return self
         #endif

--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -92,15 +92,17 @@ private let AlertDialogMaxWidth: Dp = 560.dp
 
 // SKIP INSERT: @OptIn(ExperimentalMaterial3Api::class)
 @Composable func SheetPresentation(isPresented: Binding<Bool>, isFullScreen: Bool, context: ComposeContext, content: () -> any View, onDismiss: (() -> Void)?) {
-    let interactiveDismissDisabledPreference = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<Bool>, Any>) { mutableStateOf(Preference<Bool>(key: InteractiveDismissDisabledPreferenceKey.self)) }
-    let interactiveDismissDisabledCollector = PreferenceCollector<Bool>(key: InteractiveDismissDisabledPreferenceKey.self, state: interactiveDismissDisabledPreference)
-
     let sheetState = rememberModalBottomSheetState(skipPartiallyExpanded: true)
     let isPresentedValue = isPresented.get()
     if isPresentedValue || sheetState.isVisible {
         // Don't fully evaluate content until we set up the presented environment. For now we just want
-        // to get at the modifiers to look for `BackDismissDisabled`
+        // to get at the modifiers to look for `BackDismissDisabled` and statically-applied
+        // presentation preferences (see `harvestPreference`)
         let contentRenderables = ComposeBuilder.from(content).Evaluate(context: context, options: EvaluateOptions(isKeepNonModified: true).value)
+        // Seed from the harvested static preference so the first composition already gates
+        // gestures correctly; dynamic updates keep flowing through the collector
+        let interactiveDismissDisabledPreference = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<Bool>, Any>) { mutableStateOf(Preference<Bool>(key: InteractiveDismissDisabledPreferenceKey.self, initialValue: harvestPreference(key: InteractiveDismissDisabledPreferenceKey.self, on: contentRenderables) as? Bool)) }
+        let interactiveDismissDisabledCollector = PreferenceCollector<Bool>(key: InteractiveDismissDisabledPreferenceKey.self, state: interactiveDismissDisabledPreference)
         let topInset = remember { mutableStateOf(0.dp) }
         let topInsetPx = with(LocalDensity.current) { topInset.value.toPx() }
         let handleHeight = isFullScreen ? 0.dp : 8.dp
@@ -108,18 +110,26 @@ private let AlertDialogMaxWidth: Dp = 560.dp
         let handlePadding = isFullScreen ? 0.dp : 10.dp
         let handlePaddingPx = with(LocalDensity.current) { handlePadding.toPx() }
         let sheetMaxWidth = isFullScreen ? Dp.Unspecified : BottomSheetDefaults.SheetMaxWidth
-        let shape = GenericShape { size, _ in
-            let y = topInsetPx - handleHeightPx - handlePaddingPx
-            addRect(Rect(offset = Offset(x: Float(0.0), y: y), size: Size(width: size.width, height: size.height - y)))
+        // Remember the shape keyed on its inputs: a fresh (unequal) instance per pass is an
+        // unstable ModalBottomSheet argument that forces the sheet machinery to recompose on
+        // every presenter recomposition
+        let shape = remember(topInsetPx, handleHeightPx, handlePaddingPx) {
+            GenericShape { size, _ in
+                let y = topInsetPx - handleHeightPx - handlePaddingPx
+                addRect(Rect(offset = Offset(x: Float(0.0), y: y), size: Size(width: size.width, height: size.height - y)))
+            }
         }
         let interactiveDismissDisabled = isFullScreen || interactiveDismissDisabledPreference.value.reduced
         // Implementing backDismissDisabled as a preference doesn't work because preferences require an extra composition
         // and only the first composition of `ModalBottomSheetProperties` is taken into account. So we require the
-        // modifier directly on the content view
-        let backDismissDisabled = isBackDismissDisabled(on: contentRenderables)
-        let onDismissRequest = {
-            isPresented.set(false)
-        }
+        // modifier directly on the content view. Harvested once per presentation for the same
+        // reason: later values are ignored anyway, and a per-pass recomputation destabilizes
+        // the ModalBottomSheet arguments
+        let backDismissDisabled = remember { isBackDismissDisabled(on: contentRenderables) }
+        // Stable dismiss callback: a fresh closure per pass is an unstable ModalBottomSheet
+        // argument (see `shape` above)
+        let currentIsPresented = rememberUpdatedState(isPresented)
+        let onDismissRequest: () -> Void = remember { { currentIsPresented.value.set(false) } }
         let properties = ModalBottomSheetProperties(shouldDismissOnBackPress: !backDismissDisabled)
         ModalBottomSheet(onDismissRequest: onDismissRequest, sheetState: sheetState, sheetMaxWidth: sheetMaxWidth, sheetGesturesEnabled: !interactiveDismissDisabled, containerColor: androidx.compose.ui.graphics.Color.Unspecified, shape: shape, dragHandle: nil, contentWindowInsets: { WindowInsets(0.dp, 0.dp, 0.dp, 0.dp) }, properties: properties) {
             
@@ -130,10 +140,15 @@ private let AlertDialogMaxWidth: Dp = 560.dp
             let sheetDepth = EnvironmentValues.shared._sheetDepth
             var systemBarEdges: Edge.Set = isFullScreen ? .all : [.top, .bottom]
 
-            let detentPreferences = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<PresentationDetentPreferences>, Any>) { mutableStateOf(Preference<PresentationDetentPreferences>(key: PresentationDetentPreferenceKey.self)) }
+            // Seed both preference states from the statically-applied modifiers harvested off
+            // the evaluated content, so the sheet's FIRST composition uses the final detent
+            // geometry and drag-indicator visibility instead of defaults that settle (with a
+            // visible jump) one composition later. Dynamic preference updates still flow
+            // through the collectors exactly as before
+            let detentPreferences = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<PresentationDetentPreferences>, Any>) { mutableStateOf(Preference<PresentationDetentPreferences>(key: PresentationDetentPreferenceKey.self, initialValue: harvestPreference(key: PresentationDetentPreferences.self, on: contentRenderables) as? PresentationDetentPreferences)) }
             let detentPreferencesCollector = PreferenceCollector<PresentationDetentPreferences>(key: PresentationDetentPreferences.self, state: detentPreferences)
             let reducedDetentPreferences = detentPreferences.value.reduced
-            let dragIndicatorPreferences = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<PresentationDragIndicatorPreferences>, Any>) { mutableStateOf(Preference<PresentationDragIndicatorPreferences>(key: PresentationDragIndicatorPreferenceKey.self)) }
+            let dragIndicatorPreferences = rememberSaveable(stateSaver: context.stateSaver as! Saver<Preference<PresentationDragIndicatorPreferences>, Any>) { mutableStateOf(Preference<PresentationDragIndicatorPreferences>(key: PresentationDragIndicatorPreferenceKey.self, initialValue: harvestPreference(key: PresentationDragIndicatorPreferences.self, on: contentRenderables) as? PresentationDragIndicatorPreferences)) }
             let dragIndicatorPreferencesCollector = PreferenceCollector<PresentationDragIndicatorPreferences>(key: PresentationDragIndicatorPreferences.self, state: dragIndicatorPreferences)
             let reducedDragIndicatorVisibility = dragIndicatorPreferences.value.reduced.visibility
 
@@ -256,6 +271,31 @@ func isBackDismissDisabled(on renderables: kotlin.collections.List<Renderable>) 
         }
     }
     return false
+}
+
+/// One-shot harvest of a statically-applied `preference(key:value:)` value from evaluated
+/// renderables, mirroring `isBackDismissDisabled`.
+///
+/// Used to seed presentation preference state so that the presentation's first composition
+/// uses final values (detent geometry, drag indicator, interactive dismiss) instead of
+/// defaults that only settle after the collected preferences propagate a composition later.
+/// Only sees preferences applied to the presented content's own modifier chain — values
+/// applied deeper in the tree still arrive through the collector as before. Returns the
+/// first match, matching the collector's outermost-wins reduction for these keys.
+func harvestPreference(key: Any, on renderables: kotlin.collections.List<Renderable>) -> Any? {
+    for renderable in renderables {
+        let value = renderable.forEachModifier(perform: { modifier in
+            if let preferenceModifier = modifier as? PreferenceModifier, preferenceModifier.key == key {
+                return preferenceModifier.value
+            } else {
+                return nil
+            }
+        })
+        if value != nil {
+            return value
+        }
+    }
+    return nil
 }
 
 final class DisableScrollToDismissConnection : NestedScrollConnection {

--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -582,8 +582,11 @@ final class DisableScrollToDismissConnection : NestedScrollConnection {
             }
         }
     }
+    // Stable dismiss callback: a fresh closure per pass is an unstable Dialog argument
+    let currentIsPresented = rememberUpdatedState(isPresented)
+    let onDismissRequest: () -> Void = remember { { currentIsPresented.value.set(false) } }
     SkipAlertDialog(
-        onDismissRequest: { isPresented.set(false) },
+        onDismissRequest: onDismissRequest,
         neutralButtons: neutralButtonsList,
         confirmButton: {
             if let r = confirmRenderable {

--- a/Sources/SkipUI/SkipUI/Layout/Presentation.swift
+++ b/Sources/SkipUI/SkipUI/Layout/Presentation.swift
@@ -312,21 +312,27 @@ final class DisableScrollToDismissConnection : NestedScrollConnection {
 @Composable func ConfirmationDialogPresentation(title: Text?, isPresented: Binding<Bool>, context: ComposeContext, actions: any View, message: (any View)? = nil) {
     let sheetState = rememberModalBottomSheetState(skipPartiallyExpanded: true)
     if isPresented.get() || sheetState.isVisible {
-        // Collect buttons and message text
-        let actionRenderables = actions.Evaluate(context: context, options: 0)
-        let composableActions: kotlin.collections.List<Renderable> = actionRenderables.mapNotNull {
-            let stripped = $0.strip()
-            return stripped as? Button ?? stripped as? Link ?? stripped as? NavigationLink
-        }
-        let messageRenderables: kotlin.collections.List<Renderable> = message?.Evaluate(context: context, options: 0) ?? listOf()
-        let messageText = messageRenderables.mapNotNull {
-            $0.strip() as? Text
-        }.firstOrNull()
+        // Stable dismiss callback: a fresh closure per pass is an unstable ModalBottomSheet
+        // argument that forces the sheet machinery to recompose on every presenter recomposition
+        let currentIsPresented = rememberUpdatedState(isPresented)
+        let onDismissRequest: () -> Void = remember { { currentIsPresented.value.set(false) } }
+        ModalBottomSheet(onDismissRequest: onDismissRequest, sheetState: sheetState, containerColor: androidx.compose.ui.graphics.Color.Transparent, dragHandle: nil, contentWindowInsets: { WindowInsets(0.dp, 0.dp, 0.dp, 0.dp) }) {
+            // Collect buttons and message text. Evaluated inside the dialog's own composition:
+            // in the presenter's scope these full evaluations re-ran the actions and message
+            // view bodies on every presenter recomposition while the dialog was open
+            let actionRenderables = actions.Evaluate(context: context, options: 0)
+            let composableActions: kotlin.collections.List<Renderable> = actionRenderables.mapNotNull {
+                let stripped = $0.strip()
+                return stripped as? Button ?? stripped as? Link ?? stripped as? NavigationLink
+            }
+            let messageRenderables: kotlin.collections.List<Renderable> = message?.Evaluate(context: context, options: 0) ?? listOf()
+            let messageText = messageRenderables.mapNotNull {
+                $0.strip() as? Text
+            }.firstOrNull()
 
-        ModalBottomSheet(onDismissRequest: { isPresented.set(false) }, sheetState: sheetState, containerColor: androidx.compose.ui.graphics.Color.Transparent, dragHandle: nil, contentWindowInsets: { WindowInsets(0.dp, 0.dp, 0.dp, 0.dp) }) {
             // Add padding to always keep the sheet away from the top of the screen. It should tap to dismiss like the background
             let interactionSource = remember { MutableInteractionSource() }
-            Box(modifier: Modifier.fillMaxWidth().height(128.dp).clickable(interactionSource: interactionSource, indication: nil, onClick: { isPresented.set(false) }))
+            Box(modifier: Modifier.fillMaxWidth().height(128.dp).clickable(interactionSource: interactionSource, indication: nil, onClick: onDismissRequest))
 
             let stateSaver = remember { ComposeStateSaver() }
             let scrollState = rememberScrollState()


### PR DESCRIPTION
Addresses the preference-settle and presenter-churn items — (c) and part of (a) — of #487.

## What changes

**1. Sheets compose with final presentation-preference values on their first composition.**

`preference(key:value:)` now emits `PreferenceModifier`, a `SideEffectModifier` subclass that carries its key and value as inspectable fields (contribution behavior is byte-for-byte unchanged). `SheetPresentation` harvests statically-applied `presentationDetents` / `presentationDragIndicator` / `interactiveDismissDisabled` values from the content renderables it already evaluates (the same `forEachModifier` scan as the existing `backDismissDisabled` special case) and constructs the preference states with the harvested values as `initialValue`.

Result: a sheet with `.presentationDetents([.medium])` composes at medium-detent geometry on frame 1 instead of full height with a visible jump one composition later — and because the later collector contribution equals the seed, the settle recomposition itself disappears. Dynamic preference updates flow through the collectors exactly as before; preferences applied deeper than the content's own modifier chain keep the previous settle behavior (no regression, harvest is additive).

**2. `ModalBottomSheet` arguments stabilized.** The shape is remembered keyed on its inputs, the dismiss callback is remembered over `rememberUpdatedState`, and `backDismissDisabled` is harvested once per presentation (only its first composition is honored anyway, per the existing comment). Fresh unequal instances per presenter pass were forcing the sheet machinery to recompose on every presenter recomposition.

**3. Confirmation dialogs stop re-running action/message bodies on presenter churn.** `ConfirmationDialogPresentation` fully evaluated its actions and message (`options: 0` — bodies run) in the presenter's composition scope on every presenter recomposition while open. The evaluation now runs inside the `ModalBottomSheet` content lambda — the dialog window's own composition.

## Verification

> **Superseded, 2026-08-13.** The A/B table immediately below is confounded: the "stock" side was built
> on skip-ui 1.57.0 / skip 1.9.4 / skip-fuse-ui 1.17.2 while the patched side was 1.59.1 / 1.9.5 / 1.18.1,
> so it cannot separate this patch from the version delta. It is left in place rather than deleted,
> because it has already been read. The corrected single-variable A/B — same toolchain on both sides,
> only skip-ui swapped, 10 open/close cycles per build — is in the comment below, and its honest summary
> is: the pre-settle observations go 10 → 0 and sheet-content evaluations 41 → 32, with presenter ticks
> unchanged at 44 on both sides as a control, and **no measurable smoothness win**. Independent later work
> on our own app supports that reading: the dominant cost on a slow sheet turned out to be the body's
> lazy-container shape (see #508), not preference settling.


On-device A/B (API 35 emulator; standalone instrumented app https://github.com/Aecasorg/skip-fuse-perf-repro, scene 4: a sheet with `.presentationDetents([.medium])` presented over a presenter that ticks an unrelated `@Observable` every second):

| | stock 1.59.1 | patched |
|---|---|---|
| height seen by the sheet content's 1st evaluation | 801.5 (full height) → 438.1 ~50ms later, visible jump | **438.1 from the 1st evaluation** |
| sheet-content evaluations during open | n | n − 1 (settle pass gone) |
| evaluations per presenter tick while open | +1 | +1 (unchanged — see note) |

Note on the last row: content re-evaluation on presenter churn persists because the content lambda's captures (fresh renderables per presenter pass) invalidate the dialog composition — that residue is the bridged-peer identity problem (skip-bridge#113 / #486 territory) and is out of scope here. We considered memoizing `contentRenderables` as the issue suggested, but with `isKeepNonModified` evaluation the sheet's liveness for builder-level state rides on the presenter-scope re-evaluate — caching it without content identity would freeze open sheets, so we deliberately did not.

Alert presentation has the same presenter-scope evaluation pattern (plus text-field state extraction) — left for a follow-up to keep this reviewable.

Independent of #499 (different files except `Presentation.swift`, no overlapping hunks); the two merge in either order.

Happy to adjust naming, split the commits into separate PRs, or extend the harvest to alerts here if you'd prefer.

