### PR TITLE
Preserve accessibility semantics on actionable list rows

### DIFF
--- a/Sources/SkipUI/SkipUI/Commands/Menu.swift
+++ b/Sources/SkipUI/SkipUI/Commands/Menu.swift
@@ -168,7 +168,10 @@ public final class Menu : View, Renderable {
             // `ModifiedContent`, not on `stripped`. Harvest them here so the
             // resulting Compose `DropdownMenuItem` carries the same test tag
             // and content description a regular Button would.
-            let itemModifier = accessibilityModifier(for: renderable, context: context)
+            let itemModifier = composeAccessibilityModifiers(
+                for: renderable,
+                context: context
+            ).modifier
             if let button = stripped as? Button {
                 let isSelected: Bool?
                 if let tagModifier = TagModifier.on(content: renderable, role: .tag) {
@@ -201,32 +204,6 @@ public final class Menu : View, Renderable {
                 renderable.Render(context: context)
             }
         }
-    }
-
-    /// Walks `renderable`'s modifier chain and composes the `Modifier`
-    /// transform from every `.accessibility`-role `RenderModifier` (i.e.
-    /// `.accessibilityIdentifier(_:)`, `.accessibilityLabel(_:)`, etc.) so
-    /// it can be applied to a raw Compose element. `forEachModifier` yields
-    /// outermost-first; we collect into a list and apply in reverse so the
-    /// outermost ends up wrapping the inner ones — matching how a normal
-    /// `Renderable.Render` would build the chain.
-    @Composable private static func accessibilityModifier(for renderable: Renderable, context: ComposeContext) -> Modifier {
-        var collected: [RenderModifier] = []
-        let _: Bool? = renderable.forEachModifier { (mod: ModifierProtocol) -> Bool? in
-            if let renderMod = mod as? RenderModifier, renderMod.role == .accessibility {
-                collected.append(renderMod)
-            }
-            return nil
-        }
-        var modifier: Modifier = Modifier
-        for renderMod in collected.reversed() {
-            if let modAction = renderMod.modifierAction {
-                var ctx = context
-                ctx.modifier = modifier
-                modifier = modAction(ctx)
-            }
-        }
-        return modifier
     }
 
     @Composable private static func RenderDropdownMenuItem(for view: ComposeBuilder, context: ComposeContext, modifier: Modifier = Modifier, tintColor: Color? = nil, isSelected: Bool? = nil, action: () -> Void) {

--- a/Sources/SkipUI/SkipUI/Containers/List.swift
+++ b/Sources/SkipUI/SkipUI/Containers/List.swift
@@ -67,6 +67,8 @@ import androidx.compose.ui.geometry.RoundRect
 import androidx.compose.ui.graphics.Path.Companion.combine
 import androidx.compose.ui.graphics.PathOperation
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.zIndex
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
@@ -422,23 +424,43 @@ public final class List : View, Renderable {
         let badge = badgeModifier.badge
         let (isListItem, listItemAction) = item.shouldRenderListItem(context: context)
         if isListItem {
-            let actionModifier: Modifier
+            let rowModifier: Modifier
+            let rowContent: Renderable
+            let rowContentModifiers: kotlin.collections.List<ModifierProtocol>
             if let listItemAction {
                 let isDisabled = !EnvironmentValues.shared.isEnabled || item.forEachModifier { ($0 as? DisabledModifier)?.disabled } == true
-                actionModifier = Modifier.clickable(onClick: listItemAction, enabled: !isDisabled)
+                let baseModifier = Modifier.clickable(
+                    onClick: listItemAction,
+                    enabled: !isDisabled
+                ).then(modifier)
+                let accessibilityComposition = EnvironmentValues.shared.setValuesWithReturn({
+                    $0.setisEnabled(!isDisabled)
+                    return ComposeResult.ok
+                }, in: {
+                    return composeAccessibilityModifiers(
+                        for: item,
+                        context: context,
+                        modifier: baseModifier
+                    )
+                })
+                rowModifier = accessibilityComposition.modifier
+                rowContent = item.strip()
+                rowContentModifiers = accessibilityComposition.remainingModifiers
             } else {
-                actionModifier = Modifier
+                rowModifier = modifier
+                rowContent = item
+                rowContentModifiers = listOf()
             }
             if let badge {
-                Row(modifier: actionModifier.then(modifier), horizontalArrangement: Arrangement.SpaceBetween, verticalAlignment: androidx.compose.ui.Alignment.CenterVertically) {
+                Row(modifier: rowModifier, horizontalArrangement: Arrangement.SpaceBetween, verticalAlignment: androidx.compose.ui.Alignment.CenterVertically) {
                     Box(modifier: Modifier.weight(Float(1.0)), contentAlignment: androidx.compose.ui.Alignment.CenterStart) {
-                        item.RenderListItem(context: context, modifiers: listOf())
+                        rowContent.RenderListItem(context: context, modifiers: rowContentModifiers)
                     }
                     RenderBadge(badge: badge, prominence: badgeModifier.prominence ?? .standard, context: context)
                 }
             } else {
-                Box(modifier: actionModifier.then(modifier), contentAlignment: androidx.compose.ui.Alignment.CenterStart) {
-                    item.RenderListItem(context: context, modifiers: listOf())
+                Box(modifier: rowModifier, contentAlignment: androidx.compose.ui.Alignment.CenterStart) {
+                    rowContent.RenderListItem(context: context, modifiers: rowContentModifiers)
                 }
             }
         } else {
@@ -528,6 +550,8 @@ public final class List : View, Renderable {
         let leadingSwipe = swipeConfigs.leading
         let trailingSwipe = swipeConfigs.trailing
         let hasUserSwipe = leadingSwipe != nil || trailingSwipe != nil
+        let isEnabled = EnvironmentValues.shared.isEnabled &&
+            content.forEachModifier { ($0 as? DisabledModifier)?.disabled } != true
         let isDeleteEnabled = (editActions.contains(.delete) || onDelete != nil) && editActionsModifier.isDeleteDisabled != true
         let isMoveEnabled = (editActions.contains(.move) || onMove != nil) && editActionsModifier.isMoveDisabled != true
         guard isDeleteEnabled || isMoveEnabled || hasUserSwipe else {
@@ -556,7 +580,7 @@ public final class List : View, Renderable {
                 }
             } : nil
             itemContent = { rowModifier in
-                RenderSwipeableItem(content: content, level: level, context: context, modifier: rowModifier, styling: styling, leadingConfig: leadingSwipe, trailingConfig: trailingSwipe, rowKey: key, activeSwipeKey: activeSwipeKey, onDestructiveDelete: onDestructiveDelete)
+                RenderSwipeableItem(content: content, level: level, context: context, modifier: rowModifier, styling: styling, leadingConfig: leadingSwipe, trailingConfig: trailingSwipe, rowKey: key, activeSwipeKey: activeSwipeKey, isEnabled: isEnabled, onDestructiveDelete: onDestructiveDelete)
             }
         } else if isDeleteEnabled {
             let rememberedOnDelete = rememberUpdatedState({
@@ -608,7 +632,7 @@ public final class List : View, Renderable {
     /// The foreground row determines the cell's height; reveal buttons match it
     /// via `Modifier.matchParentSize()` so we never propagate unbounded height
     /// constraints up into the surrounding LazyColumn.
-    @Composable private func RenderSwipeableItem(content: Renderable, level: Int, context: ComposeContext, modifier: Modifier, styling: ListStyling, leadingConfig: SwipeActionsConfig?, trailingConfig: SwipeActionsConfig?, rowKey: String, activeSwipeKey: MutableState<String?>, onDestructiveDelete: (() -> Void)? = nil) {
+    @Composable private func RenderSwipeableItem(content: Renderable, level: Int, context: ComposeContext, modifier: Modifier, styling: ListStyling, leadingConfig: SwipeActionsConfig?, trailingConfig: SwipeActionsConfig?, rowKey: String, activeSwipeKey: MutableState<String?>, isEnabled: Bool, onDestructiveDelete: (() -> Void)? = nil) {
         let coroutineScope = rememberCoroutineScope()
 
         /* Extract Buttons and per-button .tint(_:) values from each edge's
@@ -701,6 +725,19 @@ public final class List : View, Renderable {
         let trailingNaturalState = remember { mutableFloatStateOf(Float(0)) }
         let leadingNaturalState = remember { mutableFloatStateOf(Float(0)) }
 
+        /* A disabled SwiftUI row owns no swipe interaction. Close an already
+           revealed row and clear its active key as soon as inherited enabled
+           state changes, while input and semantics are gated synchronously
+           below. */
+        LaunchedEffect(isEnabled) {
+            if isEnabled == false && anchoredState.currentValue != SwipeAnchor.closed {
+                anchoredState.snapTo(SwipeAnchor.closed)
+                if activeSwipeKey.value == rowKey {
+                    activeSwipeKey.value = nil
+                }
+            }
+        }
+
         /* When a *different* row's swipe opens, animate this row closed.
            Matches iOS list behavior of one open swipe at a time. */
         let currentlyOpen = activeSwipeKey.value
@@ -729,7 +766,14 @@ public final class List : View, Renderable {
            snap back to closed. */
         LaunchedEffect(anchoredState.settledValue) {
             let settled = anchoredState.settledValue
-            if settled == SwipeAnchor.trailingFull {
+            if isEnabled == false {
+                if settled != SwipeAnchor.closed {
+                    anchoredState.snapTo(SwipeAnchor.closed)
+                }
+                if activeSwipeKey.value == rowKey {
+                    activeSwipeKey.value = nil
+                }
+            } else if settled == SwipeAnchor.trailingFull {
                 if let action = trailingFullSwipeTarget?.action {
                     action()
                 }
@@ -811,7 +855,7 @@ public final class List : View, Renderable {
                                     continue
                                 }
                                 Box(modifier: Modifier.weight(weight).fillMaxHeight()) {
-                                    RenderSwipeRevealButton(button: button, sizeModifier: Modifier.fillMaxSize(), context: context, tintOverride: leadingTintMap[button], onTap: {
+                                    RenderSwipeRevealButton(button: button, sizeModifier: Modifier.fillMaxSize(), context: context, tintOverride: leadingTintMap[button], isEnabled: isEnabled, isAccessibilityVisible: isEnabled && revealedLeadingPx > Float(1), onTap: {
                                         button.action()
                                         if button.role == ButtonRole.destructive, let onDestructiveDelete {
                                             onDestructiveDelete()
@@ -826,7 +870,7 @@ public final class List : View, Renderable {
                     } else {
                         Row(modifier: Modifier.fillMaxHeight().wrapContentWidth().onSizeChanged { leadingNaturalState.value = Float($0.width) }) {
                             for button in leadingButtons {
-                                RenderSwipeRevealButton(button: button, sizeModifier: Modifier.fillMaxHeight().widthIn(min: minButtonWidthDp), context: context, tintOverride: leadingTintMap[button], onTap: {
+                                RenderSwipeRevealButton(button: button, sizeModifier: Modifier.fillMaxHeight().widthIn(min: minButtonWidthDp), context: context, tintOverride: leadingTintMap[button], isEnabled: isEnabled, isAccessibilityVisible: isEnabled && revealedLeadingPx > Float(1), onTap: {
                                     button.action()
                                     if button.role == ButtonRole.destructive, let onDestructiveDelete {
                                         onDestructiveDelete()
@@ -854,7 +898,7 @@ public final class List : View, Renderable {
                                     continue
                                 }
                                 Box(modifier: Modifier.weight(weight).fillMaxHeight()) {
-                                    RenderSwipeRevealButton(button: button, sizeModifier: Modifier.fillMaxSize(), context: context, tintOverride: trailingTintMap[button], onTap: {
+                                    RenderSwipeRevealButton(button: button, sizeModifier: Modifier.fillMaxSize(), context: context, tintOverride: trailingTintMap[button], isEnabled: isEnabled, isAccessibilityVisible: isEnabled && revealedTrailingPx > Float(1), onTap: {
                                         button.action()
                                         if button.role == ButtonRole.destructive, let onDestructiveDelete {
                                             onDestructiveDelete()
@@ -869,7 +913,7 @@ public final class List : View, Renderable {
                     } else {
                         Row(modifier: Modifier.fillMaxHeight().wrapContentWidth().onSizeChanged { trailingNaturalState.value = Float($0.width) }) {
                             for button in trailingButtons {
-                                RenderSwipeRevealButton(button: button, sizeModifier: Modifier.fillMaxHeight().widthIn(min: minButtonWidthDp), context: context, tintOverride: trailingTintMap[button], onTap: {
+                                RenderSwipeRevealButton(button: button, sizeModifier: Modifier.fillMaxHeight().widthIn(min: minButtonWidthDp), context: context, tintOverride: trailingTintMap[button], isEnabled: isEnabled, isAccessibilityVisible: isEnabled && revealedTrailingPx > Float(1), onTap: {
                                     button.action()
                                     if button.role == ButtonRole.destructive, let onDestructiveDelete {
                                         onDestructiveDelete()
@@ -926,7 +970,7 @@ public final class List : View, Renderable {
                     let o = anchoredState.offset
                     IntOffset(o.isNaN() ? 0 : o.toInt(), 0)
                 }
-                .anchoredDraggable(state: anchoredState, orientation: Orientation.Horizontal)
+                .anchoredDraggable(state: anchoredState, orientation: Orientation.Horizontal, enabled: isEnabled)
             ) {
                 RenderItem(content: content, level: level, context: context, styling: styling)
                 /* Subtle scrim that intensifies with swipe progress so the row
@@ -982,7 +1026,7 @@ public final class List : View, Renderable {
     /// stretch mode it's fillMaxSize() inside a weighted Box so the button
     /// expands with the row. Padding around the label keeps icon/text from
     /// touching the cell edges.
-    @Composable private func RenderSwipeRevealButton(button: Button, sizeModifier: Modifier, context: ComposeContext, tintOverride: Color? = nil, onTap: () -> Void) {
+    @Composable private func RenderSwipeRevealButton(button: Button, sizeModifier: Modifier, context: ComposeContext, tintOverride: Color? = nil, isEnabled: Bool, isAccessibilityVisible: Bool, onTap: () -> Void) {
         let backgroundColor: androidx.compose.ui.graphics.Color
         let contentColor: androidx.compose.ui.graphics.Color
         if button.role == ButtonRole.destructive {
@@ -1011,7 +1055,12 @@ public final class List : View, Renderable {
         Row(modifier: sizeModifier
             .clipToBounds()
             .background(backgroundColor)
-            .clickable(onClick: onTap)
+            .semantics {
+                if isAccessibilityVisible == false {
+                    hideFromAccessibility()
+                }
+            }
+            .clickable(onClick: onTap, enabled: isEnabled)
             .padding(horizontal: 12.dp, vertical: 8.dp),
             horizontalArrangement: Arrangement.Center,
             verticalAlignment: androidx.compose.ui.Alignment.CenterVertically) {

--- a/Sources/SkipUI/SkipUI/System/Accessibility.swift
+++ b/Sources/SkipUI/SkipUI/System/Accessibility.swift
@@ -3,9 +3,14 @@
 #if !SKIP_BRIDGE
 import Foundation
 #if SKIP
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.heading
-import androidx.compose.ui.semantics.invisibleToUser
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.popup
 import androidx.compose.ui.semantics.role
@@ -163,14 +168,34 @@ extension View {
         #endif
     }
 
+    /// Marks changing content for a native accessibility announcement.
+    public func accessibilityLiveRegion(_ region: AccessibilityLiveRegion) -> some View {
+        #if SKIP
+        let mode = region == .assertive
+            ? LiveRegionMode.Assertive
+            : LiveRegionMode.Polite
+        return ModifiedContent(content: self, modifier: RenderModifier(role: .accessibility) {
+            $0.modifier.semantics { liveRegion = mode }
+        })
+        #else
+        return self
+        #endif
+    }
+
     @available(*, unavailable)
     public func accessibilityAction(_ actionKind: AccessibilityActionKind = .default, _ handler: @escaping () -> Void) -> some View {
         return self
     }
 
-    @available(*, unavailable)
     public func accessibilityAction(named name: Text, _ handler: @escaping () -> Void) -> some View {
+        #if SKIP
+        return ModifiedContent(
+            content: self,
+            modifier: NamedAccessibilityActionModifier(name: name, handler: handler)
+        )
+        #else
         return self
+        #endif
     }
 
     @available(*, unavailable)
@@ -178,24 +203,27 @@ extension View {
         return self
     }
 
-    @available(*, unavailable)
     public func accessibilityActions(@ViewBuilder _ content: () -> any View) -> some View {
+        #if SKIP
+        return ModifiedContent(
+            content: self,
+            modifier: AccessibilityActionsModifier(content: ComposeBuilder.from(content))
+        )
+        #else
         return self
+        #endif
     }
 
-    @available(*, unavailable)
     public func accessibilityAction(named nameKey: LocalizedStringKey, _ handler: @escaping () -> Void) -> some View {
-        return self
+        return accessibilityAction(named: Text(nameKey), handler)
     }
 
-    @available(*, unavailable)
     public func accessibilityAction(named nameResource: LocalizedStringResource, _ handler: @escaping () -> Void) -> some View {
-        return self
+        return accessibilityAction(named: Text(nameResource), handler)
     }
 
-    @available(*, unavailable)
     public func accessibilityAction(named name: String, _ handler: @escaping () -> Void) -> some View {
-        return self
+        return accessibilityAction(named: Text(verbatim: name), handler)
     }
 
     @available(*, unavailable)
@@ -313,7 +341,7 @@ extension View {
         #if SKIP
         return ModifiedContent(content: self, modifier: RenderModifier(role: .accessibility) {
             if isEnabled {
-                return $0.modifier.semantics { if hidden { invisibleToUser() } }
+                return $0.modifier.semantics { if hidden { hideFromAccessibility() } }
             } else {
                 return $0.modifier
             }
@@ -507,6 +535,82 @@ extension View {
     }
 }
 
+#if SKIP
+final class NamedAccessibilityActionModifier: RenderModifier {
+    init(name: Text, handler: @escaping () -> Void) {
+        super.init(role: .accessibility) { context in
+            guard EnvironmentValues.shared.isEnabled else {
+                return context.modifier
+            }
+            let title = name.localizedTextString()
+            return context.modifier.semantics {
+                customActions = listOf(CustomAccessibilityAction(
+                    label: title,
+                    action: {
+                        handler()
+                        return true
+                    }
+                ))
+            }
+        }
+    }
+}
+
+final class AccessibilityActionsModifier: RenderModifier {
+    init(content: ComposeBuilder) {
+        super.init(role: .accessibility) { context in
+            guard EnvironmentValues.shared.isEnabled else {
+                return context.modifier
+            }
+
+            let actions: kotlin.collections.MutableList<CustomAccessibilityAction> =
+                mutableListOf()
+            for renderable in content.Evaluate(context: context.content(), options: 0) {
+                guard
+                    renderable.forEachModifier({ ($0 as? DisabledModifier)?.disabled }) != true,
+                    let button = renderable.strip() as? Button,
+                    let title = Self.title(for: button, context: context)
+                else {
+                    continue
+                }
+                actions.add(CustomAccessibilityAction(
+                    label: title,
+                    action: {
+                        button.action()
+                        return true
+                    }
+                ))
+            }
+            guard actions.isEmpty() == false else {
+                return context.modifier
+            }
+            return context.modifier.semantics {
+                customActions = actions
+            }
+        }
+    }
+
+    @Composable private static func title(
+        for button: Button,
+        context: ComposeContext
+    ) -> String? {
+        let renderable = button.label.Evaluate(context: context.content(), options: 0)
+            .firstOrNull()?.strip()
+        if let text = renderable as? Text {
+            return text.localizedTextString()
+        }
+        if
+            let label = renderable as? Label,
+            let text = label.title.Evaluate(context: context.content(), options: 0)
+                .firstOrNull()?.strip() as? Text
+        {
+            return text.localizedTextString()
+        }
+        return nil
+    }
+}
+#endif
+
 public struct AccessibilityActionKind : Equatable {
     public static let `default` = AccessibilityActionKind()
     public static let escape = AccessibilityActionKind()
@@ -517,6 +621,11 @@ public struct AccessibilityActionKind : Equatable {
 
     private init() {
     }
+}
+
+public enum AccessibilityLiveRegion: Equatable {
+    case polite
+    case assertive
 }
 
 public enum AccessibilityAdjustmentDirection : Hashable {

--- a/Sources/SkipUI/SkipUI/View/ModifiedContent.swift
+++ b/Sources/SkipUI/SkipUI/View/ModifiedContent.swift
@@ -114,6 +114,50 @@ class RenderModifier: ModifierProtocol {
     }
 }
 
+/// The result of routing accessibility render modifiers to a native Compose
+/// control while preserving every other modifier for the SwiftUI content.
+struct AccessibilityModifierComposition {
+    let modifier: Modifier
+    let remainingModifiers: kotlin.collections.List<ModifierProtocol>
+}
+
+/// Composes every accessibility-role `RenderModifier` onto `modifier` in the
+/// same order as normal rendering, and returns the untouched remaining
+/// modifiers in their original outermost-first order.
+@Composable func composeAccessibilityModifiers(
+    for renderable: Renderable,
+    context: ComposeContext,
+    modifier: Modifier = Modifier
+) -> AccessibilityModifierComposition {
+    var accessibilityModifiers: [RenderModifier] = []
+    let remainingModifiers: kotlin.collections.MutableList<ModifierProtocol> =
+        mutableListOf()
+    let _: Bool? = renderable.forEachModifier { (candidate: ModifierProtocol) -> Bool? in
+        if
+            let renderModifier = candidate as? RenderModifier,
+            renderModifier.role == .accessibility
+        {
+            accessibilityModifiers.append(renderModifier)
+        } else {
+            remainingModifiers.add(candidate)
+        }
+        return nil
+    }
+
+    var composedModifier = modifier
+    for renderModifier in accessibilityModifiers.reversed() {
+        if let modifierAction = renderModifier.modifierAction {
+            var modifierContext = context
+            modifierContext.modifier = composedModifier
+            composedModifier = modifierAction(modifierContext)
+        }
+    }
+    return AccessibilityModifierComposition(
+        modifier: composedModifier,
+        remainingModifiers: remainingModifiers
+    )
+}
+
 /// A modifier that sets an environment value.
 class EnvironmentModifier: ModifierProtocol {
     let role: ModifierRole

--- a/Tests/SkipUITests/SkipUITests.swift
+++ b/Tests/SkipUITests/SkipUITests.swift
@@ -75,6 +75,7 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsMatcher
@@ -115,6 +116,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextInputSelection
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.performGesture
+import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.test.swipeUp
 import androidx.compose.ui.test.up
 import androidx.compose.ui.text.AnnotatedString
@@ -565,6 +567,315 @@ final class SkipUITests: SkipUITestCase {
                 }
                 .accessibilityIdentifier("menu.label")
             }
+        }
+    }
+
+    func testCategoryReorderActionsSurviveNavigationListSemanticsMerge() throws {
+        try testUI(view: {
+            CategoryReorderSemanticsTestView(isBusy: false)
+        }, eval: { rule in
+            #if SKIP
+            rule.onAllNodesWithTag("category.row.1")
+                .assertCountEquals(1)
+            rule.onAllNodesWithTag("category.row.1", useUnmergedTree: true)
+                .assertCountEquals(1)
+
+            let mergedRow = rule.onNodeWithTag("category.row.1")
+            mergedRow.assertHasClickAction()
+            let mergedNode = mergedRow.fetchSemanticsNode()
+            let mergedActions = mergedNode.config
+                .getOrNull(SemanticsActions.CustomActions)
+            XCTAssertEqual(
+                mergedActions?.map { $0.label },
+                listOf("Move Up", "Move Down", "Edit", "Archive")
+            )
+
+            let unmergedRow = rule
+                .onNodeWithTag("category.row.1", useUnmergedTree: true)
+                .fetchSemanticsNode()
+            XCTAssertEqual(mergedNode.id, unmergedRow.id)
+            XCTAssertNotNil(
+                unmergedRow.config.getOrNull(SemanticsActions.OnClick)
+            )
+            XCTAssertNil(
+                unmergedRow.parent?.config.getOrNull(SemanticsActions.OnClick)
+            )
+            let unmergedActions = unmergedRow.config
+                .getOrNull(SemanticsActions.CustomActions)
+            XCTAssertEqual(
+                unmergedActions?.map { $0.label },
+                listOf("Move Up", "Move Down", "Edit", "Archive")
+            )
+            #endif
+        })
+    }
+
+    func testCategoryReorderBoundaryFiltersOnlyUnavailableMove() throws {
+        try testUI(view: {
+            CategoryReorderSemanticsTestView(isBusy: false)
+        }, eval: { rule in
+            #if SKIP
+            rule.onAllNodesWithTag("category.row.0")
+                .assertCountEquals(1)
+            rule.onAllNodesWithTag("category.row.0", useUnmergedTree: true)
+                .assertCountEquals(1)
+
+            let mergedRow = rule.onNodeWithTag("category.row.0")
+            mergedRow.assertHasClickAction()
+            let mergedNode = mergedRow.fetchSemanticsNode()
+            let mergedActions = mergedNode.config
+                .getOrNull(SemanticsActions.CustomActions)
+            XCTAssertEqual(
+                mergedActions?.map { $0.label },
+                listOf("Move Down", "Edit", "Archive")
+            )
+
+            let unmergedRow = rule
+                .onNodeWithTag("category.row.0", useUnmergedTree: true)
+                .fetchSemanticsNode()
+            XCTAssertEqual(mergedNode.id, unmergedRow.id)
+            XCTAssertNotNil(
+                unmergedRow.config.getOrNull(SemanticsActions.OnClick)
+            )
+            XCTAssertNil(
+                unmergedRow.parent?.config.getOrNull(SemanticsActions.OnClick)
+            )
+            let unmergedActions = unmergedRow.config
+                .getOrNull(SemanticsActions.CustomActions)
+            XCTAssertEqual(
+                unmergedActions?.map { $0.label },
+                listOf("Move Down", "Edit", "Archive")
+            )
+            #endif
+        })
+    }
+
+    func testCategoryReorderBusyStateSuppressesMergedAndUnmergedActions() throws {
+        try testUI(view: {
+            CategoryReorderSemanticsTestView(isBusy: true)
+        }, eval: { rule in
+            #if SKIP
+            rule.onAllNodesWithTag("category.row.1")
+                .assertCountEquals(1)
+            rule.onAllNodesWithTag("category.row.1", useUnmergedTree: true)
+                .assertCountEquals(1)
+
+            let mergedNode = rule.onNodeWithTag("category.row.1")
+                .fetchSemanticsNode()
+            let mergedActions = mergedNode.config
+                .getOrNull(SemanticsActions.CustomActions)
+            XCTAssertTrue(mergedActions?.isEmpty() != false)
+
+            let unmergedRow = rule
+                .onNodeWithTag("category.row.1", useUnmergedTree: true)
+                .fetchSemanticsNode()
+            XCTAssertEqual(mergedNode.id, unmergedRow.id)
+            XCTAssertNil(
+                unmergedRow.parent?.config.getOrNull(SemanticsActions.OnClick)
+            )
+            let unmergedActions = unmergedRow.config
+                .getOrNull(SemanticsActions.CustomActions)
+            XCTAssertTrue(unmergedActions?.isEmpty() != false)
+
+            rule.onNodeWithTag("category.row.1")
+                .performTouchInput { swipeLeft() }
+            rule.waitForIdle()
+            rule.onNodeWithTag("category.swipe.archive.1").assertDoesNotExist()
+            rule.onNodeWithTag("category.swipe.edit.1").assertDoesNotExist()
+            rule.onAllNodesWithTag(
+                "category.swipe.archive.1",
+                useUnmergedTree: true
+            ).assertCountEquals(1)
+            rule.onAllNodesWithTag(
+                "category.swipe.edit.1",
+                useUnmergedTree: true
+            ).assertCountEquals(1)
+
+            let unmergedArchive = rule
+                .onNodeWithTag("category.swipe.archive.1", useUnmergedTree: true)
+                .fetchSemanticsNode()
+            XCTAssertNotNil(
+                unmergedArchive.parent?.config
+                    .getOrNull(SemanticsProperties.HideFromAccessibility)
+            )
+
+            let unmergedEdit = rule
+                .onNodeWithTag("category.swipe.edit.1", useUnmergedTree: true)
+                .fetchSemanticsNode()
+            XCTAssertNotNil(
+                unmergedEdit.parent?.config
+                    .getOrNull(SemanticsProperties.HideFromAccessibility)
+            )
+
+            try check(rule, id: "category.callback.count", hasText: "0")
+            #endif
+        })
+    }
+
+    func testCategoryReorderStatusAndClosedSwipeAccessibilitySemantics() throws {
+        try testUI(view: {
+            CategoryReorderSemanticsTestView(isBusy: false)
+        }, eval: { rule in
+            #if SKIP
+            let mode = rule.onNodeWithTag("category.reorder.status")
+                .fetchSemanticsNode().config.getOrNull(SemanticsProperties.LiveRegion)
+            XCTAssertEqual(mode, LiveRegionMode.Polite)
+
+            rule.onAllNodesWithTag("category.row.1")
+                .assertCountEquals(1)
+            rule.onAllNodesWithTag("category.row.1", useUnmergedTree: true)
+                .assertCountEquals(1)
+            let mergedNode = rule.onNodeWithTag("category.row.1")
+                .fetchSemanticsNode()
+            let unmergedRow = rule
+                .onNodeWithTag("category.row.1", useUnmergedTree: true)
+                .fetchSemanticsNode()
+            XCTAssertEqual(mergedNode.id, unmergedRow.id)
+            XCTAssertNotNil(
+                unmergedRow.config.getOrNull(SemanticsActions.OnClick)
+            )
+            XCTAssertNil(
+                unmergedRow.parent?.config.getOrNull(SemanticsActions.OnClick)
+            )
+
+            rule.onNodeWithTag("category.swipe.archive.1").assertDoesNotExist()
+            rule.onNodeWithTag("category.swipe.edit.1").assertDoesNotExist()
+            rule.onAllNodesWithTag(
+                "category.swipe.archive.1",
+                useUnmergedTree: true
+            ).assertCountEquals(1)
+            rule.onAllNodesWithTag(
+                "category.swipe.edit.1",
+                useUnmergedTree: true
+            ).assertCountEquals(1)
+
+            let unmergedArchive = rule
+                .onNodeWithTag("category.swipe.archive.1", useUnmergedTree: true)
+                .fetchSemanticsNode()
+            XCTAssertNotNil(
+                unmergedArchive.parent?.config
+                    .getOrNull(SemanticsProperties.HideFromAccessibility)
+            )
+
+            let unmergedEdit = rule
+                .onNodeWithTag("category.swipe.edit.1", useUnmergedTree: true)
+                .fetchSemanticsNode()
+            XCTAssertNotNil(
+                unmergedEdit.parent?.config
+                    .getOrNull(SemanticsProperties.HideFromAccessibility)
+            )
+
+            let mergedActions = mergedNode.config
+                .getOrNull(SemanticsActions.CustomActions)
+            XCTAssertEqual(
+                mergedActions?.map { $0.label },
+                listOf("Move Up", "Move Down", "Edit", "Archive")
+            )
+            let unmergedActions = unmergedRow.config
+                .getOrNull(SemanticsActions.CustomActions)
+            XCTAssertEqual(
+                unmergedActions?.map { $0.label },
+                listOf("Move Up", "Move Down", "Edit", "Archive")
+            )
+            #endif
+        })
+    }
+
+    struct CategoryReorderSemanticsItem: Identifiable, Equatable {
+        let id: Int
+        let title: String
+
+        static let samples = [
+            CategoryReorderSemanticsItem(id: 0, title: "Work"),
+            CategoryReorderSemanticsItem(id: 1, title: "Home"),
+            CategoryReorderSemanticsItem(id: 2, title: "Appointments")
+        ]
+    }
+
+    struct CategoryReorderSemanticsTestView: View {
+        @State var items = CategoryReorderSemanticsItem.samples
+        @State var callbackCount = 0
+        let isBusy: Bool
+
+        var body: some View {
+            NavigationStack {
+                List {
+                    ForEach(items) { item in
+                        categoryRow(item)
+                    }
+                    .onMove { source, destination in
+                        callbackCount += 1
+                        items.move(fromOffsets: source, toOffset: destination)
+                    }
+
+                    LabeledContent("Category update status") {
+                        #if SKIP
+                        Text("Ready")
+                            .accessibilityIdentifier("category.reorder.status")
+                            .accessibilityLiveRegion(.polite)
+                        #else
+                        Text("Ready")
+                        #endif
+                    }
+
+                    LabeledContent("Callback count") {
+                        Text("\(callbackCount)")
+                            .accessibilityIdentifier("category.callback.count")
+                    }
+                }
+            }
+        }
+
+        func categoryRow(_ item: CategoryReorderSemanticsItem) -> some View {
+            NavigationLink {
+                Text("\(item.title) category")
+            } label: {
+                Text(item.title)
+            }
+            .accessibilityIdentifier("category.row.\(item.id)")
+            .accessibilityActions {
+                Button("Move Up") {
+                    callbackCount += 1
+                }
+                .disabled(canMove(item, direction: -1) == false)
+
+                Button("Move Down") {
+                    callbackCount += 1
+                }
+                .disabled(canMove(item, direction: 1) == false)
+
+                Button("Edit") {
+                    callbackCount += 1
+                }
+
+                Button("Archive") {
+                    callbackCount += 1
+                }
+            }
+            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                Button {
+                    callbackCount += 1
+                } label: {
+                    Text("Archive")
+                        .accessibilityIdentifier("category.swipe.archive.\(item.id)")
+                }
+
+                Button {
+                    callbackCount += 1
+                } label: {
+                    Text("Edit")
+                        .accessibilityIdentifier("category.swipe.edit.\(item.id)")
+                }
+            }
+            .moveDisabled(isBusy)
+            .disabled(isBusy)
+        }
+
+        func canMove(_ item: CategoryReorderSemanticsItem, direction: Int) -> Bool {
+            guard let index = items.firstIndex(of: item) else {
+                return false
+            }
+            return items.indices.contains(index + direction)
         }
     }
   


### PR DESCRIPTION
## Summary

Preserve SwiftUI accessibility modifiers on the native actionable Compose node used for a `List` row.

- Add one shared `composeAccessibilityModifiers` utility that composes accessibility-role modifiers onto a native control and returns every remaining modifier unchanged.
- Make the native actionable `List` row own `clickable`, test-tag/content-description semantics, and custom accessibility actions on the same Compose node.
- Render the stripped inner `NavigationLink` label with only the remaining modifiers, avoiding a second semantics owner.
- Reuse the shared utility for raw Compose `Menu` items.
- Bridge named accessibility actions, action collections, and live regions; keep disabled or closed swipe controls out of the merged accessibility tree.
- Add four focused `SkipUITests` covering normal, boundary, busy, and closed-swipe/status semantics.

This fixes the case where an actionable `NavigationLink` row exposed its click action on the outer native row while accessibility modifiers stayed on an inner label node. The merged Compose tree could therefore lose the row test tag and custom actions.

## Verification

Contribution source is based directly on current upstream `main`:

- base: `ff81a283a8d761fb355d50eb0d37136bbc0b5af1`
- commit: `c7c577fd1c5b9d9f13552ba9e7b8b95073d2cbae`
- five-file patch SHA-256 (`git diff --binary`): `d2924aece63061df75dace1888841c016547d723a391c9c68a20f86b9a36b77e`
- `git diff --check`: pass
- lightweight source contract: exact five paths, no generated artifacts, one shared helper, both `List` and `Menu` consumers, four focused tests, and four merged/unmerged same-node assertions

The accepted targeted XCSkipTests/Robolectric proof was preserved from this exact source state rather than rerun for PR preparation:

- suite: `skip.ui.SkipUITests`
- result: 4 tests, 0 failures, 0 errors, 0 skipped
- JUnit XML SHA-256: `2a8af47c52307bbd6ac249ba06fb41e34d9b53fdc4e7dc6822f0e52d0bc91cc9`
- focused identities:
  - `testCategoryReorderActionsSurviveNavigationListSemanticsMerge$SkipUI`
  - `testCategoryReorderBoundaryFiltersOnlyUnavailableMove$SkipUI`
  - `testCategoryReorderBusyStateSuppressesMergedAndUnmergedActions$SkipUI`
  - `testCategoryReorderStatusAndClosedSwipeAccessibilitySemantics$SkipUI`

Each test queries the row in merged and unmerged trees and verifies that both queries resolve to the same semantics-node ID. The tests also cover native click ownership, custom-action filtering, busy-state suppression, live-region mode, and hidden closed-swipe actions.

## Evidence boundary

This draft claims targeted Robolectric/Compose semantics only. PR preparation did **not** rerun Gradle, Robolectric, a full Swift test suite, an emulator, or a device. It does not claim TalkBack, Switch Access, keyboard navigation, accessibility-service runtime behavior, iOS behavior, performance, or full-regression coverage.

No consumer-app source, dependency pin, generated output, or compatibility fallback is part of this change.

The current Skip contribution guide says public SwiftUI-surface additions need a corresponding SkipFuseUI update. This patch makes accessibility action overloads available and adds `accessibilityLiveRegion`; a paired SkipFuseUI follow-up should be resolved during review. No second implementation authority is included here.

Skip Pull Request Checklist:

- [ ] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device
- [x] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository. A paired follow-up is required for the public accessibility API surface and is intentionally not part of this draft.
- [ ] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app

-----

- [x] AI was used to generate or assist with generating this PR. AI assisted with root-cause analysis, patch preparation, focused test construction, and PR drafting. The final contribution was mechanically checked against the accepted five-file source digest and preserved targeted JUnit evidence; no generated artifact was committed.

