### PR TITLE
List: make the reorder drag visible on dark backgrounds

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/List.swift
+++ b/Sources/SkipUI/SkipUI/Containers/List.swift
@@ -59,6 +59,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.geometry.CornerRadius
@@ -1042,6 +1043,21 @@ public final class List : View, Renderable {
             if dragging {
                 let elevation = animateDpAsState(8.dp)
                 itemModifier = itemModifier.shadow(elevation.value)
+                // A shadow expresses elevation by darkening what is AROUND the
+                // row, so on a dark background it expresses nothing: over #000
+                // there is nothing left to darken, and a row being dragged looks
+                // exactly like one at rest. Material's own answer on dark
+                // surfaces is tonal elevation — the surface itself gets lighter.
+                //
+                // Drawn OVER the content rather than behind it, because a list
+                // row usually paints its own background and a tint behind it
+                // would never be seen. `onSurface` so it follows the scheme:
+                // lighter on dark themes, darker on light ones.
+                let dragTint = MaterialTheme.colorScheme.onSurface.copy(alpha: Float(0.10))
+                itemModifier = itemModifier.drawWithContent {
+                    drawContent()
+                    drawRect(color: dragTint)
+                }
             }
             content(itemModifier)
         }


### PR DESCRIPTION
Fixes the problem reported in #517.

## The problem

`RenderReorderableItem` styles the dragged row with `Modifier.shadow(8.dp)` and
nothing else. A shadow expresses elevation by darkening what is *around* the
row — so over a dark page it expresses nothing. On `#000` there is nothing left
to darken, and the row under your finger is pixel-identical to the rows at rest.
A reorder on a dark-themed app has no visible affordance at all.

## The change

Draw a tonal lift alongside the shadow, which is Material's own answer for
elevation on dark surfaces: the surface itself gets lighter.

```swift
let dragTint = MaterialTheme.colorScheme.onSurface.copy(alpha: Float(0.10))
itemModifier = itemModifier.drawWithContent {
    drawContent()
    drawRect(color: dragTint)
}
```

Two choices worth flagging for review:

- **Over the content, not behind it.** A list row almost always paints its own
  background, so a tint drawn behind it would never be seen.
- **`onSurface`, not a fixed colour**, so it follows the scheme in both
  directions — lighter on dark themes, darker on light ones. Light themes keep
  the shadow they already had and gain a subtle press-like tint; dark themes gain
  the only feedback they can receive.

Happy to put it behind an environment hook in the shape of `material3Ripple`
instead, if you would rather this be opt-in than a default.

## Why apps cannot work around it

- `onMove` is invoked from `onDragEnd`, so SwiftUI code learns about the move
  only on drop.
- `Modifier.detectReorderAfterLongPress` claims the long press, so an app's own
  `.onLongPressGesture(..., onPressingChanged:)` on the row never fires.
- And that callback is one-way regardless: `onLongPressChange()` calls
  `onChanged(true)` and nothing ever calls it with `false`.

## Testing

Built and run on device: Android 14, Samsung SM-A326U (Dimensity 700), release
build, a 24-row playlist on a `#121212` page with `#252525` rows. Before the
patch, dragging produced no visible change; after it, the dragged row lifts while
held and returns to rest on drop. Light-theme rendering unchanged apart from the
new tint.
