### PR TITLE
Read List's item-animation gating state once per pass instead of inside every item

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/List.swift
+++ b/Sources/SkipUI/SkipUI/Containers/List.swift
@@ -290,11 +290,15 @@ public final class List : View, Renderable {
         LazyColumn(state: reorderableState.listState, modifier: modifier, contentPadding: contentPadding, verticalArrangement: listVerticalArrangement) {
             // Read move trigger here so that a move will recompose list content
             let _ = moveTrigger.value
-            let shouldAnimateItems: @Composable () -> Bool = {
-                // We disable animation to prevent filtered items from animating when they return
-                let animate = !forceUnanimatedItems.value && EnvironmentValues.shared._searchableState?.isSearching.value != true
-                return animate
-            }
+            // We disable animation to prevent filtered items from animating when they return.
+            //
+            // Read the gating state HERE, once, rather than from inside each item lambda: a read
+            // inside the item subscribes every visible item's own composition scope to these
+            // states, so a single flip of either invalidates every visible row individually and
+            // re-runs its content. That is expensive in a transpiled app and much worse in a Fuse
+            // app, where re-running a row rebuilds its view tree across the bridge. The value is
+            // identical for all items within a pass, so hoisting it changes no behavior.
+            let animateItems = !forceUnanimatedItems.value && EnvironmentValues.shared._searchableState?.isSearching.value != true
 
             // Initialize the factory context with closures that use the LazyListScope to generate items
             var startItemIndex = hasHeader ? 1 : 0 // Header inset
@@ -305,7 +309,7 @@ public final class List : View, Renderable {
                 startItemIndex: startItemIndex,
                 item: { renderable, level in
                     item {
-                        let itemModifier: Modifier = shouldAnimateItems() ? Modifier.animateItem() : Modifier
+                        let itemModifier: Modifier = animateItems ? Modifier.animateItem() : Modifier
                         RenderItem(content: renderable, level: level, context: itemContext, modifier: itemModifier, styling: styling)
                     }
                 },
@@ -315,7 +319,7 @@ public final class List : View, Renderable {
                     items(count: count, key: key) { index in
                         let keyValue = key?(index) // Key closure already remaps index
                         let index = itemCollector.value.remapIndex(index, from: offset)
-                        let itemModifier: Modifier = shouldAnimateItems() ? Modifier.animateItem() : Modifier
+                        let itemModifier: Modifier = animateItems ? Modifier.animateItem() : Modifier
                         let renderable = factory(index + range.start, itemContext)
                         RenderEditableItem(content: renderable, level: level, context: itemContext, modifier: itemModifier, styling: styling, key: keyValue, index: index, onDelete: onDelete, onMove: onMove, reorderableState: reorderableState, activeSwipeKey: activeSwipeKey)
                     }
@@ -325,7 +329,7 @@ public final class List : View, Renderable {
                     items(count: objects.count, key: key) { index in
                         let keyValue = key(index) // Key closure already remaps index
                         let index = itemCollector.value.remapIndex(index, from: offset)
-                        let itemModifier: Modifier = shouldAnimateItems() ? Modifier.animateItem() : Modifier
+                        let itemModifier: Modifier = animateItems ? Modifier.animateItem() : Modifier
                         let renderable = factory(objects[index], itemContext)
                         RenderEditableItem(content: renderable, level: level, context: itemContext, modifier: itemModifier, styling: styling, key: keyValue, index: index, onDelete: onDelete, onMove: onMove, reorderableState: reorderableState, activeSwipeKey: activeSwipeKey)
                     }
@@ -335,7 +339,7 @@ public final class List : View, Renderable {
                     items(count: objectsBinding.wrappedValue.count, key: key) { index in
                         let keyValue = key(index) // Key closure already remaps index
                         let index = itemCollector.value.remapIndex(index, from: offset)
-                        let itemModifier: Modifier = shouldAnimateItems() ? Modifier.animateItem() : Modifier
+                        let itemModifier: Modifier = animateItems ? Modifier.animateItem() : Modifier
                         let renderable = factory(objectsBinding, index, itemContext)
                         RenderEditableItem(content: renderable, level: level, context: itemContext, modifier: itemModifier, styling: styling, objectsBinding: objectsBinding, key: keyValue, index: index, editActions: editActions, onDelete: onDelete, onMove: onMove, reorderableState: reorderableState, activeSwipeKey: activeSwipeKey)
                     }


### PR DESCRIPTION
Small self-contained fix from the investigation written up in #486.

## Problem

`RenderList` builds the item-animation predicate as a `@Composable` closure and calls it from inside each of the four item-production lambdas:

```swift
let shouldAnimateItems: @Composable () -> Bool = {
    let animate = !forceUnanimatedItems.value && EnvironmentValues.shared._searchableState?.isSearching.value != true
    return animate
}
…
items(count: count, key: key) { index in
    …
    let itemModifier: Modifier = shouldAnimateItems() ? Modifier.animateItem() : Modifier   // L308 / L318 / L328 / L338
```

Because the reads happen inside the item lambda, **every visible item's own composition scope subscribes** to `forceUnanimatedItems` and to `_searchableState.isSearching`. A single flip of either then invalidates every visible row individually and re-runs its content. `forceUnanimatedItems` is not rare: it is set `true` on any unanimated recomposition and flipped back 300 ms later by the `LaunchedEffect` at L267-276.

The predicate's value is identical for every item within a pass, so nothing is gained by evaluating it per item.

## Change

Compute it once in the `LazyColumn` content scope (next to the existing `moveTrigger` read) and capture the `Bool` in the item lambdas. Strictly fewer subscribing scopes; same value everywhere it is used; no behavior change.

## Verification

`swift build` clean (transpile + macOS compile) on top of `main`.

The user-visible cost of the current behavior is much larger in a Fuse app than a transpiled one — re-running a row there rebuilds its view tree across the bridge (two JNI hops plus a fresh peer allocation per bridged view per level), so a flip that re-runs ten visible rows is meaningfully expensive. Details in #486.

## Not included

The `LaunchedEffect(System.currentTimeMillis())` at L267-276 restarts on every `RenderList` pass because its key is wall-clock time, and its delayed write flips `forceUnanimatedItems` back — which recomposes the list, which restarts the effect. That looks like a self-sustaining ~300 ms cycle for any list that is not animating, and this PR does not address it: every data-version signal we considered as a replacement key (item count, first/last identifier) changes animation behavior for same-count data replacements, which is a visible regression we did not want to introduce blind. Happy to take direction on the intended semantics there and follow up — it seems the more valuable of the two fixes.
