### PR TITLE
Clamp finite frame max width to parent bounds

### DIFF
--- a/Sources/SkipUI/SkipUI/Compose/ComposeExtensions.swift
+++ b/Sources/SkipUI/SkipUI/Compose/ComposeExtensions.swift
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.requiredWidthIn
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -83,7 +84,7 @@ extension Modifier {
         } else if let min, min! > Float(0) {
             return requiredWidthIn(min: min!.dp)
         } else if let max, max! >= Float(0) {
-            return requiredWidthIn(max: max!.dp)
+            return widthIn(max: max!.dp)
         } else {
             return self
         }

--- a/Tests/SkipUITests/LayoutTests.swift
+++ b/Tests/SkipUITests/LayoutTests.swift
@@ -5,6 +5,10 @@ import XCTest
 import OSLog
 import Foundation
 
+#if SKIP
+import androidx.compose.ui.test.onNodeWithTag
+#endif
+
 final class LayoutTests: XCSnapshotTestCase {
 
     func testRenderWhiteDot() throws {
@@ -629,15 +633,36 @@ final class LayoutTests: XCSnapshotTestCase {
     }
 
     func testFrameMaxWidthRespectsParentBounds() throws {
-        // Skip on Android until the layout issue is fixed
-        // See: https://github.com/skiptools/skip-ui/issues/339
         #if SKIP
-        throw XCTSkip("Android: .frame(maxWidth:) may expand beyond parent bounds")
-        #endif
-        
-        // Create a black container (width: 12), put a white rectangle inside with
-        // maxWidth: 20 (larger than parent), and add a red border.
-        // Expected: The white rectangle should be constrained to width 12 (parent bounds).
+        let cases: [(parent: CGFloat, maximum: CGFloat, expected: CGFloat)] = [
+            (400.0, 680.0, 400.0),
+            (680.0, 680.0, 680.0),
+            (800.0, 680.0, 680.0),
+            (400.0, .infinity, 400.0),
+        ]
+
+        composeRule.setContent {
+            VStack(spacing: 0.0) {
+                ForEach(0..<cases.count, id: \.self) { index in
+                    Color.white
+                        .frame(maxWidth: cases[index].maximum, maxHeight: 40.0)
+                        .accessibilityIdentifier("frame-max-width-\(index)")
+                        .frame(width: cases[index].parent, height: 40.0)
+                }
+            }
+            .Compose(context: ComposeContext())
+        }
+        composeRule.waitForIdle()
+
+        for (index, testCase) in cases.enumerated() {
+            let measuredWidth = Double(composeRule
+                .onNodeWithTag("frame-max-width-\(index)")
+                .fetchSemanticsNode()
+                .boundsInRoot.width) / Double(composeRule.density.density)
+            XCTAssertEqual(measuredWidth, testCase.expected, accuracy: 0.5,
+                "parent: \(testCase.parent), maximum: \(testCase.maximum)")
+        }
+        #else
         XCTAssertEqual(try pixmap(content: ZStack {
             Color.black.frame(width: 12.0, height: 6.0)
             Color.white
@@ -651,6 +676,7 @@ final class LayoutTests: XCSnapshotTestCase {
         . . . . . . . . . . . .
         . . . . . . . . . . . .
         """)
+        #endif
     }
 
 }


### PR DESCRIPTION
## Summary

Fixes `Modifier.frame(maxWidth:)` on Android so a finite maximum width is clamped by tighter incoming parent constraints, matching SwiftUI behavior.

The max-only branch used Compose `requiredWidthIn(max:)`, which permits the child to measure wider than its parent and then centers the oversized result. This changes only that branch to `widthIn(max:)`. The existing min-only and min-plus-max behavior is unchanged.

Closes #339.

## Verification

- Added an Android matrix to the existing `testFrameMaxWidthRespectsParentBounds`:
  - parent 400, max 680 → 400
  - parent 680, max 680 → 680
  - parent 800, max 680 → 680
  - parent 400, max infinity → 400
- Regression commit reproduced the defect on Android: the first case measured 680 instead of 400.
- With the one-line fix, the same four-case Android test passed (1 test executed).
- `swift test --filter LayoutTests.testFrameMaxWidthRespectsParentBounds` passed on the host platform (1 test, 0 failures).

Skip Pull Request Checklist:

- [ ] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository. No Fuse update is required; the defect is isolated to SkipUI's Android modifier mapping.
- [ ] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app

-----

- [x] AI was used to generate or assist with generating this PR. AI helped trace the failing modifier branch and draft the regression matrix and PR description. I manually verified the scoped diff, reproduced the regression before applying the fix, reran the identical Android test after the fix, inspected the generated Kotlin, and ran the targeted Swift test.

