### PR TITLE
Bugfix: Stabilize Focused Text Input Scrolling

### DIFF
--- a/Sources/SkipUI/SkipUI/Containers/List.swift
+++ b/Sources/SkipUI/SkipUI/Containers/List.swift
@@ -290,10 +290,21 @@ public final class List : View, Renderable {
         LazyColumn(state: reorderableState.listState, modifier: modifier, contentPadding: contentPadding, verticalArrangement: listVerticalArrangement) {
             // Read move trigger here so that a move will recompose list content
             let _ = moveTrigger.value
-            let shouldAnimateItems: @Composable () -> Bool = {
-                // We disable animation to prevent filtered items from animating when they return
-                let animate = !forceUnanimatedItems.value && EnvironmentValues.shared._searchableState?.isSearching.value != true
+            let shouldAnimateItems: @Composable (Bool) -> Bool = { suppressTextInputAnimation in
+                // Focused text inputs can conflict with LazyColumn placement animation and visibly lag behind scrolling.
+                let animate = !forceUnanimatedItems.value
+                    && !suppressTextInputAnimation
+                    && EnvironmentValues.shared._searchableState?.isSearching.value != true
                 return animate
+            }
+            let updateTextInputAnimationSuppression: @Composable (MutableState<Bool>, MutableState<Bool>) -> Void = { textInputFocused, suppressTextInputAnimation in
+                if reorderableState.listState.isScrollInProgress {
+                    if textInputFocused.value {
+                        suppressTextInputAnimation.value = true
+                    }
+                } else {
+                    suppressTextInputAnimation.value = false
+                }
             }
 
             // Initialize the factory context with closures that use the LazyListScope to generate items
@@ -305,8 +316,16 @@ public final class List : View, Renderable {
                 startItemIndex: startItemIndex,
                 item: { renderable, level in
                     item {
-                        let itemModifier: Modifier = shouldAnimateItems() ? Modifier.animateItem() : Modifier
-                        RenderItem(content: renderable, level: level, context: itemContext, modifier: itemModifier, styling: styling)
+                        let textInputFocused = remember { mutableStateOf(false) }
+                        let suppressTextInputAnimation = remember { mutableStateOf(false) }
+                        updateTextInputAnimationSuppression(textInputFocused, suppressTextInputAnimation)
+                        let itemModifier: Modifier = shouldAnimateItems(suppressTextInputAnimation.value) ? Modifier.animateItem() : Modifier
+                        EnvironmentValues.shared.setValues {
+                            $0.set_listItemTextInputFocused(textInputFocused)
+                            return ComposeResult.ok
+                        } in: {
+                            RenderItem(content: renderable, level: level, context: itemContext, modifier: itemModifier, styling: styling)
+                        }
                     }
                 },
                 indexedItems: { range, identifier, offset, onDelete, onMove, level, factory in
@@ -315,9 +334,17 @@ public final class List : View, Renderable {
                     items(count: count, key: key) { index in
                         let keyValue = key?(index) // Key closure already remaps index
                         let index = itemCollector.value.remapIndex(index, from: offset)
-                        let itemModifier: Modifier = shouldAnimateItems() ? Modifier.animateItem() : Modifier
+                        let textInputFocused = remember { mutableStateOf(false) }
+                        let suppressTextInputAnimation = remember { mutableStateOf(false) }
+                        updateTextInputAnimationSuppression(textInputFocused, suppressTextInputAnimation)
+                        let itemModifier: Modifier = shouldAnimateItems(suppressTextInputAnimation.value) ? Modifier.animateItem() : Modifier
                         let renderable = factory(index + range.start, itemContext)
-                        RenderEditableItem(content: renderable, level: level, context: itemContext, modifier: itemModifier, styling: styling, key: keyValue, index: index, onDelete: onDelete, onMove: onMove, reorderableState: reorderableState, activeSwipeKey: activeSwipeKey)
+                        EnvironmentValues.shared.setValues {
+                            $0.set_listItemTextInputFocused(textInputFocused)
+                            return ComposeResult.ok
+                        } in: {
+                            RenderEditableItem(content: renderable, level: level, context: itemContext, modifier: itemModifier, styling: styling, key: keyValue, index: index, onDelete: onDelete, onMove: onMove, reorderableState: reorderableState, activeSwipeKey: activeSwipeKey)
+                        }
                     }
                 },
                 objectItems: { objects, identifier, offset, onDelete, onMove, level, factory in
@@ -325,9 +352,17 @@ public final class List : View, Renderable {
                     items(count: objects.count, key: key) { index in
                         let keyValue = key(index) // Key closure already remaps index
                         let index = itemCollector.value.remapIndex(index, from: offset)
-                        let itemModifier: Modifier = shouldAnimateItems() ? Modifier.animateItem() : Modifier
+                        let textInputFocused = remember { mutableStateOf(false) }
+                        let suppressTextInputAnimation = remember { mutableStateOf(false) }
+                        updateTextInputAnimationSuppression(textInputFocused, suppressTextInputAnimation)
+                        let itemModifier: Modifier = shouldAnimateItems(suppressTextInputAnimation.value) ? Modifier.animateItem() : Modifier
                         let renderable = factory(objects[index], itemContext)
-                        RenderEditableItem(content: renderable, level: level, context: itemContext, modifier: itemModifier, styling: styling, key: keyValue, index: index, onDelete: onDelete, onMove: onMove, reorderableState: reorderableState, activeSwipeKey: activeSwipeKey)
+                        EnvironmentValues.shared.setValues {
+                            $0.set_listItemTextInputFocused(textInputFocused)
+                            return ComposeResult.ok
+                        } in: {
+                            RenderEditableItem(content: renderable, level: level, context: itemContext, modifier: itemModifier, styling: styling, key: keyValue, index: index, onDelete: onDelete, onMove: onMove, reorderableState: reorderableState, activeSwipeKey: activeSwipeKey)
+                        }
                     }
                 },
                 objectBindingItems: { objectsBinding, identifier, offset, editActions, onDelete, onMove, level, factory in
@@ -335,9 +370,17 @@ public final class List : View, Renderable {
                     items(count: objectsBinding.wrappedValue.count, key: key) { index in
                         let keyValue = key(index) // Key closure already remaps index
                         let index = itemCollector.value.remapIndex(index, from: offset)
-                        let itemModifier: Modifier = shouldAnimateItems() ? Modifier.animateItem() : Modifier
+                        let textInputFocused = remember { mutableStateOf(false) }
+                        let suppressTextInputAnimation = remember { mutableStateOf(false) }
+                        updateTextInputAnimationSuppression(textInputFocused, suppressTextInputAnimation)
+                        let itemModifier: Modifier = shouldAnimateItems(suppressTextInputAnimation.value) ? Modifier.animateItem() : Modifier
                         let renderable = factory(objectsBinding, index, itemContext)
-                        RenderEditableItem(content: renderable, level: level, context: itemContext, modifier: itemModifier, styling: styling, objectsBinding: objectsBinding, key: keyValue, index: index, editActions: editActions, onDelete: onDelete, onMove: onMove, reorderableState: reorderableState, activeSwipeKey: activeSwipeKey)
+                        EnvironmentValues.shared.setValues {
+                            $0.set_listItemTextInputFocused(textInputFocused)
+                            return ComposeResult.ok
+                        } in: {
+                            RenderEditableItem(content: renderable, level: level, context: itemContext, modifier: itemModifier, styling: styling, objectsBinding: objectsBinding, key: keyValue, index: index, editActions: editActions, onDelete: onDelete, onMove: onMove, reorderableState: reorderableState, activeSwipeKey: activeSwipeKey)
+                        }
                     }
                 },
                 sectionHeader: { content in

--- a/Sources/SkipUI/SkipUI/Containers/Table.swift
+++ b/Sources/SkipUI/SkipUI/Containers/Table.swift
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -97,9 +98,20 @@ public final class Table<ObjectType, ID> : View, Renderable where ObjectType: Id
             forceUnanimatedItems.value = false
         }
 
-        let shouldAnimateItems: @Composable () -> Bool = {
-            // We disable animation to prevent filtered items from animating when they return
-            !forceUnanimatedItems.value && EnvironmentValues.shared._searchableState?.isSearching.value != true
+        let shouldAnimateItems: @Composable (Bool) -> Bool = { suppressTextInputAnimation in
+            // Focused text inputs can conflict with LazyColumn placement animation and visibly lag behind scrolling.
+            !forceUnanimatedItems.value
+                && !suppressTextInputAnimation
+                && EnvironmentValues.shared._searchableState?.isSearching.value != true
+        }
+        let updateTextInputAnimationSuppression: @Composable (MutableState<Bool>, MutableState<Bool>) -> Void = { textInputFocused, suppressTextInputAnimation in
+            if listState.isScrollInProgress {
+                if textInputFocused.value {
+                    suppressTextInputAnimation.value = true
+                }
+            } else {
+                suppressTextInputAnimation.value = false
+            }
         }
 
         let key: (Int) -> String = { composeBundleString(for: data[$0].id) }
@@ -112,13 +124,29 @@ public final class Table<ObjectType, ID> : View, Renderable where ObjectType: Id
             }
             if !isCompact {
                 item {
-                    let animationModifier = shouldAnimateItems() ? Modifier.animateItem() : Modifier
-                    RenderHeadersRow(columnSpecs: columnSpecs, context: context, animationModifier: animationModifier)
+                    let textInputFocused = remember { mutableStateOf(false) }
+                    let suppressTextInputAnimation = remember { mutableStateOf(false) }
+                    updateTextInputAnimationSuppression(textInputFocused, suppressTextInputAnimation)
+                    let animationModifier = shouldAnimateItems(suppressTextInputAnimation.value) ? Modifier.animateItem() : Modifier
+                    EnvironmentValues.shared.setValues {
+                        $0.set_listItemTextInputFocused(textInputFocused)
+                        return ComposeResult.ok
+                    } in: {
+                        RenderHeadersRow(columnSpecs: columnSpecs, context: context, animationModifier: animationModifier)
+                    }
                 }
             }
             items(count: data.count, key: key) { index in
-                let animationModifier = shouldAnimateItems() ? Modifier.animateItem() : Modifier
-                RenderRow(columnSpecs: columnSpecs, index: index, context: context, isCompact: isCompact, animationModifier: animationModifier)
+                let textInputFocused = remember { mutableStateOf(false) }
+                let suppressTextInputAnimation = remember { mutableStateOf(false) }
+                updateTextInputAnimationSuppression(textInputFocused, suppressTextInputAnimation)
+                let animationModifier = shouldAnimateItems(suppressTextInputAnimation.value) ? Modifier.animateItem() : Modifier
+                EnvironmentValues.shared.setValues {
+                    $0.set_listItemTextInputFocused(textInputFocused)
+                    return ComposeResult.ok
+                } in: {
+                    RenderRow(columnSpecs: columnSpecs, index: index, context: context, isCompact: isCompact, animationModifier: animationModifier)
+                }
             }
             if footerSafeAreaHeight.value > 0.0 {
                 item {

--- a/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
+++ b/Sources/SkipUI/SkipUI/Environment/EnvironmentValues.swift
@@ -744,6 +744,11 @@ extension EnvironmentValues {
         set { setBuiltinValue(key: "_isSearching", value: newValue, defaultValue: { nil }) }
     }
 
+    var _listItemTextInputFocused: MutableState<Bool>? {
+        get { builtinValue(key: "_listItemTextInputFocused", defaultValue: { nil }) as! MutableState<Bool>? }
+        set { setBuiltinValue(key: "_listItemTextInputFocused", value: newValue, defaultValue: { nil }) }
+    }
+
     var _keyboardOptions: KeyboardOptions? {
         get { builtinValue(key: "_keyboardOptions", defaultValue: { nil }) as! KeyboardOptions? }
         set { setBuiltinValue(key: "_keyboardOptions", value: newValue, defaultValue: { nil }) }

--- a/Sources/SkipUI/SkipUI/Text/TextEditor.swift
+++ b/Sources/SkipUI/SkipUI/Text/TextEditor.swift
@@ -7,6 +7,9 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.VisualTransformation
 #endif
@@ -49,9 +52,15 @@ public struct TextEditor : View, Renderable {
         let keyboardActions = KeyboardActions(EnvironmentValues.shared._onSubmitState, LocalFocusManager.current)
         let colors = TextField.colors(styleInfo: styleInfo, outline: Color.clear)
         let visualTransformation = VisualTransformation.None
+        var modifier = context.modifier.fillSize()
+        if let listItemTextInputFocused = EnvironmentValues.shared._listItemTextInputFocused {
+            modifier = modifier.onFocusChanged {
+                listItemTextInputFocused.value = $0.hasFocus
+            }
+        }
         OutlinedTextField(value: text.wrappedValue, onValueChange: {
             text.wrappedValue = $0
-        }, modifier: context.modifier.fillSize(), textStyle: animatable.value, enabled: EnvironmentValues.shared.isEnabled, singleLine: false, keyboardOptions: keyboardOptions, keyboardActions: keyboardActions, colors: colors, visualTransformation: visualTransformation)
+        }, modifier: modifier, textStyle: animatable.value, enabled: EnvironmentValues.shared.isEnabled, singleLine: false, keyboardOptions: keyboardOptions, keyboardActions: keyboardActions, colors: colors, visualTransformation: visualTransformation)
     }
     #else
     public var body: some View {

--- a/Sources/SkipUI/SkipUI/Text/TextField.swift
+++ b/Sources/SkipUI/SkipUI/Text/TextField.swift
@@ -18,6 +18,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
@@ -119,6 +120,11 @@ public struct TextField : View, Renderable {
         // A vertical field takes Enter as a newline, so only single-line fields submit on it.
         let isVertical = axis == Axis.vertical
         var baseModifier = context.modifier.fillWidth()
+        if let listItemTextInputFocused = EnvironmentValues.shared._listItemTextInputFocused {
+            baseModifier = baseModifier.onFocusChanged {
+                listItemTextInputFocused.value = $0.hasFocus
+            }
+        }
         if !isVertical {
             baseModifier = baseModifier.onPreviewKeyEvent { keyEvent in
                 if keyEvent.type == KeyEventType.KeyDown &&


### PR DESCRIPTION
This PR stabilizes scrolling behavior for focused `TextField` and `TextEditor` views inside `List` and `Table`.

Before this change, the list item placement animation could continue running while a focused text input was inside the scrolling row. On Android/Compose, the focused text input layout can update independently from the surrounding `LazyColumn` item placement animation. Visually, this could make the focused `TextField` or `TextEditor` appear to lag behind the rest of the row while scrolling.

**To reproduce:**
1. Open a form-style `List` containing a `TextField` or `TextEditor` (e.g. the bottom text field in the `FormPlayground` of the Skip Showcase app).
2. Focus the text input so the cursor is active.
3. Scroll the list while the text input remains focused.
4. Observe that the focused input can visually lag behind the surrounding content.

Below is a before/after comparison of this example:

**Before:**
<img width="400" height="897" alt="Before" src="https://github.com/user-attachments/assets/a6b378a5-f8da-48cd-940d-be2d8ed2ef59" />

**After:**
<img width="400" height="897" alt="After" src="https://github.com/user-attachments/assets/8e33abdb-12a1-4531-b92e-2fdfa709442d" />

As you can see, the focused text input now scrolls together with its row after this change.

---

Thank you for contributing to the Skip project! Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device
- [X] REQUIRED: I have checked whether this change requires a corresponding update in the [Skip Fuse UI](https://github.com/skiptools/skip-fuse-ui) repository (link related PR if applicable)
- [ ] OPTIONAL: I have added an example of any UI changes to the [Showcase](https://github.com/skiptools/skipapp-showcase) sample app

-----

- [X] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used Codex to iteratively investigate and refine the fix for the focused text input scrolling issue. To verify the results, I tested multiple playground views which contain text fields or text editors in the Skip Showcase app and my own Skip app. All of these scenarios work properly after the bug fix.

-----

