### PR TITLE
Added searchable isPresented support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2118,6 +2118,7 @@ Support levels:
               <summary><code>.searchable</code> (<a href="https://skip.dev/docs/components/searchable/">example</a>)</summary>
               <ul>
                 <li><code>func searchable(text: Binding&lt;String>, prompt: Text? = nil) -> some View</code></li>
+                <li><code>func searchable(text: Binding&lt;String>, isPresented: Binding&lt;Bool>, prompt: Text? = nil) -> some View</code></li>
                 <li><code>func searchable(text: Binding&lt;String>, prompt: String) -> some View</code></li>
               </ul>
           </details>      

--- a/Sources/SkipUI/SkipUI/Commands/Search.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Search.swift
@@ -34,7 +34,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 #endif
@@ -144,8 +146,17 @@ let searchFieldHeight = 56.0
         }
     }
     let keyboardActions = KeyboardActions(submitState)
+    let currentText = state.text.wrappedValue
+    let defaultTextFieldValue = TextFieldValue(text: currentText, selection: TextRange(currentText.count))
+    let textFieldValue = remember { mutableStateOf(defaultTextFieldValue) }
+    var currentTextFieldValue = textFieldValue.value
+    if currentTextFieldValue.text != currentText {
+        currentTextFieldValue = defaultTextFieldValue
+    }
     LaunchedEffect(isPresented) {
         if isPresented {
+            let presentedText = state.text.wrappedValue
+            textFieldValue.value = TextFieldValue(text: presentedText, selection: TextRange(presentedText.count))
             state.isSearching.value = true
             focusRequester.requestFocus()
         } else if state.isPresented != nil {
@@ -155,8 +166,9 @@ let searchFieldHeight = 56.0
     }
     Row(horizontalArrangement: Arrangement.spacedBy(8.dp), verticalAlignment: androidx.compose.ui.Alignment.CenterVertically, modifier: context.modifier) {
         let isFocused = remember { mutableStateOf(false) }
-        OutlinedTextField(value: state.text.wrappedValue, onValueChange: {
-            state.text.wrappedValue = $0
+        OutlinedTextField(value: currentTextFieldValue, onValueChange: {
+            textFieldValue.value = $0
+            state.text.wrappedValue = $0.text
         }, modifier: Modifier.weight(Float(1.0)).semantics { testTagsAsResourceId = true }.testTag("skip_ui_automation_search_field").focusRequester(focusRequester).onFocusChanged {
             if $0.isFocused {
                 state.isSearching.value = true

--- a/Sources/SkipUI/SkipUI/Commands/Search.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Search.swift
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,9 +48,22 @@ extension View {
         #endif
     }
 
+    public func searchable(text: Binding<String>, isPresented: Binding<Bool>, placement: SearchFieldPlacement = .automatic, prompt: Text? = nil) -> any View {
+        #if SKIP
+        return ModifiedContent(content: self, modifier: SearchableModifier(text: text, prompt: prompt, isPresented: isPresented))
+        #else
+        return self
+        #endif
+    }
+
     // SKIP @bridge
     public func searchable(getText: @escaping () -> String, setText: @escaping (String) -> Void, prompt: Text?) -> any View {
         return searchable(text: Binding(get: getText, set: setText), prompt: prompt)
+    }
+
+    // SKIP @bridge
+    public func searchable(getText: @escaping () -> String, setText: @escaping (String) -> Void, getIsPresented: @escaping () -> Bool, setIsPresented: @escaping (Bool) -> Void, prompt: Text?) -> any View {
+        return searchable(text: Binding(get: getText, set: setText), isPresented: Binding(get: getIsPresented, set: setIsPresented), prompt: prompt)
     }
 
     public func searchable(text: Binding<String>, placement: SearchFieldPlacement = .automatic, prompt: LocalizedStringKey) -> any View {
@@ -118,6 +132,7 @@ let searchFieldHeight = 56.0
     let prompt = state.prompt ?? Text(verbatim: stringResource(android.R.string.search_go))
     let focusManager = LocalFocusManager.current
     let focusRequester = remember { FocusRequester() }
+    let isPresented = state.isPresented?.wrappedValue == true
     let contentContext = context.content()
     let keyboardOptions = KeyboardOptions(imeAction: ImeAction.Search)
     let submitState = OnSubmitState(triggers: .search) {
@@ -129,6 +144,15 @@ let searchFieldHeight = 56.0
         }
     }
     let keyboardActions = KeyboardActions(submitState)
+    LaunchedEffect(isPresented) {
+        if isPresented {
+            state.isSearching.value = true
+            focusRequester.requestFocus()
+        } else if state.isPresented != nil {
+            focusManager.clearFocus()
+            state.isSearching.value = false
+        }
+    }
     Row(horizontalArrangement: Arrangement.spacedBy(8.dp), verticalAlignment: androidx.compose.ui.Alignment.CenterVertically, modifier: context.modifier) {
         let isFocused = remember { mutableStateOf(false) }
         OutlinedTextField(value: state.text.wrappedValue, onValueChange: {
@@ -136,6 +160,7 @@ let searchFieldHeight = 56.0
         }, modifier: Modifier.weight(Float(1.0)).semantics { testTagsAsResourceId = true }.testTag("skip_ui_automation_search_field").focusRequester(focusRequester).onFocusChanged {
             if $0.isFocused {
                 state.isSearching.value = true
+                state.isPresented?.wrappedValue = true
             }
         }, placeholder: {
             TextField.Placeholder(prompt: prompt, context: contentContext)
@@ -154,6 +179,7 @@ let searchFieldHeight = 56.0
                 state.text.wrappedValue = ""
                 focusManager.clearFocus()
                 state.isSearching.value = false
+                state.isPresented?.wrappedValue = false
             }
         }
     }
@@ -162,10 +188,12 @@ let searchFieldHeight = 56.0
 final class SearchableModifier: ModifierProtocol {
     let text: Binding<String>
     let prompt: Text?
+    let isPresented: Binding<Bool>?
 
-    init(text: Binding<String>, prompt: Text?) {
+    init(text: Binding<String>, prompt: Text?, isPresented: Binding<Bool>? = nil) {
         self.text = text
         self.prompt = prompt
+        self.isPresented = isPresented
     }
 
     override var role: ModifierRole {
@@ -173,7 +201,9 @@ final class SearchableModifier: ModifierProtocol {
     }
 
     @Composable override func Evaluate(content: View, context: ComposeContext, options: Int) -> kotlin.collections.List<Renderable>? {
-        let isSearching = rememberSaveable(stateSaver: context.stateSaver as! Saver<Bool, Any>) { mutableStateOf(false) }
+        let isSearching = rememberSaveable(stateSaver: context.stateSaver as! Saver<Bool, Any>) {
+            mutableStateOf(isPresented?.wrappedValue == true)
+        }
         let renderables = EnvironmentValues.shared.setValuesWithReturn {
             $0.set_isSearching(isSearching)
             return ComposeResult.ok
@@ -182,7 +212,7 @@ final class SearchableModifier: ModifierProtocol {
         }
         var ret: kotlin.collections.MutableList<Renderable> = mutableListOf()
         for i in 0..<renderables.size {
-            ret.add(ModifiedContent(content: renderables[i], modifier: SearchableStateModifier(text: text, prompt: prompt, isSearching: isSearching, isFirstRenderable: i == 0)))
+            ret.add(ModifiedContent(content: renderables[i], modifier: SearchableStateModifier(text: text, prompt: prompt, isPresented: isPresented, isSearching: isSearching, isFirstRenderable: i == 0)))
         }
         return ret
     }
@@ -193,7 +223,7 @@ final class SearchableModifier: ModifierProtocol {
 }
 
 final class SearchableStateModifier: RenderModifier {
-    init(text: Binding<String>, prompt: Text?, isSearching: MutableState<Bool>, isFirstRenderable: Bool) {
+    init(text: Binding<String>, prompt: Text?, isPresented: Binding<Bool>?, isSearching: MutableState<Bool>, isFirstRenderable: Bool) {
         super.init()
         self.action = { renderable, context in
             let submitState = EnvironmentValues.shared._onSubmitState
@@ -203,7 +233,7 @@ final class SearchableStateModifier: RenderModifier {
             // so isNavigationRoot is not yet true. Treat "modifier on NavigationStack" as on-stack
             // so only Navigation shows the search bar; ScrollView/List/etc. must not show a second one.
             let isOnNavigationStack = isModifierOnNavigationStack || isNavigationRoot
-            let state = SearchableState(text: text, prompt: prompt, submitState: submitState, isSearching: isSearching, isOnNavigationStack: isOnNavigationStack)
+            let state = SearchableState(text: text, prompt: prompt, submitState: submitState, isPresented: isPresented, isSearching: isSearching, isOnNavigationStack: isOnNavigationStack)
             // Bubble the search state to the navigation stack if root, else down to the component
             if isModifierOnNavigationStack || isNavigationRoot != true {
                 EnvironmentValues.shared.setValues {
@@ -235,6 +265,7 @@ struct SearchableState: Equatable {
     let text: Binding<String>
     let prompt: Text?
     let submitState: OnSubmitState?
+    let isPresented: Binding<Bool>?
     let isSearching: MutableState<Bool>
     let isOnNavigationStack: Bool
 


### PR DESCRIPTION
This PR adds support for controlling search presentation with the `searchable(text:isPresented:)` modifier. The bound `isPresented` value can now show and hide the search field programmatically, and user-driven search focus or cancellation updates the binding.

**Related PRs:**
- https://github.com/skiptools/skip-fuse-ui/pull/141
- https://github.com/skiptools/skipapp-showcase/pull/120

---

Thank you for contributing to the Skip project! Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device
- [X] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [X] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

