### PR TITLE
Fix Font.custom(_:size:relativeTo:) sizing on Android

### DIFF
--- a/Sources/SkipUI/SkipUI/Text/Font.swift
+++ b/Sources/SkipUI/SkipUI/Text/Font.swift
@@ -240,10 +240,11 @@ public struct Font : Hashable {
 
     public static func custom(_ name: String, size: CGFloat, relativeTo textStyle: Font.TextStyle) -> Font {
         #if SKIP
-        let systemFont = system(textStyle)
+        // size is the absolute point size at the default Dynamic Type level. Using sp units
+        // ensures it scales proportionally with Android's font size accessibility setting,
+        // which is the closest equivalent to Dynamic Type scaling on Android.
         return Font(fontImpl: {
-            let absoluteSize = systemFont.fontImpl().fontSize.value + size
-            androidx.compose.ui.text.TextStyle(fontFamily: Self.findNamedFont(name, ctx: LocalContext.current), fontSize: absoluteSize.sp)
+            androidx.compose.ui.text.TextStyle(fontFamily: Self.findNamedFont(name, ctx: LocalContext.current), fontSize: size.sp)
         })
         #else
         fatalError()


### PR DESCRIPTION
## Summary

`Font.custom(_:size:relativeTo:)` was computing the Android font size incorrectly. The previous implementation added the base text style's system font size on top of the caller-supplied `size`:

```swift
let systemFont = system(textStyle)
let absoluteSize = systemFont.fontImpl().fontSize.value + size
androidx.compose.ui.text.TextStyle(fontSize: absoluteSize.sp)
```

This produced fonts that were too large (e.g. a `.caption`-relative custom font of 14pt would actually render at ~26sp), and the `relativeTo` style was being used as an _additive_ offset rather than just a scaling reference.

## Fix

Use `size` directly in `sp` units and drop the additive offset:

```swift
androidx.compose.ui.text.TextStyle(fontSize: size.sp)
```

`size` is the absolute point size at the default Dynamic Type level per the SwiftUI docs. Using `sp` ensures it scales proportionally with Android's font size accessibility setting — the closest equivalent to iOS Dynamic Type scaling.

This also aligns the behavior of `Font.custom(_:size:relativeTo:)` with the already-correct `Font.custom(_:size:)` implementation.

## Testing

Personally tested on a real Android device with multiple Dynamic Type levels. Custom fonts now render at the expected size and scale correctly with accessibility font size changes.

---

> Fix authored with assistance from [Claude Code](https://claude.ai/code) (Anthropic). The fix and behavior have been personally reviewed and tested by the contributor.